### PR TITLE
Mock write streams, so cases.test.ts becomes simpler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "depcheck": "^1.4.0",
         "eslint": "^7.24.0",
         "jest": "^26.6.3",
-        "jest-mock-process": "^1.4.0",
         "pkg": "^4.5.1",
         "ts-jest": "26.5.4",
         "ts-node": "^9.1.1",
@@ -5077,15 +5076,6 @@
       },
       "engines": {
         "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/jest-mock-process": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-1.4.0.tgz",
-      "integrity": "sha512-3LM1TyEaRKRjh/x9rZPmuy28r7q8cgNkHYcrPWtxXT3ZzPPS+bKNs2ysb8BJPVB41X5yM1sMtatvE5z2XJ0S/w==",
-      "dev": true,
-      "peerDependencies": {
-        "jest": ">=23.4 <27"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -13505,13 +13495,6 @@
         "@jest/types": "^26.6.2",
         "@types/node": "*"
       }
-    },
-    "jest-mock-process": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jest-mock-process/-/jest-mock-process-1.4.0.tgz",
-      "integrity": "sha512-3LM1TyEaRKRjh/x9rZPmuy28r7q8cgNkHYcrPWtxXT3ZzPPS+bKNs2ysb8BJPVB41X5yM1sMtatvE5z2XJ0S/w==",
-      "dev": true,
-      "requires": {}
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "depcheck": "^1.4.0",
     "eslint": "^7.24.0",
     "jest": "^26.6.3",
-    "jest-mock-process": "^1.4.0",
     "pkg": "^4.5.1",
     "ts-jest": "26.5.4",
     "ts-node": "^9.1.1",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -173,7 +173,7 @@ export class Commander {
 
         if (preScripts.failed.length !== 0) {
             writeStreams.stdout(chalk`{red failure} `);
-            preScripts.failed.forEach((job, i, arr) => Utils.printJobNames(writeStreams.stdout, job, i, arr));
+            preScripts.failed.forEach((job, i, arr) => Utils.printJobNames(writeStreams.stdout.bind(writeStreams), job, i, arr));
             writeStreams.stdout(`\n`);
         }
 

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -117,7 +117,7 @@ export class Commander {
     }
 
     static printReport = async (writeStreams: WriteStreams, jobs: ReadonlyArray<Job>) => {
-        writeStreams.stdout(`\n`);
+        writeStreams.stdout("\n");
 
         const preScripts: { never: Job[], successful: Job[], failed: Job[], warned: Job[] } = {
             never: [],
@@ -150,31 +150,31 @@ export class Commander {
         if (preScripts.never.length !== 0) {
             writeStreams.stdout(chalk`{magenta not started} `);
             preScripts.never.forEach((job, i, arr) => Utils.printJobNames(writeStreams.stdout.bind(writeStreams), job, i, arr));
-            writeStreams.stdout(`\n`);
+            writeStreams.stdout("\n");
         }
 
         if (preScripts.successful.length !== 0) {
             writeStreams.stdout(chalk`{green successful} `);
             preScripts.successful.forEach((job, i, arr) => Utils.printJobNames(writeStreams.stdout.bind(writeStreams), job, i, arr));
-            writeStreams.stdout(`\n`);
+            writeStreams.stdout("\n");
         }
 
         if (preScripts.warned.length !== 0) {
             writeStreams.stdout(chalk`{yellowBright warning} `);
             preScripts.warned.forEach((job, i, arr) => Utils.printJobNames(writeStreams.stdout.bind(writeStreams), job, i, arr));
-            writeStreams.stdout(`\n`);
+            writeStreams.stdout("\n");
         }
 
         if (afterScripts.warned.length !== 0) {
             writeStreams.stdout(chalk`{yellowBright after script} `);
             afterScripts.warned.forEach((job, i, arr) => Utils.printJobNames(writeStreams.stdout.bind(writeStreams), job, i, arr));
-            writeStreams.stdout(`\n`);
+            writeStreams.stdout("\n");
         }
 
         if (preScripts.failed.length !== 0) {
             writeStreams.stdout(chalk`{red failure} `);
             preScripts.failed.forEach((job, i, arr) => Utils.printJobNames(writeStreams.stdout.bind(writeStreams), job, i, arr));
-            writeStreams.stdout(`\n`);
+            writeStreams.stdout("\n");
         }
 
         for (const job of preScripts.successful) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -19,7 +19,7 @@ const checkFolderAndFile = (cwd: string, file?: string) => {
 };
 
 export async function handler(argv: any, writeStreams: WriteStreams) {
-    assert(typeof argv.cwd != "object", '--cwd option cannot be an array');
+    assert(typeof argv.cwd != "object", "--cwd option cannot be an array");
     const cwd = argv.cwd?.replace(/\/$/, "") ?? ".";
 
     if (fs.existsSync(`${cwd}/.gitlab-ci-local-env`)) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -4,11 +4,11 @@ import * as yargs from "yargs";
 import {Commander} from "./commander";
 import {Parser} from "./parser";
 import * as state from "./state";
-import {ExitError} from "./types/exit-error";
 import {assert} from "./asserts";
 import * as dotenv from "dotenv";
 import * as camelCase from "camelcase";
 import * as prettyHrtime from "pretty-hrtime";
+import {WriteStreams} from "./types/write-streams";
 
 let parser: Parser | null = null;
 const checkFolderAndFile = (cwd: string, file?: string) => {
@@ -18,16 +18,7 @@ const checkFolderAndFile = (cwd: string, file?: string) => {
     assert(fs.existsSync(gitlabFilePath), `${cwd} does not contain ${file ?? ".gitlab-ci.yml"}`);
 };
 
-exports.command = "$0 [job]";
-exports.describe = "Runs the entire pipeline or a single [job]";
-exports.builder = (y: any) => {
-    y.positional("job", {
-        describe: "Jobname to execute",
-        type: "string",
-    });
-};
-
-export async function handler(argv: any) {
+export async function handler(argv: any, writeStreams: WriteStreams) {
     assert(typeof argv.cwd != "object", '--cwd option cannot be an array');
     const cwd = argv.cwd?.replace(/\/$/, "") ?? ".";
 
@@ -46,35 +37,24 @@ export async function handler(argv: any) {
     } else if (argv.list != null) {
         checkFolderAndFile(cwd, argv.file);
         const pipelineIid = await state.getPipelineIid(cwd);
-        parser = await Parser.create(cwd, pipelineIid, false, argv.file, argv.home);
-        Commander.runList(parser);
+        parser = await Parser.create(cwd, writeStreams, pipelineIid, false, argv.file, argv.home);
+        Commander.runList(parser, writeStreams);
     } else if (argv.job) {
         checkFolderAndFile(cwd, argv.file);
         const pipelineIid = await state.getPipelineIid(cwd);
-        parser = await Parser.create(cwd, pipelineIid, false, argv.file, argv.home);
-        await Commander.runSingleJob(parser, argv.job, argv.needs, argv.privileged);
+        parser = await Parser.create(cwd, writeStreams, pipelineIid, false, argv.file, argv.home);
+        await Commander.runSingleJob(parser, writeStreams, argv.job, argv.needs, argv.privileged);
     } else {
         const time = process.hrtime();
         checkFolderAndFile(cwd, argv.file);
         await state.incrementPipelineIid(cwd);
         const pipelineIid = await state.getPipelineIid(cwd);
-        parser = await Parser.create(cwd, pipelineIid, false, argv.file, argv.home);
-        await Commander.runPipeline(parser, argv.manual || [], argv.privileged);
-        process.stdout.write(chalk`{grey pipeline finished} in {grey ${prettyHrtime(process.hrtime(time))}}\n`);
+        parser = await Parser.create(cwd, writeStreams, pipelineIid, false, argv.file, argv.home);
+        await Commander.runPipeline(parser, writeStreams, argv.manual || [], argv.privileged);
+        writeStreams.stdout(chalk`{grey pipeline finished} in {grey ${prettyHrtime(process.hrtime(time))}}\n`);
     }
+    writeStreams.flush();
 }
-
-exports.handler = async (argv: any) => {
-    try {
-        await handler(argv);
-    } catch (e) {
-        if (e instanceof ExitError) {
-            process.stderr.write(chalk`{red ${e.message}}\n`);
-            process.exit(1);
-        }
-        throw e;
-    }
-};
 
 process.on('SIGINT', async (_: string, code: number) => {
     if (!parser) {

--- a/src/job.ts
+++ b/src/job.ts
@@ -6,6 +6,7 @@ import * as camelCase from "camelcase";
 import {ExitError} from "./types/exit-error";
 import {Utils} from "./utils";
 import {JobOptions} from "./types/job-options";
+import {WriteStreams} from "./types/write-streams";
 
 export class Job {
 
@@ -30,6 +31,7 @@ export class Job {
     readonly cache: { key: string | { files: string[] }, paths: string[] };
     private _prescriptsExitCode = 0;
     private readonly jobData: any;
+    private readonly writeStreams: WriteStreams;
     private started = false;
     private finished = false;
     private running = false;
@@ -43,6 +45,7 @@ export class Job {
         const globals = opt.globals;
         const userVariables = opt.userVariables;
 
+        this.writeStreams = opt.writeStreams;
         this.maxJobNameLength = opt.maxJobNameLength;
         this.name = opt.name;
         this.cwd = opt.cwd;
@@ -173,6 +176,7 @@ export class Job {
 
     async start(privileged: boolean): Promise<void> {
         const startTime = process.hrtime();
+        const writeStreams = this.writeStreams;
 
         this.running = true;
         this.started = true;
@@ -181,13 +185,13 @@ export class Job {
         await fs.truncate(this.getOutputFilesPath());
         if (!this.interactive) {
             const jobNameStr = this.getJobNameString();
-            process.stdout.write(chalk`${jobNameStr} {magentaBright starting} ${this.imageName ?? "shell"} ({yellow ${this.stage}})\n`);
+            writeStreams.stdout(chalk`${jobNameStr} {magentaBright starting} ${this.imageName ?? "shell"} ({yellow ${this.stage}})\n`);
         }
 
         const prescripts = this.beforeScripts.concat(this.scripts);
         this._prescriptsExitCode = await this.execScripts(prescripts, privileged);
         if (this.afterScripts.length === 0 && this._prescriptsExitCode > 0 && !this.allowFailure) {
-            process.stderr.write(`${this.getExitedString(startTime, this._prescriptsExitCode, false)}\n`);
+            writeStreams.stderr(`${this.getExitedString(startTime, this._prescriptsExitCode, false)}\n`);
             this.running = false;
             this.finished = true;
             this.success = false;
@@ -196,7 +200,7 @@ export class Job {
         }
 
         if (this.afterScripts.length === 0 && this._prescriptsExitCode > 0 && this.allowFailure) {
-            process.stderr.write(`${this.getExitedString(startTime, this._prescriptsExitCode, true)}\n`);
+            writeStreams.stderr(`${this.getExitedString(startTime, this._prescriptsExitCode, true)}\n`);
             this.running = false;
             this.finished = true;
             await this.removeContainer();
@@ -204,11 +208,11 @@ export class Job {
         }
 
         if (this._prescriptsExitCode > 0 && this.allowFailure) {
-            process.stderr.write(`${this.getExitedString(startTime, this._prescriptsExitCode, true)}\n`);
+            writeStreams.stderr(`${this.getExitedString(startTime, this._prescriptsExitCode, true)}\n`);
         }
 
         if (this._prescriptsExitCode > 0 && !this.allowFailure) {
-            process.stderr.write(`${this.getExitedString(startTime, this._prescriptsExitCode, false)}\n`);
+            writeStreams.stderr(`${this.getExitedString(startTime, this._prescriptsExitCode, false)}\n`);
         }
 
         this._afterScriptsExitCode = 0;
@@ -217,14 +221,14 @@ export class Job {
         }
 
         if (this._afterScriptsExitCode > 0) {
-            process.stderr.write(`${this.getExitedString(startTime, this._afterScriptsExitCode, true, " (after_script)")}\n`);
+            writeStreams.stderr(`${this.getExitedString(startTime, this._afterScriptsExitCode, true, " (after_script)")}\n`);
         }
 
         if (this._prescriptsExitCode > 0 && !this.allowFailure) {
             this.success = false;
         }
 
-        process.stdout.write(`${this.getFinishedString(startTime)}\n`);
+        writeStreams.stdout(`${this.getFinishedString(startTime)}\n`);
 
         this.running = false;
         this.finished = true;
@@ -277,6 +281,7 @@ export class Job {
     private async execScripts(scripts: string[], privileged: boolean): Promise<number> {
         const jobNameStr = this.getJobNameString();
         const outputFilesPath = this.getOutputFilesPath();
+        const writeStreams = this.writeStreams;
         const artifactsFrom = this.needs || this.dependencies;
         let time;
         let endTime;
@@ -322,7 +327,7 @@ export class Job {
             pullCmd += `fi\n`
             await Utils.spawn(pullCmd, this.cwd);
             endTime = process.hrtime(time);
-            process.stdout.write(chalk`${this.getJobNameString()} {magentaBright pulled} ${this.imageName} in {magenta ${prettyHrtime(endTime)}}\n`);
+            writeStreams.stdout(chalk`${this.getJobNameString()} {magentaBright pulled} ${this.imageName} in {magenta ${prettyHrtime(endTime)}}\n`);
 
             let dockerCmd = ``;
             if (privileged) {
@@ -343,7 +348,7 @@ export class Job {
 
             if (this.cache && this.cache.key && typeof this.cache.key === "string" && this.cache.paths) {
                 this.cache.paths.forEach((path) => {
-                    process.stdout.write(chalk`${jobNameStr} {magentaBright mounting cache} for path ${path}\n`);
+                    writeStreams.stdout(chalk`${jobNameStr} {magentaBright mounting cache} for path ${path}\n`);
                     // /tmp/ location instead of .gitlab-ci-local/cache avoids the (unneeded) inclusion of cache folders when docker copy all files into the container, thus saving time for all jobs
                     dockerCmd += `-v /tmp/gitlab-ci-local/cache/${this.cache.key}/${path}:/builds/${path} `
                 });
@@ -375,14 +380,14 @@ export class Job {
             time = process.hrtime();
             await Utils.spawn(`docker cp . ${this.containerId}:/builds/`, this.cwd);
             endTime = process.hrtime(time);
-            process.stdout.write(chalk`${this.getJobNameString()} {magentaBright copied source to container} in {magenta ${prettyHrtime(endTime)}}\n`);
+            writeStreams.stdout(chalk`${this.getJobNameString()} {magentaBright copied source to container} in {magenta ${prettyHrtime(endTime)}}\n`);
 
             if (artifactsFrom === null || artifactsFrom.length > 0) {
                 time = process.hrtime();
                 await fs.mkdirp(`${this.cwd}/.gitlab-ci-local/artifacts/${this.pipelineIid}/`);
                 await Utils.spawn(`docker cp ${this.cwd}/.gitlab-ci-local/artifacts/${this.pipelineIid}/. ${this.containerId}:/builds/`);
                 endTime = process.hrtime(time);
-                process.stdout.write(chalk`${this.getJobNameString()} {magentaBright copied artifacts to container} in {magenta ${prettyHrtime(endTime)}}\n`);
+                writeStreams.stdout(chalk`${this.getJobNameString()} {magentaBright copied artifacts to container} in {magenta ${prettyHrtime(endTime)}}\n`);
             }
         }
 
@@ -391,7 +396,7 @@ export class Job {
             await fs.mkdirp(`${this.cwd}/.gitlab-ci-local/artifacts/${this.pipelineIid}/`);
             await Utils.spawn(`rsync -a ${this.cwd}/.gitlab-ci-local/artifacts/${this.pipelineIid}/. ${this.cwd}`);
             endTime = process.hrtime(time);
-            process.stdout.write(chalk`${this.getJobNameString()} {magentaBright copied artifacts to cwd} in {magenta ${prettyHrtime(endTime)}}\n`);
+            writeStreams.stdout(chalk`${this.getJobNameString()} {magentaBright copied artifacts to cwd} in {magenta ${prettyHrtime(endTime)}}\n`);
         }
 
         const cp = childProcess.spawn(this.containerId ? `docker start --attach -i ${this.containerId}` : `bash -e`, {
@@ -425,26 +430,26 @@ export class Job {
 
         cp.stdin.write(`exit 0\n`);
 
-        const outFunc = (e: any, stream: NodeJS.WriteStream, colorize: (str: string) => string) => {
+        const outFunc = (e: any, stream: (txt: string) => void, colorize: (str: string) => string) => {
             for (const line of `${e}`.split(/\r?\n/)) {
                 if (line.length === 0) {
                     continue;
                 }
 
-                stream.write(`${jobNameStr} `);
+                stream(`${jobNameStr} `);
                 if (!line.startsWith('\u001b[32m$')) {
-                    stream.write(`${colorize(">")} `);
+                    stream(`${colorize(">")} `);
                 }
-                stream.write(`${line}\n`);
+                stream(`${line}\n`);
                 fs.appendFileSync(outputFilesPath, `${line}\n`);
             }
         };
 
         const exitCode = await new Promise<number>((resolve, reject) => {
-            cp.stdout.on("data", (e) => outFunc(e, process.stdout, (s) => chalk`{greenBright ${s}}`));
-            cp.stderr.on("data", (e) => outFunc(e, process.stderr, (s) => chalk`{redBright ${s}}`));
+            cp.stdout.on("data", (e) => outFunc(e, writeStreams.stdout.bind(writeStreams), (s) => chalk`{greenBright ${s}}`));
+            cp.stderr.on("data", (e) => outFunc(e, writeStreams.stderr.bind(writeStreams), (s) => chalk`{redBright ${s}}`));
 
-            cp.on('exit', (code) => resolve(code ?? 0));
+            cp.on('exit', (code) => setTimeout(() => { resolve(code ?? 0)}, 5));
             cp.on("error", (err) => reject(err));
         });
 
@@ -465,7 +470,7 @@ export class Job {
                 }
 
                 endTime = process.hrtime(time);
-                process.stdout.write(chalk`${this.getJobNameString()} {magentaBright saved artifacts} in {magenta ${prettyHrtime(endTime)}}\n`);
+                writeStreams.stdout(chalk`${this.getJobNameString()} {magentaBright saved artifacts} in {magenta ${prettyHrtime(endTime)}}\n`);
             }
         }
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -467,7 +467,7 @@ export class Job {
             cp.stdout.on("data", (e) => outFunc(e, writeStreams.stdout.bind(writeStreams), (s) => chalk`{greenBright ${s}}`));
             cp.stderr.on("data", (e) => outFunc(e, writeStreams.stderr.bind(writeStreams), (s) => chalk`{redBright ${s}}`));
 
-            cp.on("exit", (code) => setTimeout(() => { resolve(code ?? 0);}, 5));
+            cp.on("exit", (code) => resolve(code ?? 0));
             cp.on("error", (err) => reject(err));
         });
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -455,7 +455,7 @@ export class Job {
                 }
 
                 stream(`${jobNameStr} `);
-                if (!line.startsWith('\u001b[32m$')) {
+                if (!line.startsWith("\u001b[32m$")) {
                     stream(`${colorize(">")} `);
                 }
                 stream(`${line}\n`);
@@ -467,7 +467,7 @@ export class Job {
             cp.stdout.on("data", (e) => outFunc(e, writeStreams.stdout.bind(writeStreams), (s) => chalk`{greenBright ${s}}`));
             cp.stderr.on("data", (e) => outFunc(e, writeStreams.stderr.bind(writeStreams), (s) => chalk`{redBright ${s}}`));
 
-            cp.on('exit', (code) => setTimeout(() => { resolve(code ?? 0)}, 5));
+            cp.on("exit", (code) => setTimeout(() => { resolve(code ?? 0);}, 5));
             cp.on("error", (err) => reject(err));
         });
 

--- a/src/mock-write-streams.ts
+++ b/src/mock-write-streams.ts
@@ -2,34 +2,34 @@ import {WriteStreams} from "./types/write-streams";
 
 export class MockWriteStreams implements WriteStreams {
 
-    private currentStderr = '';
-    private currentStdout = '';
+    private currentStderr = "";
+    private currentStdout = "";
 
     public readonly stderrLines: string[] = [];
     public readonly stdoutLines: string[] = [];
 
     stderr(txt: string): void {
         this.currentStderr += txt;
-        if (txt.endsWith('\n')) {
+        if (txt.endsWith("\n")) {
             this.stderrLines.push(this.currentStderr.slice(0, -1));
-            this.currentStderr = '';
+            this.currentStderr = "";
         }
     }
 
     stdout(txt: string): void {
         this.currentStdout += txt;
-        if (txt.endsWith('\n')) {
+        if (txt.endsWith("\n")) {
             this.stdoutLines.push(this.currentStdout.slice(0, -1));
-            this.currentStdout = '';
+            this.currentStdout = "";
         }
     }
 
     flush(): void {
         if (this.currentStdout.length != 0) {
-            this.stdout('\n');
+            this.stdout("\n");
         }
         if (this.currentStderr.length != 0) {
-            this.stderr('\n');
+            this.stderr("\n");
         }
     }
 

--- a/src/mock-write-streams.ts
+++ b/src/mock-write-streams.ts
@@ -1,0 +1,36 @@
+import {WriteStreams} from "./types/write-streams";
+
+export class MockWriteStreams implements WriteStreams {
+
+    private currentStderr = '';
+    private currentStdout = '';
+
+    public readonly stderrLines: string[] = [];
+    public readonly stdoutLines: string[] = [];
+
+    stderr(txt: string): void {
+        this.currentStderr += txt;
+        if (txt.endsWith('\n')) {
+            this.stderrLines.push(this.currentStderr.slice(0, -1));
+            this.currentStderr = '';
+        }
+    }
+
+    stdout(txt: string): void {
+        this.currentStdout += txt;
+        if (txt.endsWith('\n')) {
+            this.stdoutLines.push(this.currentStdout.slice(0, -1));
+            this.currentStdout = '';
+        }
+    }
+
+    flush(): void {
+        if (this.currentStdout.length != 0) {
+            this.stdout('\n');
+        }
+        if (this.currentStderr.length != 0) {
+            this.stderr('\n');
+        }
+    }
+
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -14,12 +14,14 @@ import {GitUser} from "./types/git-user";
 import {Utils} from "./utils";
 import {assert} from "./asserts";
 import * as path from "path";
+import {WriteStreams} from "./types/write-streams";
 
 export class Parser {
 
     private readonly jobs: Map<string, Job> = new Map();
     private readonly stages: Map<string, Stage> = new Map();
     private readonly cwd: string;
+    private readonly writeStreams: WriteStreams;
     private readonly file?: string;
     private readonly home?: string;
     private readonly pipelineIid: number;
@@ -31,16 +33,17 @@ export class Parser {
     private maxJobNameLength = 0;
     private readonly tabCompletionPhase: boolean;
 
-    private constructor(cwd: string, pipelineIid: number, tabCompletionPhase: boolean, home?: string, file?: string) {
+    private constructor(cwd: string, writeStreams: WriteStreams, pipelineIid: number, tabCompletionPhase: boolean, home?: string, file?: string) {
         this.cwd = cwd;
         this.pipelineIid = pipelineIid;
         this.tabCompletionPhase = tabCompletionPhase;
         this.file = file;
         this.home = home;
+        this.writeStreams = writeStreams;
     }
 
-    static async create(cwd: string, pipelineIid: number, tabCompletionPhase: boolean, home?: string, file?: string) {
-        const parser = new Parser(cwd, pipelineIid, tabCompletionPhase, file, home);
+    static async create(cwd: string, writeStreams: WriteStreams, pipelineIid: number, tabCompletionPhase: boolean, home?: string, file?: string) {
+        const parser = new Parser(cwd, writeStreams, pipelineIid, tabCompletionPhase, file, home);
 
         const time = process.hrtime();
         await parser.init();
@@ -48,7 +51,7 @@ export class Parser {
         await parser.validateNeedsTags();
         const parsingTime = process.hrtime(time);
         if (!tabCompletionPhase) {
-            process.stdout.write(chalk`{cyan ${"yml files".padEnd(parser.maxJobNameLength)}} {magentaBright processed} in {magenta ${prettyHrtime(parsingTime)}}\n`);
+            writeStreams.stdout(chalk`{cyan ${"yml files".padEnd(parser.maxJobNameLength)}} {magentaBright processed} in {magenta ${prettyHrtime(parsingTime)}}\n`);
         }
 
         return parser;
@@ -140,6 +143,7 @@ export class Parser {
 
     async init() {
         const cwd = this.cwd;
+        const writeStreams = this.writeStreams;
 
         this.gitRemote = await Parser.initGitRemote(cwd);
         this.userVariables = await Parser.initUserVariables(cwd, this.gitRemote, this.home ?? process.env.HOME ?? "");
@@ -147,11 +151,11 @@ export class Parser {
         let ymlPath, yamlDataList: any[] = [];
         ymlPath = this.file ? `${cwd}/${this.file}` : `${cwd}/.gitlab-ci.yml`;
         const gitlabCiData = await Parser.loadYaml(ymlPath);
-        yamlDataList = yamlDataList.concat(await Parser.prepareIncludes(gitlabCiData, cwd, this.gitRemote, this.tabCompletionPhase));
+        yamlDataList = yamlDataList.concat(await Parser.prepareIncludes(gitlabCiData, cwd, writeStreams, this.gitRemote, this.tabCompletionPhase));
 
         ymlPath = `${cwd}/.gitlab-ci-local.yml`;
         const gitlabCiLocalData = await Parser.loadYaml(ymlPath);
-        yamlDataList = yamlDataList.concat(await Parser.prepareIncludes(gitlabCiLocalData, cwd, this.gitRemote, this.tabCompletionPhase));
+        yamlDataList = yamlDataList.concat(await Parser.prepareIncludes(gitlabCiLocalData, cwd, writeStreams, this.gitRemote, this.tabCompletionPhase));
 
         const gitlabData: any = deepExtend({}, ...yamlDataList);
 
@@ -241,6 +245,7 @@ export class Parser {
 
             const jobId = await state.getJobId(cwd);
             const job = new Job({
+                writeStreams: this.writeStreams,
                 name: jobName,
                 maxJobNameLength: this.maxJobNameLength,
                 userVariables: this.userVariables,
@@ -377,25 +382,25 @@ export class Parser {
         };
     }
 
-    static async downloadIncludeRemote(cwd: string, url: string): Promise<void> {
+    static async downloadIncludeRemote(cwd: string, writeStreams: WriteStreams, url: string): Promise<void> {
         const time = process.hrtime();
         const fsUrl = Utils.fsUrl(url);
         const res = await fetch(url);
         fs.outputFileSync(`${cwd}/.gitlab-ci-local/includes/${fsUrl}`, await res.text());
         const endTime = process.hrtime(time);
-        process.stdout.write(chalk`{cyan downloaded} {magentaBright ${url}} in {magenta ${prettyHrtime(endTime)}}\n`);
+        writeStreams.stdout(chalk`{cyan downloaded} {magentaBright ${url}} in {magenta ${prettyHrtime(endTime)}}\n`);
     }
 
-    static async downloadIncludeProjectFile(cwd: string, project: string, ref: string, file: string, gitRemoteDomain: string): Promise<void> {
+    static async downloadIncludeProjectFile(cwd: string, writeStreams: WriteStreams, project: string, ref: string, file: string, gitRemoteDomain: string): Promise<void> {
         const time = process.hrtime();
         fs.ensureDirSync(`${cwd}/.gitlab-ci-local/includes/${gitRemoteDomain}/${project}/${ref}/`);
         await Utils.spawn(`git archive --remote=git@${gitRemoteDomain}:${project}.git ${ref} ${file} | tar -xC .gitlab-ci-local/includes/${gitRemoteDomain}/${project}/${ref}/`, cwd);
         const endTime = process.hrtime(time);
         const remoteUrl = `${gitRemoteDomain}/${project}/${file}`;
-        process.stdout.write(chalk`{cyan downloaded} {magentaBright ${remoteUrl}} in {magenta ${prettyHrtime(endTime)}}\n`);
+        writeStreams.stdout(chalk`{cyan downloaded} {magentaBright ${remoteUrl}} in {magenta ${prettyHrtime(endTime)}}\n`);
     }
 
-    static async prepareIncludes(gitlabData: any, cwd: string, gitRemote: GitRemote, tabCompletionPhase: boolean): Promise<any[]> {
+    static async prepareIncludes(gitlabData: any, cwd: string, writeStreams: WriteStreams, gitRemote: GitRemote, tabCompletionPhase: boolean): Promise<any[]> {
         let includeDatas: any[] = [];
         const promises = [];
 
@@ -405,12 +410,12 @@ export class Parser {
                 continue;
             }
             if (value["file"]) {
-                promises.push(Parser.downloadIncludeProjectFile(cwd, value["project"], value["ref"] || "master", value["file"], gitRemote.domain));
+                promises.push(Parser.downloadIncludeProjectFile(cwd, writeStreams, value["project"], value["ref"] || "master", value["file"], gitRemote.domain));
             } else if (value["template"]) {
                 const {project, ref, file, domain} = Parser.parseTemplateInclude(value['template']);
-                promises.push(Parser.downloadIncludeProjectFile(cwd, project, ref, file, domain));
+                promises.push(Parser.downloadIncludeProjectFile(cwd, writeStreams, project, ref, file, domain));
             } else if (value['remote']) {
-                promises.push(Parser.downloadIncludeRemote(cwd, value['remote']));
+                promises.push(Parser.downloadIncludeRemote(cwd, writeStreams, value['remote']));
             }
 
         }
@@ -420,18 +425,18 @@ export class Parser {
         for (const value of gitlabData["include"] || []) {
             if (value["local"]) {
                 const localDoc = await Parser.loadYaml(`${cwd}/${value.local}`);
-                includeDatas = includeDatas.concat(await Parser.prepareIncludes(localDoc, cwd, gitRemote, tabCompletionPhase));
+                includeDatas = includeDatas.concat(await Parser.prepareIncludes(localDoc, cwd, writeStreams, gitRemote, tabCompletionPhase));
             } else if (value["file"]) {
                 const fileDoc = await Parser.loadYaml(`${cwd}/.gitlab-ci-local/includes/${gitRemote.domain}/${value["project"]}/${value["ref"] || "master"}/${value["file"]}`);
-                includeDatas = includeDatas.concat(await Parser.prepareIncludes(fileDoc, cwd, gitRemote, tabCompletionPhase));
+                includeDatas = includeDatas.concat(await Parser.prepareIncludes(fileDoc, cwd, writeStreams, gitRemote, tabCompletionPhase));
             } else if (value['template']) {
                 const {project, ref, file, domain} = Parser.parseTemplateInclude(value['template']);
                 const fileDoc = await Parser.loadYaml(`${cwd}/.gitlab-ci-local/includes/${domain}/${project}/${ref}/${file}`);
-                includeDatas = includeDatas.concat(await Parser.prepareIncludes(fileDoc, cwd, gitRemote, tabCompletionPhase));
+                includeDatas = includeDatas.concat(await Parser.prepareIncludes(fileDoc, cwd, writeStreams, gitRemote, tabCompletionPhase));
             } else if (value['remote']) {
                 const fsUrl = Utils.fsUrl(value['remote']);
                 const fileDoc = await Parser.loadYaml(`${cwd}/.gitlab-ci-local/includes/${fsUrl}`);
-                includeDatas = includeDatas.concat(await Parser.prepareIncludes(fileDoc, cwd, gitRemote, tabCompletionPhase));
+                includeDatas = includeDatas.concat(await Parser.prepareIncludes(fileDoc, cwd, writeStreams, gitRemote, tabCompletionPhase));
             } else {
                 throw new ExitError(`Didn't understand include ${JSON.stringify(value)}`);
             }

--- a/src/process-write-streams.ts
+++ b/src/process-write-streams.ts
@@ -1,0 +1,16 @@
+import {WriteStreams} from "./types/write-streams";
+
+export class ProcessWriteStreams implements WriteStreams {
+    stderr(txt: string): void {
+        process.stderr.write(txt);
+    }
+
+    stdout(txt: string): void {
+        process.stdout.write(txt);
+    }
+
+    flush(): void {
+        // Process write streams flushes themselves.
+    }
+
+}

--- a/src/types/job-options.ts
+++ b/src/types/job-options.ts
@@ -1,7 +1,9 @@
 import {GitRemote} from "./git-remote";
 import {GitUser} from "./git-user";
+import {WriteStreams} from "./write-streams";
 
 export interface JobOptions {
+    writeStreams: WriteStreams,
     jobData: any;
     name: string;
     cwd: string;

--- a/src/types/write-streams.ts
+++ b/src/types/write-streams.ts
@@ -1,0 +1,5 @@
+export interface WriteStreams {
+    stdout: (txt: string) => void,
+    stderr: (txt: string) => void,
+    flush: () => void,
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,11 +47,11 @@ export class Utils {
         }
     }
 
-    static printJobNames(job: { name: string }, i: number, arr: { name: string }[]) {
+    static printJobNames(stream: (txt: string) => void, job: { name: string }, i: number, arr: { name: string }[]) {
         if (i === arr.length - 1) {
-            process.stdout.write(chalk`{blueBright ${job.name}}`);
+            stream(chalk`{blueBright ${job.name}}`);
         } else {
-            process.stdout.write(chalk`{blueBright ${job.name}}, `);
+            stream(chalk`{blueBright ${job.name}}, `);
         }
     }
 

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -552,7 +552,7 @@ test("list-case --list", async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test("--cwd unknown-directory/", async () => {
+test("something/unknown-directory (non-existing dir)", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
@@ -563,7 +563,7 @@ test("--cwd unknown-directory/", async () => {
     }
 });
 
-test("--cwd docs/", async () => {
+test("docs/ (no .gitlab-ci.yml)", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -563,7 +563,7 @@ test("something/unknown-directory (non-existing dir)", async () => {
     }
 });
 
-test("docs/ (no .gitlab-ci.yml)", async () => {
+test("docs (no .gitlab-ci.yml)", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -337,10 +337,64 @@ test("include-template <test-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{blueBright test-job} {greenBright >} Test Something`,
+        chalk`{blueBright test-job} {greenBright >} Test something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
     expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test("include-invalid-local", async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: "tests/test-cases/include-invalid-local",
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe("Local include file cannot be found .gitlab-ci-invalid.yml");
+    }
+});
+
+test("include-invalid-project", async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: "tests/test-cases/include-invalid-project",
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe("Project include could not be fetched { project: firecow/gitlab-ci-local-includes, ref: master, file: .gitlab-modue.yml }");
+    }
+});
+
+test("include-invalid-remote", async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: "tests/test-cases/include-invalid-remote",
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe("Remote include could not be fetched https://gitlab.com/firecow/gitlab-ci-local-includes/-/raw/master/.itlab-http.yml");
+    }
+});
+
+test("include-remote-with-inner-local", async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: "tests/test-cases/include-remote-with-inner-local",
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job  } {greenBright >} Test something`,
+        chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test("inject-ssh-agent", async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: "tests/test-cases/inject-ssh-agent",
+    }, writeStreams);
 });
 
 test("manual <build-job>", async () => {

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -1,55 +1,55 @@
 import {MockWriteStreams} from "../src/mock-write-streams";
-import * as chalk from 'chalk';
+import * as chalk from "chalk";
 import {handler} from "../src/handler";
 
-test('plain', async () => {
+test("plain", async () => {
     const writeStream = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/plain',
+        cwd: "tests/test-cases/plain",
     }, writeStream);
 
     expect(writeStream.stdoutLines.length).toEqual(15);
     expect(writeStream.stderrLines.length).toEqual(1);
 });
 
-test('invalid-jobname', async () => {
+test("invalid-jobname", async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
-            cwd: 'tests/test-cases/invalid-jobname',
+            cwd: "tests/test-cases/invalid-jobname",
         }, mockWriteStreams);
     } catch (e) {
         expect(e.message).toBe("Jobs cannot include spaces, yet! 'test job'");
     }
 });
 
-test('plain <notfound>', async () => {
+test("plain <notfound>", async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
-            cwd: 'tests/test-cases/plain',
-            job: 'notfound'
+            cwd: "tests/test-cases/plain",
+            job: "notfound"
         }, mockWriteStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`{blueBright notfound} could not be found`);
     }
 });
 
-test('trigger', async () => {
+test("trigger", async () => {
     const mockWriteStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/trigger',
+        cwd: "tests/test-cases/trigger",
     }, mockWriteStreams);
 
     const expected = [chalk`{green successful} {blueBright pipe-gen-job}, {blueBright trigger_job}`];
     expect(mockWriteStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('needs <build-job> --needs', async () => {
+test("needs <build-job> --needs", async () => {
     const mockWriteStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/needs',
-        job: 'build-job',
+        cwd: "tests/test-cases/needs",
+        job: "build-job",
         needs: true
     }, mockWriteStreams);
 
@@ -57,36 +57,36 @@ test('needs <build-job> --needs', async () => {
     expect(mockWriteStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('needs-invalid-stage <build-job> --needs', async () => {
+test("needs-invalid-stage <build-job> --needs", async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
-            cwd: 'tests/test-cases/needs-invalid-stage',
-            job: 'build-job',
+            cwd: "tests/test-cases/needs-invalid-stage",
+            job: "build-job",
         }, mockWriteStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`{blueBright test-job} is needed by {blueBright build-job}, but it is in the same or a future stage`);
     }
 });
 
-test('needs-unspecified-job <build-job> --needs', async () => {
+test("needs-unspecified-job <build-job> --needs", async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
-            cwd: 'tests/test-cases/needs-unspecified-job',
-            job: 'test-job',
+            cwd: "tests/test-cases/needs-unspecified-job",
+            job: "test-job",
         }, mockWriteStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`[ {blueBright invalid} ] jobs are needed by {blueBright test-job}, but they cannot be found`);
     }
 });
 
-test('custom-home <test-job>', async () => {
+test("custom-home <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/custom-home',
-        job: 'test-job',
-        home: 'tests/test-cases/custom-home/.home',
+        cwd: "tests/test-cases/custom-home",
+        job: "test-job",
+        home: "tests/test-cases/custom-home/.home",
     }, writeStreams);
 
     const expected = [
@@ -98,21 +98,21 @@ test('custom-home <test-job>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('image <test-job>', async () => {
+test("image <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/image',
-        job: 'test-job'
+        cwd: "tests/test-cases/image",
+        job: "test-job"
     }, writeStreams);
     const expected = [chalk`{blueBright test-job                } {greenBright >} Test something`];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('image <test-entrypoint>', async () => {
+test("image <test-entrypoint>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/image',
-        job: 'test-entrypoint',
+        cwd: "tests/test-cases/image",
+        job: "test-entrypoint",
         privileged: true
     }, writeStreams);
 
@@ -126,11 +126,11 @@ test('image <test-entrypoint>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('image <test-entrypoint-override>', async () => {
+test("image <test-entrypoint-override>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/image',
-        job: 'test-entrypoint-override'
+        cwd: "tests/test-cases/image",
+        job: "test-entrypoint-override"
     }, writeStreams);
 
     const expected = [
@@ -139,23 +139,23 @@ test('image <test-entrypoint-override>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('no-script <test-job>', async () => {
+test("no-script <test-job>", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'tests/test-cases/no-script',
-            job: 'test-job'
+            cwd: "tests/test-cases/no-script",
+            job: "test-job"
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`{blueBright test-job} must have script specified`);
     }
 });
 
-test('before-script <test-job>', async () => {
+test("before-script <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/before-script',
-        job: 'test-job'
+        cwd: "tests/test-cases/before-script",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -165,11 +165,11 @@ test('before-script <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('script-multidimension <test-job>', async () => {
+test("script-multidimension <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/script-multidimension',
-        job: 'test-job'
+        cwd: "tests/test-cases/script-multidimension",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -180,11 +180,11 @@ test('script-multidimension <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('before-script-default <test-job>', async () => {
+test("before-script-default <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/before-script-default',
-        job: 'test-job'
+        cwd: "tests/test-cases/before-script-default",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -194,11 +194,11 @@ test('before-script-default <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('after-script <test-job>', async () => {
+test("after-script <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/after-script',
-        job: 'test-job'
+        cwd: "tests/test-cases/after-script",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -208,11 +208,11 @@ test('after-script <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('after-script-default <test-job>', async () => {
+test("after-script-default <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/after-script-default',
-        job: 'test-job'
+        cwd: "tests/test-cases/after-script-default",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -222,44 +222,44 @@ test('after-script-default <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('artifacts <consume-artifacts> --needs', async () => {
+test("artifacts <consume-artifacts> --needs", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/artifacts',
-        job: 'consume-artifacts',
+        cwd: "tests/test-cases/artifacts",
+        job: "consume-artifacts",
         needs: true
     }, writeStreams);
 
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('artifacts-no-globstar', async () => {
+test("artifacts-no-globstar", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'tests/test-cases/artifacts-no-globstar'
+            cwd: "tests/test-cases/artifacts-no-globstar"
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe("Artfact paths cannot contain globstar, yet! 'test-job'");
     }
 });
 
-test('cache <consume-cache> --needs', async () => {
+test("cache <consume-cache> --needs", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/cache',
-        job: 'consume-cache',
+        cwd: "tests/test-cases/cache",
+        job: "consume-cache",
         needs: true
     }, writeStreams);
 
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('dotenv <test-job>', async () => {
+test("dotenv <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/dotenv',
-        job: 'test-job'
+        cwd: "tests/test-cases/dotenv",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -269,11 +269,11 @@ test('dotenv <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('extends <test-job>', async () => {
+test("extends <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/extends',
-        job: 'test-job'
+        cwd: "tests/test-cases/extends",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -285,11 +285,11 @@ test('extends <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('include <test-job>', async () => {
+test("include <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/include',
-        job: 'test-job'
+        cwd: "tests/test-cases/include",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -299,11 +299,11 @@ test('include <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('include <build-job>', async () => {
+test("include <build-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/include',
-        job: 'build-job'
+        cwd: "tests/test-cases/include",
+        job: "build-job"
     }, writeStreams);
 
     const expected = [
@@ -313,11 +313,11 @@ test('include <build-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 //
-test('include <deploy-job>', async () => {
+test("include <deploy-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/include',
-        job: 'deploy-job'
+        cwd: "tests/test-cases/include",
+        job: "deploy-job"
     }, writeStreams);
 
     const expected = [
@@ -327,11 +327,11 @@ test('include <deploy-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('include-template <test-job>', async () => {
+test("include-template <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/include-template',
-        job: 'test-job'
+        cwd: "tests/test-cases/include-template",
+        job: "test-job"
     }, writeStreams);
 
     const expected = [
@@ -341,11 +341,11 @@ test('include-template <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('manual <build-job>', async () => {
+test("manual <build-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/manual',
-        manual: 'build-job'
+        cwd: "tests/test-cases/manual",
+        manual: "build-job"
     }, writeStreams);
 
     const expected = [
@@ -355,11 +355,11 @@ test('manual <build-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('reference <test-job>', async () => {
+test("reference <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/reference',
-        job: 'test-job',
+        cwd: "tests/test-cases/reference",
+        job: "test-job",
     }, writeStreams);
 
     const expected = [
@@ -370,11 +370,11 @@ test('reference <test-job>', async () => {
     expect(writeStreams.stderrLines.length).toBe(0);
 });
 
-test('script-failures <test-job>', async () => {
+test("script-failures <test-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/script-failures',
-        job: 'test-job',
+        cwd: "tests/test-cases/script-failures",
+        job: "test-job",
     }, writeStreams);
 
     const expected = [
@@ -383,11 +383,11 @@ test('script-failures <test-job>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('script-failures <test-job-after-script>', async () => {
+test("script-failures <test-job-after-script>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/script-failures',
-        job: 'test-job-after-script',
+        cwd: "tests/test-cases/script-failures",
+        job: "test-job-after-script",
     }, writeStreams);
 
     const expected = [
@@ -397,11 +397,11 @@ test('script-failures <test-job-after-script>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('script-failures <allow-failure-job>', async () => {
+test("script-failures <allow-failure-job>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/script-failures',
-        job: 'allow-failure-job',
+        cwd: "tests/test-cases/script-failures",
+        job: "allow-failure-job",
     }, writeStreams);
 
     const expected = [
@@ -410,11 +410,11 @@ test('script-failures <allow-failure-job>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('script-failures <allow-failure-after-scripts>', async () => {
+test("script-failures <allow-failure-after-scripts>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/script-failures',
-        job: 'allow-failure-after-script',
+        cwd: "tests/test-cases/script-failures",
+        job: "allow-failure-after-script",
     }, writeStreams);
 
     const expected = [
@@ -424,68 +424,68 @@ test('script-failures <allow-failure-after-scripts>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('stage-not-found <test-job>', async () => {
+test("stage-not-found <test-job>", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'tests/test-cases/stage-not-found',
-            job: 'test-job'
+            cwd: "tests/test-cases/stage-not-found",
+            job: "test-job"
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`{yellow stage:invalid} not found for {blueBright test-job}`);
     }
 });
 
-test('invalid-variables-bool <test-job>', async () => {
+test("invalid-variables-bool <test-job>", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'tests/test-cases/invalid-variables-bool',
-            job: 'test-job'
+            cwd: "tests/test-cases/invalid-variables-bool",
+            job: "test-job"
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`{blueBright test-job} has invalid variables hash of key value pairs. INVALID=true`);
     }
 });
 
-test('invalid-variables-null <test-job>', async () => {
+test("invalid-variables-null <test-job>", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'tests/test-cases/invalid-variables-null',
-            job: 'test-job'
+            cwd: "tests/test-cases/invalid-variables-null",
+            job: "test-job"
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`{blueBright test-job} has invalid variables hash of key value pairs. INVALID=null`);
     }
 });
 
-test('invalid-stages', async () => {
+test("invalid-stages", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'tests/test-cases/invalid-stages',
+            cwd: "tests/test-cases/invalid-stages",
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`{yellow stages:} must be an array`);
     }
 });
 
-test('no-git-config', async () => {
+test("no-git-config", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'tests/test-cases/no-git-config',
+            cwd: "tests/test-cases/no-git-config",
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe("Could not locate.gitconfig or .git/config file");
     }
 });
 
-test('list-case --list', async () => {
+test("list-case --list", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
-        cwd: 'tests/test-cases/list-case/',
+        cwd: "tests/test-cases/list-case/",
         list: true
     }, writeStreams);
 
@@ -496,22 +496,22 @@ test('list-case --list', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('--cwd unknown-directory/', async () => {
+test("--cwd unknown-directory/", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'something/unknown-directory'
+            cwd: "something/unknown-directory"
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`something/unknown-directory is not a directory`);
     }
 });
 
-test('--cwd docs/', async () => {
+test("--cwd docs/", async () => {
     try {
         const writeStreams = new MockWriteStreams();
         await handler({
-            cwd: 'docs'
+            cwd: "docs"
         }, writeStreams);
     } catch (e) {
         expect(e.message).toBe(chalk`docs does not contain .gitlab-ci.yml`);

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -1,467 +1,454 @@
-import * as mockProcess from "jest-mock-process";
-import * as defaultCmd from "../src/default-cmd";
+import {MockWriteStreams} from "../src/mock-write-streams";
+import * as chalk from 'chalk';
+import {handler} from "../src/handler";
 
-jest.setTimeout(90000);
-
-let mockProcessExit: any;
-let mockProcessStdout: any;
-let mockProcessStderr: any;
-
-beforeEach(() => {
-    mockProcessExit = mockProcess.mockProcessExit(new Error("Test exited"));
-    mockProcessStdout = mockProcess.mockProcessStdout();
-    mockProcessStderr = mockProcess.mockProcessStderr();
-});
-
-afterEach(() => {
-    mockProcessStdout.mockClear();
-    mockProcessStderr.mockClear();
-    mockProcessExit.mockClear();
-});
-
-test('plain', async () => {
-    await defaultCmd.handler({
+test.concurrent('plain', async () => {
+    const writeStream = new MockWriteStreams();
+    await handler({
         cwd: 'tests/test-cases/plain',
-    });
+    }, writeStream);
 
-    expect(mockProcessStdout).toBeCalledTimes(25);
-    expect(mockProcessStderr).toBeCalledTimes(3);
-    expect(mockProcessExit).toBeCalledTimes(0);
+    expect(writeStream.stdoutLines.length).toEqual(15);
+    expect(writeStream.stderrLines.length).toEqual(1);
 });
 
-test('invalid-jobname', async () => {
+test.concurrent('invalid-jobname', async () => {
+    const mockWriteStreams = new MockWriteStreams();
     try {
-        await defaultCmd.handler({
+        await handler({
             cwd: 'tests/test-cases/invalid-jobname',
-        });
+        }, mockWriteStreams);
     } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31mJobs cannot include spaces, yet! 'test job'[39m\n");
+        expect(e.message).toBe("Jobs cannot include spaces, yet! 'test job'");
     }
 });
 
-test('plain <notfound>', async () => {
+test.concurrent('plain <notfound>', async () => {
+    const mockWriteStreams = new MockWriteStreams();
     try {
-        await defaultCmd.handler({
+        await handler({
             cwd: 'tests/test-cases/plain',
             job: 'notfound'
-        });
+        }, mockWriteStreams);
     } catch (e) {
-        expect(e.message).toBe("Test exited");
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mnotfound[39m[31m could not be found[39m\n");
-        expect(mockProcessStdout).toBeCalledTimes(1);
-        expect(mockProcessStderr).toBeCalledTimes(1);
+        expect(e.message).toBe(chalk`{blueBright notfound} could not be found`);
     }
 });
 
-test('trigger', async () => {
-    await defaultCmd.handler({
+test.concurrent('trigger', async () => {
+    const mockWriteStreams = new MockWriteStreams();
+    await handler({
         cwd: 'tests/test-cases/trigger',
-    });
+    }, mockWriteStreams);
 
-    expect(mockProcessStdout).toHaveBeenCalledWith("[94mtrigger_job[39m");
+    const expected = [chalk`{green successful} {blueBright pipe-gen-job}, {blueBright trigger_job}`];
+    expect(mockWriteStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-
-test('needs <build-job> --needs', async () => {
-    await defaultCmd.handler({
+test.concurrent('needs <build-job> --needs', async () => {
+    const mockWriteStreams = new MockWriteStreams();
+    await handler({
         cwd: 'tests/test-cases/needs',
         job: 'build-job',
         needs: true
-    });
+    }, mockWriteStreams);
 
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
+    const expected = [chalk`{blueBright test-job } {greenBright >} Test something`];
+    expect(mockWriteStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('needs-invalid-stage <build-job> --needs', async () => {
+test.concurrent('needs-invalid-stage <build-job> --needs', async () => {
+    const mockWriteStreams = new MockWriteStreams();
     try {
-        await defaultCmd.handler({
+        await handler({
             cwd: 'tests/test-cases/needs-invalid-stage',
             job: 'build-job',
-        });
+        }, mockWriteStreams);
     } catch (e) {
-        expect(e.message).toBe("Test exited");
-        expect(mockProcessStdout).toBeCalledTimes(0);
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mtest-job[39m[31m is needed by [94mbuild-job[39m[31m, but it is in the same or a future stage[39m\n");
+        expect(e.message).toBe(chalk`{blueBright test-job} is needed by {blueBright build-job}, but it is in the same or a future stage`);
     }
 });
 
-test('needs-unspecified-job <build-job> --needs', async () => {
+test.concurrent('needs-unspecified-job <build-job> --needs', async () => {
+    const mockWriteStreams = new MockWriteStreams();
     try {
-        await defaultCmd.handler({
+        await handler({
             cwd: 'tests/test-cases/needs-unspecified-job',
             job: 'test-job',
-        });
+        }, mockWriteStreams);
     } catch (e) {
-        expect(e.message).toBe("Test exited");
-        expect(mockProcessStdout).toBeCalledTimes(0);
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31m[ [94minvalid[39m[31m ] jobs are needed by [94mtest-job[39m[31m, but they cannot be found[39m\n");
+        expect(e.message).toBe(chalk`[ {blueBright invalid} ] jobs are needed by {blueBright test-job}, but they cannot be found`);
     }
 });
 
-test('custom-home <test-job>', async () => {
-    await defaultCmd.handler({
+test.concurrent('custom-home <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
         cwd: 'tests/test-cases/custom-home',
         job: 'test-job',
         home: 'tests/test-cases/custom-home/.home',
-    });
+    }, writeStreams);
 
-    expect(mockProcessStdout).toHaveBeenCalledWith("global-var-value\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("group-var-value\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("project-var-value\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("Im content of a file variable\n");
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} global-var-value`,
+        chalk`{blueBright test-job} {greenBright >} group-var-value`,
+        chalk`{blueBright test-job} {greenBright >} project-var-value`,
+        chalk`{blueBright test-job} {greenBright >} Im content of a file variable`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test('image <test-job>', async () => {
-    await defaultCmd.handler({
+test.concurrent('image <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
         cwd: 'tests/test-cases/image',
         job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
+    }, writeStreams);
+    const expected = [chalk`{blueBright test-job                } {greenBright >} Test something`];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
-
-test('image <test-entrypoint>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/image',
-        job: 'test-entrypoint',
-        privileged: true
-    });
-
-    expect(mockProcessStdout).toHaveBeenCalledWith("/\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("Hello from 'firecow/gitlab-ci-local-test-image' image entrypoint\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("I am epic multiline value\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("/builds\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test Entrypoint\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("I'm a test file\n");
-
-});
-
-test('image <test-entrypoint-override>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/image',
-        job: 'test-entrypoint-override'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('no-script <test-job>', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/no-script',
-            job: 'test-job'
-        });
-    } catch (e) {
-        expect(e.message).toBe("Test exited");
-        expect(mockProcessStdout).toBeCalledTimes(0);
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mtest-job[39m[31m must have script specified[39m\n");
-    }
-});
-
-test('before-script <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/before-script',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Before test\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('script-multidimension <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/script-multidimension',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something else\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('before-script-default <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/before-script-default',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Before test\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('after-script <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/after-script',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Cleanup after test\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('after-script-default <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/after-script-default',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Cleanup after test\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('artifacts <consume-artifacts> --needs', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/artifacts',
-        job: 'consume-artifacts',
-        needs: true
-    });
-    expect(mockProcessExit).toBeCalledTimes(0);
-    expect(mockProcessStderr).toBeCalledTimes(0);
-});
-
-test('artifacts-no-globstar', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/artifacts-no-globstar'
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31mArtfact paths cannot contain globstar, yet! 'test-job'[39m\n");
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('cache <consume-cache> --needs', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/cache',
-        job: 'consume-cache',
-        needs: true
-    });
-    expect(mockProcessExit).toBeCalledTimes(0);
-    expect(mockProcessStderr).toBeCalledTimes(0);
-});
-
-test('dotenv <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/dotenv',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-});
-
-test('extends <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/extends',
-        job: 'test-job'
-    });
-
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something (before_script)\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something (after_script)\n");
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('include <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/include',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('include <build-job>', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/include',
-            job: 'build-job'
-        });
-        expect(mockProcessStdout).toHaveBeenCalledWith("Build something\n");
-        expect(mockProcessExit).toBeCalledTimes(0);
-    } catch(e) {
-        console.log(mockProcessStderr.mock.calls.join("\n"));
-        console.log(e);
-    }
-});
-
-test('include <deploy-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/include',
-        job: 'deploy-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Deploy something\n");
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('include-template <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/include-template',
-        job: 'test-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("Test Something\n");
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('manual <build-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/manual',
-        manual: 'build-job'
-    });
-    expect(mockProcessStdout).toHaveBeenCalledWith("[35mnot started[39m ");
-    expect(mockProcessStdout).toHaveBeenCalledWith("[94mtest-job[39m");
-    expect(mockProcessStdout).toHaveBeenCalledWith("[32msuccessful[39m ");
-    expect(mockProcessStdout).toHaveBeenCalledWith("[94mbuild-job[39m");
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('reference <test-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/reference',
-        job: 'test-job',
-    });
-
-    expect(mockProcessStdout).toHaveBeenCalledWith("Setting something general up\n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("Yoyo\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('script-failures <test-job>', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/script-failures',
-            job: 'test-job',
-        });
-    } catch (e) {
-        expect(mockProcessStdout).toBeCalledTimes(19);
-        expect(mockProcessStderr).toBeCalledTimes(2);
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('script-failures <test-job-after-script>', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/script-failures',
-            job: 'test-job-after-script',
-        });
-    } catch (e) {
-        expect(mockProcessStdout).toBeCalledTimes(19);
-        expect(mockProcessStderr).toBeCalledTimes(2);
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('script-failures <allow-failure-job>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/script-failures',
-        job: 'allow-failure-job',
-    });
-
-    expect(mockProcessStdout).toHaveBeenCalledWith("[93mwarning[39m ");
-    expect(mockProcessStderr).toBeCalledTimes(1);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('script-failures <allow-failure-after-scripts>', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/script-failures',
-        job: 'allow-failure-after-script',
-    });
-
-    expect(mockProcessStdout).toHaveBeenCalledWith("[93mwarning[39m ");
-    expect(mockProcessStderr).toBeCalledTimes(2);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('stage-not-found <test-job>', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/stage-not-found',
-            job: 'test-job'
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31m[33mstage:invalid[39m[31m not found for [94mtest-job[39m[31m[39m\n");
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('invalid-variables-bool <test-job>', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/invalid-variables-bool',
-            job: 'test-job'
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith(`[31m[94mtest-job[31m has invalid variables hash of key value pairs. INVALID=true[39m\n`);
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('invalid-variables-null <test-job>', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/invalid-variables-null',
-            job: 'test-job'
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mtest-job[39m[31m has invalid variables hash of key value pairs. INVALID=null[39m\n");
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('invalid-stages', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/invalid-stages',
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith(`[31m[33mstages:[39m[31m must be an array[39m\n`);
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('no-git-config', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'tests/test-cases/no-git-config',
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith(`[31mCould not locate.gitconfig or .git/config file[39m\n`);
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('list-case --list', async () => {
-    await defaultCmd.handler({
-        cwd: 'tests/test-cases/list-case/',
-        list: true
-    });
-
-    expect(mockProcessStdout).toHaveBeenCalledWith("[94mtest-job [39m  Run Tests  [33mtest [39m  on_success         \n");
-    expect(mockProcessStdout).toHaveBeenCalledWith("[94mbuild-job[39m             [33mbuild[39m  on_success  warning  [[94mtest-job[39m]\n");
-    expect(mockProcessStderr).toBeCalledTimes(0);
-    expect(mockProcessExit).toBeCalledTimes(0);
-});
-
-test('--cwd unknown-directory/', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'something/unknown-directory'
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith(`[31msomething/unknown-directory is not a directory[39m\n`);
-        expect(e.message).toBe("Test exited");
-    }
-});
-
-test('--cwd docs/', async () => {
-    try {
-        await defaultCmd.handler({
-            cwd: 'docs'
-        });
-    } catch (e) {
-        expect(mockProcessStderr).toHaveBeenCalledWith(`[31mdocs does not contain .gitlab-ci.yml[39m\n`);
-        expect(e.message).toBe("Test exited");
-    }
-});
+//
+// test('image <test-entrypoint>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/image',
+//         job: 'test-entrypoint',
+//         privileged: true
+//     });
+//
+//     expect(mockProcessStdout).toHaveBeenCalledWith("/\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Hello from 'firecow/gitlab-ci-local-test-image' image entrypoint\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("I am epic multiline value\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("/builds\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test Entrypoint\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("I'm a test file\n");
+//
+// });
+//
+// test('image <test-entrypoint-override>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/image',
+//         job: 'test-entrypoint-override'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('no-script <test-job>', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/no-script',
+//             job: 'test-job'
+//         });
+//     } catch (e) {
+//         expect(e.message).toBe("Test exited");
+//         expect(mockProcessStdout).toBeCalledTimes(0);
+//         expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mtest-job[39m[31m must have script specified[39m\n");
+//     }
+// });
+//
+// test('before-script <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/before-script',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Before test\n");
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('script-multidimension <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/script-multidimension',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something else\n");
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('before-script-default <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/before-script-default',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Before test\n");
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('after-script <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/after-script',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Cleanup after test\n");
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('after-script-default <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/after-script-default',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Cleanup after test\n");
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('artifacts <consume-artifacts> --needs', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/artifacts',
+//         job: 'consume-artifacts',
+//         needs: true
+//     });
+//     expect(mockProcessExit).toBeCalledTimes(0);
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+// });
+//
+// test('artifacts-no-globstar', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/artifacts-no-globstar'
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith("[31mArtfact paths cannot contain globstar, yet! 'test-job'[39m\n");
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('cache <consume-cache> --needs', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/cache',
+//         job: 'consume-cache',
+//         needs: true
+//     });
+//     expect(mockProcessExit).toBeCalledTimes(0);
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+// });
+//
+// test('dotenv <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/dotenv',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
+// });
+//
+// test('extends <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/extends',
+//         job: 'test-job'
+//     });
+//
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something (before_script)\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something (after_script)\n");
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('include <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/include',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('include <build-job>', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/include',
+//             job: 'build-job'
+//         });
+//         expect(mockProcessStdout).toHaveBeenCalledWith("Build something\n");
+//         expect(mockProcessExit).toBeCalledTimes(0);
+//     } catch(e) {
+//         console.log(mockProcessStderr.mock.calls.join("\n"));
+//         console.log(e);
+//     }
+// });
+//
+// test('include <deploy-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/include',
+//         job: 'deploy-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Deploy something\n");
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('include-template <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/include-template',
+//         job: 'test-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Test Something\n");
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('manual <build-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/manual',
+//         manual: 'build-job'
+//     });
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[35mnot started[39m ");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mtest-job[39m");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[32msuccessful[39m ");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mbuild-job[39m");
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('reference <test-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/reference',
+//         job: 'test-job',
+//     });
+//
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Setting something general up\n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("Yoyo\n");
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('script-failures <test-job>', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/script-failures',
+//             job: 'test-job',
+//         });
+//     } catch (e) {
+//         expect(mockProcessStdout).toBeCalledTimes(19);
+//         expect(mockProcessStderr).toBeCalledTimes(2);
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('script-failures <test-job-after-script>', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/script-failures',
+//             job: 'test-job-after-script',
+//         });
+//     } catch (e) {
+//         expect(mockProcessStdout).toBeCalledTimes(19);
+//         expect(mockProcessStderr).toBeCalledTimes(2);
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('script-failures <allow-failure-job>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/script-failures',
+//         job: 'allow-failure-job',
+//     });
+//
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[93mwarning[39m ");
+//     expect(mockProcessStderr).toBeCalledTimes(1);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('script-failures <allow-failure-after-scripts>', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/script-failures',
+//         job: 'allow-failure-after-script',
+//     });
+//
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[93mwarning[39m ");
+//     expect(mockProcessStderr).toBeCalledTimes(2);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('stage-not-found <test-job>', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/stage-not-found',
+//             job: 'test-job'
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith("[31m[33mstage:invalid[39m[31m not found for [94mtest-job[39m[31m[39m\n");
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('invalid-variables-bool <test-job>', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/invalid-variables-bool',
+//             job: 'test-job'
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31m[94mtest-job[31m has invalid variables hash of key value pairs. INVALID=true[39m\n`);
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('invalid-variables-null <test-job>', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/invalid-variables-null',
+//             job: 'test-job'
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mtest-job[39m[31m has invalid variables hash of key value pairs. INVALID=null[39m\n");
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('invalid-stages', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/invalid-stages',
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31m[33mstages:[39m[31m must be an array[39m\n`);
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('no-git-config', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'tests/test-cases/no-git-config',
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31mCould not locate.gitconfig or .git/config file[39m\n`);
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('list-case --list', async () => {
+//     await defaultCmd.handler({
+//         cwd: 'tests/test-cases/list-case/',
+//         list: true
+//     });
+//
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mtest-job [39m  Run Tests  [33mtest [39m  on_success         \n");
+//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mbuild-job[39m             [33mbuild[39m  on_success  warning  [[94mtest-job[39m]\n");
+//     expect(mockProcessStderr).toBeCalledTimes(0);
+//     expect(mockProcessExit).toBeCalledTimes(0);
+// });
+//
+// test('--cwd unknown-directory/', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'something/unknown-directory'
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31msomething/unknown-directory is not a directory[39m\n`);
+//         expect(e.message).toBe("Test exited");
+//     }
+// });
+//
+// test('--cwd docs/', async () => {
+//     try {
+//         await defaultCmd.handler({
+//             cwd: 'docs'
+//         });
+//     } catch (e) {
+//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31mdocs does not contain .gitlab-ci.yml[39m\n`);
+//         expect(e.message).toBe("Test exited");
+//     }
+// });

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -2,7 +2,7 @@ import {MockWriteStreams} from "../src/mock-write-streams";
 import * as chalk from 'chalk';
 import {handler} from "../src/handler";
 
-test.concurrent('plain', async () => {
+test('plain', async () => {
     const writeStream = new MockWriteStreams();
     await handler({
         cwd: 'tests/test-cases/plain',
@@ -12,7 +12,7 @@ test.concurrent('plain', async () => {
     expect(writeStream.stderrLines.length).toEqual(1);
 });
 
-test.concurrent('invalid-jobname', async () => {
+test('invalid-jobname', async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
@@ -23,7 +23,7 @@ test.concurrent('invalid-jobname', async () => {
     }
 });
 
-test.concurrent('plain <notfound>', async () => {
+test('plain <notfound>', async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
@@ -35,7 +35,7 @@ test.concurrent('plain <notfound>', async () => {
     }
 });
 
-test.concurrent('trigger', async () => {
+test('trigger', async () => {
     const mockWriteStreams = new MockWriteStreams();
     await handler({
         cwd: 'tests/test-cases/trigger',
@@ -45,7 +45,7 @@ test.concurrent('trigger', async () => {
     expect(mockWriteStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test.concurrent('needs <build-job> --needs', async () => {
+test('needs <build-job> --needs', async () => {
     const mockWriteStreams = new MockWriteStreams();
     await handler({
         cwd: 'tests/test-cases/needs',
@@ -57,7 +57,7 @@ test.concurrent('needs <build-job> --needs', async () => {
     expect(mockWriteStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test.concurrent('needs-invalid-stage <build-job> --needs', async () => {
+test('needs-invalid-stage <build-job> --needs', async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
@@ -69,7 +69,7 @@ test.concurrent('needs-invalid-stage <build-job> --needs', async () => {
     }
 });
 
-test.concurrent('needs-unspecified-job <build-job> --needs', async () => {
+test('needs-unspecified-job <build-job> --needs', async () => {
     const mockWriteStreams = new MockWriteStreams();
     try {
         await handler({
@@ -81,7 +81,7 @@ test.concurrent('needs-unspecified-job <build-job> --needs', async () => {
     }
 });
 
-test.concurrent('custom-home <test-job>', async () => {
+test('custom-home <test-job>', async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
         cwd: 'tests/test-cases/custom-home',
@@ -98,7 +98,7 @@ test.concurrent('custom-home <test-job>', async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test.concurrent('image <test-job>', async () => {
+test('image <test-job>', async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
         cwd: 'tests/test-cases/image',
@@ -107,348 +107,413 @@ test.concurrent('image <test-job>', async () => {
     const expected = [chalk`{blueBright test-job                } {greenBright >} Test something`];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
+
+test('image <test-entrypoint>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/image',
+        job: 'test-entrypoint',
+        privileged: true
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-entrypoint         } {greenBright >} Hello from 'firecow/gitlab-ci-local-test-image' image entrypoint`,
+        chalk`{blueBright test-entrypoint         } {greenBright >} I am epic multiline value`,
+        chalk`{blueBright test-entrypoint         } {greenBright >} /builds`,
+        chalk`{blueBright test-entrypoint         } {greenBright >} Test Entrypoint`,
+        chalk`{blueBright test-entrypoint         } {greenBright >} I'm a test file`
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test('image <test-entrypoint-override>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/image',
+        job: 'test-entrypoint-override'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-entrypoint-override} {greenBright >} Test something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test('no-script <test-job>', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'tests/test-cases/no-script',
+            job: 'test-job'
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe(chalk`{blueBright test-job} must have script specified`);
+    }
+});
+
+test('before-script <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/before-script',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Before test`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('script-multidimension <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/script-multidimension',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Test something`,
+        chalk`{blueBright test-job} {greenBright >} Test something else`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('before-script-default <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/before-script-default',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Before test`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('after-script <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/after-script',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Cleanup after test`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('after-script-default <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/after-script-default',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Cleanup after test`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('artifacts <consume-artifacts> --needs', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/artifacts',
+        job: 'consume-artifacts',
+        needs: true
+    }, writeStreams);
+
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('artifacts-no-globstar', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'tests/test-cases/artifacts-no-globstar'
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe("Artfact paths cannot contain globstar, yet! 'test-job'");
+    }
+});
+
+test('cache <consume-cache> --needs', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/cache',
+        job: 'consume-cache',
+        needs: true
+    }, writeStreams);
+
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('dotenv <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/dotenv',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Test something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('extends <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/extends',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Test something (before_script)`,
+        chalk`{blueBright test-job} {greenBright >} Test something`,
+        chalk`{blueBright test-job} {greenBright >} Test something (after_script)`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('include <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/include',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job  } {greenBright >} Test something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('include <build-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/include',
+        job: 'build-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright build-job } {greenBright >} Build something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
 //
-// test('image <test-entrypoint>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/image',
-//         job: 'test-entrypoint',
-//         privileged: true
-//     });
-//
-//     expect(mockProcessStdout).toHaveBeenCalledWith("/\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Hello from 'firecow/gitlab-ci-local-test-image' image entrypoint\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("I am epic multiline value\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("/builds\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test Entrypoint\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("I'm a test file\n");
-//
-// });
-//
-// test('image <test-entrypoint-override>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/image',
-//         job: 'test-entrypoint-override'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('no-script <test-job>', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/no-script',
-//             job: 'test-job'
-//         });
-//     } catch (e) {
-//         expect(e.message).toBe("Test exited");
-//         expect(mockProcessStdout).toBeCalledTimes(0);
-//         expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mtest-job[39m[31m must have script specified[39m\n");
-//     }
-// });
-//
-// test('before-script <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/before-script',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Before test\n");
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('script-multidimension <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/script-multidimension',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something else\n");
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('before-script-default <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/before-script-default',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Before test\n");
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('after-script <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/after-script',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Cleanup after test\n");
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('after-script-default <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/after-script-default',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Cleanup after test\n");
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('artifacts <consume-artifacts> --needs', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/artifacts',
-//         job: 'consume-artifacts',
-//         needs: true
-//     });
-//     expect(mockProcessExit).toBeCalledTimes(0);
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-// });
-//
-// test('artifacts-no-globstar', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/artifacts-no-globstar'
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith("[31mArtfact paths cannot contain globstar, yet! 'test-job'[39m\n");
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('cache <consume-cache> --needs', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/cache',
-//         job: 'consume-cache',
-//         needs: true
-//     });
-//     expect(mockProcessExit).toBeCalledTimes(0);
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-// });
-//
-// test('dotenv <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/dotenv',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-// });
-//
-// test('extends <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/extends',
-//         job: 'test-job'
-//     });
-//
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something (before_script)\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something (after_script)\n");
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('include <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/include',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test something\n");
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('include <build-job>', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/include',
-//             job: 'build-job'
-//         });
-//         expect(mockProcessStdout).toHaveBeenCalledWith("Build something\n");
-//         expect(mockProcessExit).toBeCalledTimes(0);
-//     } catch(e) {
-//         console.log(mockProcessStderr.mock.calls.join("\n"));
-//         console.log(e);
-//     }
-// });
-//
-// test('include <deploy-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/include',
-//         job: 'deploy-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Deploy something\n");
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('include-template <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/include-template',
-//         job: 'test-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Test Something\n");
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('manual <build-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/manual',
-//         manual: 'build-job'
-//     });
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[35mnot started[39m ");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mtest-job[39m");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[32msuccessful[39m ");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mbuild-job[39m");
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('reference <test-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/reference',
-//         job: 'test-job',
-//     });
-//
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Setting something general up\n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("Yoyo\n");
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('script-failures <test-job>', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/script-failures',
-//             job: 'test-job',
-//         });
-//     } catch (e) {
-//         expect(mockProcessStdout).toBeCalledTimes(19);
-//         expect(mockProcessStderr).toBeCalledTimes(2);
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('script-failures <test-job-after-script>', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/script-failures',
-//             job: 'test-job-after-script',
-//         });
-//     } catch (e) {
-//         expect(mockProcessStdout).toBeCalledTimes(19);
-//         expect(mockProcessStderr).toBeCalledTimes(2);
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('script-failures <allow-failure-job>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/script-failures',
-//         job: 'allow-failure-job',
-//     });
-//
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[93mwarning[39m ");
-//     expect(mockProcessStderr).toBeCalledTimes(1);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('script-failures <allow-failure-after-scripts>', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/script-failures',
-//         job: 'allow-failure-after-script',
-//     });
-//
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[93mwarning[39m ");
-//     expect(mockProcessStderr).toBeCalledTimes(2);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('stage-not-found <test-job>', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/stage-not-found',
-//             job: 'test-job'
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith("[31m[33mstage:invalid[39m[31m not found for [94mtest-job[39m[31m[39m\n");
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('invalid-variables-bool <test-job>', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/invalid-variables-bool',
-//             job: 'test-job'
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31m[94mtest-job[31m has invalid variables hash of key value pairs. INVALID=true[39m\n`);
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('invalid-variables-null <test-job>', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/invalid-variables-null',
-//             job: 'test-job'
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith("[31m[94mtest-job[39m[31m has invalid variables hash of key value pairs. INVALID=null[39m\n");
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('invalid-stages', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/invalid-stages',
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31m[33mstages:[39m[31m must be an array[39m\n`);
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('no-git-config', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'tests/test-cases/no-git-config',
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31mCould not locate.gitconfig or .git/config file[39m\n`);
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('list-case --list', async () => {
-//     await defaultCmd.handler({
-//         cwd: 'tests/test-cases/list-case/',
-//         list: true
-//     });
-//
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mtest-job [39m  Run Tests  [33mtest [39m  on_success         \n");
-//     expect(mockProcessStdout).toHaveBeenCalledWith("[94mbuild-job[39m             [33mbuild[39m  on_success  warning  [[94mtest-job[39m]\n");
-//     expect(mockProcessStderr).toBeCalledTimes(0);
-//     expect(mockProcessExit).toBeCalledTimes(0);
-// });
-//
-// test('--cwd unknown-directory/', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'something/unknown-directory'
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31msomething/unknown-directory is not a directory[39m\n`);
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
-//
-// test('--cwd docs/', async () => {
-//     try {
-//         await defaultCmd.handler({
-//             cwd: 'docs'
-//         });
-//     } catch (e) {
-//         expect(mockProcessStderr).toHaveBeenCalledWith(`[31mdocs does not contain .gitlab-ci.yml[39m\n`);
-//         expect(e.message).toBe("Test exited");
-//     }
-// });
+test('include <deploy-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/include',
+        job: 'deploy-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('include-template <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/include-template',
+        job: 'test-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Test Something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('manual <build-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/manual',
+        manual: 'build-job'
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright build-job} {greenBright >} Hello, build job manual!`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('reference <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/reference',
+        job: 'test-job',
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Setting something general up`,
+        chalk`{blueBright test-job} {greenBright >} Yoyo`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stderrLines.length).toBe(0);
+});
+
+test('script-failures <test-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/script-failures',
+        job: 'test-job',
+    }, writeStreams);
+
+    const expected = [
+        chalk`{red failure} {blueBright test-job}`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test('script-failures <test-job-after-script>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/script-failures',
+        job: 'test-job-after-script',
+    }, writeStreams);
+
+    const expected = [
+        chalk`{yellowBright after script} {blueBright test-job-after-script}`,
+        chalk`{red failure} {blueBright test-job-after-script}`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test('script-failures <allow-failure-job>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/script-failures',
+        job: 'allow-failure-job',
+    }, writeStreams);
+
+    const expected = [
+        chalk`{yellowBright warning} {blueBright allow-failure-job}`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test('script-failures <allow-failure-after-scripts>', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/script-failures',
+        job: 'allow-failure-after-script',
+    }, writeStreams);
+
+    const expected = [
+        chalk`{yellowBright warning} {blueBright allow-failure-after-script}`,
+        chalk`{yellowBright after script} {blueBright allow-failure-after-script}`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test('stage-not-found <test-job>', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'tests/test-cases/stage-not-found',
+            job: 'test-job'
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe(chalk`{yellow stage:invalid} not found for {blueBright test-job}`);
+    }
+});
+
+test('invalid-variables-bool <test-job>', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'tests/test-cases/invalid-variables-bool',
+            job: 'test-job'
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe(chalk`{blueBright test-job} has invalid variables hash of key value pairs. INVALID=true`);
+    }
+});
+
+test('invalid-variables-null <test-job>', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'tests/test-cases/invalid-variables-null',
+            job: 'test-job'
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe(chalk`{blueBright test-job} has invalid variables hash of key value pairs. INVALID=null`);
+    }
+});
+
+test('invalid-stages', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'tests/test-cases/invalid-stages',
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe(chalk`{yellow stages:} must be an array`);
+    }
+});
+
+test('no-git-config', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'tests/test-cases/no-git-config',
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe("Could not locate.gitconfig or .git/config file");
+    }
+});
+
+test('list-case --list', async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: 'tests/test-cases/list-case/',
+        list: true
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job }  Run Tests  {yellow test }  on_success         `,
+        chalk`{blueBright build-job}             {yellow build}  on_success  warning  [{blueBright test-job}]`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test('--cwd unknown-directory/', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'something/unknown-directory'
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe(chalk`something/unknown-directory is not a directory`);
+    }
+});
+
+test('--cwd docs/', async () => {
+    try {
+        const writeStreams = new MockWriteStreams();
+        await handler({
+            cwd: 'docs'
+        }, writeStreams);
+    } catch (e) {
+        expect(e.message).toBe(chalk`docs does not contain .gitlab-ci.yml`);
+    }
+});

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -90,8 +90,8 @@ test("custom-home <test-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{blueBright test-job} {greenBright >} global-var-value`,
-        chalk`{blueBright test-job} {greenBright >} group-var-value`,
+        chalk`{blueBright test-job} {greenBright >} group-global-var-override-value`,
+        chalk`{blueBright test-job} {greenBright >} project-group-var-override-value`,
         chalk`{blueBright test-job} {greenBright >} project-var-value`,
         chalk`{blueBright test-job} {greenBright >} Im content of a file variable`,
     ];

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -2,6 +2,8 @@ import {MockWriteStreams} from "../src/mock-write-streams";
 import * as chalk from "chalk";
 import {handler} from "../src/handler";
 
+jest.setTimeout(90000);
+
 test("plain", async () => {
     const writeStream = new MockWriteStreams();
     await handler({

--- a/tests/print-funcs.test.ts
+++ b/tests/print-funcs.test.ts
@@ -1,16 +1,16 @@
-import * as mockProcess from 'jest-mock-process';
 import {Utils} from "../src/utils";
+import {MockWriteStreams} from "../src/mock-write-streams";
 
 test('Print job on first index', () => {
-    const mockStdout = mockProcess.mockProcessStdout();
-    Utils.printJobNames({name: "Hello"}, 0, [{name: "Hello"}, {name: "Hello"}, {name: "Hello"}]);
-    expect(mockStdout).toHaveBeenCalledWith('[94mHello[39m, ');
-    mockStdout.mockRestore();
+    const writeStreams = new MockWriteStreams();
+    Utils.printJobNames((txt) => writeStreams.stdout(txt), {name: "Hello"}, 0, [{name: "Hello"}, {name: "Hello"}, {name: "Hello"}]);
+    writeStreams.flush();
+    expect(writeStreams.stdoutLines).toEqual(['[94mHello[39m, ']);
 });
 
 test('Print job on last index', () => {
-    const mockStdout = mockProcess.mockProcessStdout();
-    Utils.printJobNames({name: "Hello"}, 2, [{name: "Hello"}, {name: "Hello"}, {name: "Hello"}]);
-    expect(mockStdout).toHaveBeenCalledWith('[94mHello[39m');
-    mockStdout.mockRestore();
+    const writeStreams = new MockWriteStreams();
+    Utils.printJobNames((txt) => writeStreams.stdout(txt), {name: "Hello"}, 2, [{name: "Hello"}, {name: "Hello"}, {name: "Hello"}]);
+    writeStreams.flush();
+    expect(writeStreams.stdoutLines).toEqual(['[94mHello[39m']);
 });

--- a/tests/print-funcs.test.ts
+++ b/tests/print-funcs.test.ts
@@ -1,16 +1,16 @@
 import {Utils} from "../src/utils";
 import {MockWriteStreams} from "../src/mock-write-streams";
 
-test('Print job on first index', () => {
+test("Print job on first index", () => {
     const writeStreams = new MockWriteStreams();
     Utils.printJobNames((txt) => writeStreams.stdout(txt), {name: "Hello"}, 0, [{name: "Hello"}, {name: "Hello"}, {name: "Hello"}]);
     writeStreams.flush();
-    expect(writeStreams.stdoutLines).toEqual(['[94mHello[39m, ']);
+    expect(writeStreams.stdoutLines).toEqual(["[94mHello[39m, "]);
 });
 
-test('Print job on last index', () => {
+test("Print job on last index", () => {
     const writeStreams = new MockWriteStreams();
     Utils.printJobNames((txt) => writeStreams.stdout(txt), {name: "Hello"}, 2, [{name: "Hello"}, {name: "Hello"}, {name: "Hello"}]);
     writeStreams.flush();
-    expect(writeStreams.stdoutLines).toEqual(['[94mHello[39m']);
+    expect(writeStreams.stdoutLines).toEqual(["[94mHello[39m"]);
 });

--- a/tests/test-cases/include-template/.gitlab-ci.yml
+++ b/tests/test-cases/include-template/.gitlab-ci.yml
@@ -4,4 +4,4 @@ include:
 
 test-job:
   script:
-    - echo "Test Something"
+    - echo "Test something"


### PR DESCRIPTION
Centralize stdout/stderr outputs in a class, that can be mocked.