### PR TITLE
Allow configuring project level variables in `.gitlab-ci-local/variables.yaml`. Fixes #156

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -120,6 +120,15 @@ export class Parser {
             variables = {...variables, ...projectEntries};
         }
 
+        const projectVariablesFile = `${cwd}/.gitlab-ci-local/variables.yml`;
+
+        if (fs.existsSync(projectVariablesFile)) {
+            const projectEntries: any = yaml.load(await fs.readFile(projectVariablesFile, "utf8")) ?? {};
+            if (typeof projectEntries === "object") {
+                variables = {...variables, ...projectEntries};
+            }
+        }
+
         // Generate files for file type variables
         for (const [key, value] of Object.entries(variables)) {
             if (!value.match(/^[/|~]/)) {

--- a/tests/test-cases/project-variables/.gitconfig
+++ b/tests/test-cases/project-variables/.gitconfig
@@ -1,2 +1,2 @@
 [remote "origin"]
-	url = git@gitlab.com/gcl/custom-home.git
+	url = git@gitlab.com/gcl/project-variables.git

--- a/tests/test-cases/project-variables/.gitconfig
+++ b/tests/test-cases/project-variables/.gitconfig
@@ -1,0 +1,2 @@
+[remote "origin"]
+	url = git@gitlab.com/gcl/custom-home.git

--- a/tests/test-cases/project-variables/.gitlab-ci-local/variables.yml
+++ b/tests/test-cases/project-variables/.gitlab-ci-local/variables.yml
@@ -1,0 +1,2 @@
+PROJECT_VAR: project-var-value
+PROJECT_FILE_VAR: ~/file-var

--- a/tests/test-cases/project-variables/.gitlab-ci.yml
+++ b/tests/test-cases/project-variables/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+test-job:
+  script:
+    - echo ${PROJECT_VAR}
+    - cat ${PROJECT_FILE_VAR}

--- a/tests/test-cases/project-variables/.home/.gitlab-ci-local/variables.yml
+++ b/tests/test-cases/project-variables/.home/.gitlab-ci-local/variables.yml
@@ -1,0 +1,4 @@
+---
+project:
+  gitlab.com/gcl/project-variables:
+    PROJECT_VAR: home-project-var-value

--- a/tests/test-cases/project-variables/.home/file-var
+++ b/tests/test-cases/project-variables/.home/file-var
@@ -1,0 +1,1 @@
+Im content of a file variable

--- a/tests/test-cases/project-variables/integration.project-variables.test.ts
+++ b/tests/test-cases/project-variables/integration.project-variables.test.ts
@@ -1,0 +1,18 @@
+import {MockWriteStreams} from "../../../src/mock-write-streams";
+import {handler} from "../../../src/handler";
+import * as chalk from "chalk";
+
+test("project-variables <test-job>", async () => {
+	const writeStreams = new MockWriteStreams();
+	await handler({
+		cwd: "tests/test-cases/project-variables",
+		job: "test-job",
+		home: "tests/test-cases/project-variables/.home",
+	}, writeStreams);
+
+	const expected = [
+		chalk`{blueBright test-job} {greenBright >} project-var-value`,
+		chalk`{blueBright test-job} {greenBright >} Im content of a file variable`,
+	];
+	expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});


### PR DESCRIPTION
This PR adds support for configuring project variables in `.gitlab-ci-local/variables.yaml`. If the same variable is configured in both `$HOME/.gitlab-ci-local/variables.yaml` and `$CWD/.gitlab-ci-local/variables.yaml`, the latter gets precedence.