### PR TITLE
Fix rsync target path for builds directory. Fixes #162

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,7 +134,7 @@ export class Utils {
     static async rsyncNonIgnoredFilesToBuilds(cwd: string, target: string): Promise<{ hrdeltatime: [number, number] }> {
         const time = process.hrtime();
         await fs.ensureDir(`${cwd}/.gitlab-ci-local/builds/${target}`);
-        await Utils.spawn(`rsync -ah --delete --exclude-from=<(git -C . ls-files --exclude-standard -oi --directory) . .gitlab-ci-local/builds/${target}/`, cwd);
+        await Utils.spawn(`rsync -ah --delete --exclude-from=<(git -C . ls-files --exclude-standard -oi --directory) ./ .gitlab-ci-local/builds/${target}/`, cwd);
         return {hrdeltatime: process.hrtime(time)};
     }
 


### PR DESCRIPTION
Rsync is copying the builds directory as a sub directory of the previous builds directory when copying files from the container. This is causing the builds directory size to double on every run.