### PR TITLE
Fix: Load variables as string. Fixes #161

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -90,7 +90,7 @@ export class Parser {
             return {};
         }
 
-        const data: any = yaml.load(await fs.readFile(variablesFile, "utf8"));
+        const data: any = yaml.load(await fs.readFile(variablesFile, "utf8"), { schema: yaml.FAILSAFE_SCHEMA });
         let variables: { [key: string]: string } = {};
 
         for (const [globalKey, globalEntry] of Object.entries(data?.global ?? [])) {
@@ -125,7 +125,7 @@ export class Parser {
         const projectVariablesFile = `${cwd}/.gitlab-ci-local/variables.yml`;
 
         if (fs.existsSync(projectVariablesFile)) {
-            const projectEntries: any = yaml.load(await fs.readFile(projectVariablesFile, "utf8")) ?? {};
+            const projectEntries: any = yaml.load(await fs.readFile(projectVariablesFile, "utf8"), { schema: yaml.FAILSAFE_SCHEMA }) ?? {};
             if (typeof projectEntries === "object") {
                 variables = {...variables, ...projectEntries};
             }
@@ -133,6 +133,9 @@ export class Parser {
 
         // Generate files for file type variables
         for (const [key, value] of Object.entries(variables)) {
+            if (typeof value !== "string") {
+                continue;
+            }
             if (!value.match(/^[/|~]/)) {
                 continue;
             }


### PR DESCRIPTION
Since environment variables are always strings, we should load all variables too as string.