### PR TITLE
Prevent recursive copying of files by rsync. Fixes #166

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,7 +134,7 @@ export class Utils {
     static async rsyncNonIgnoredFilesToBuilds(cwd: string, target: string): Promise<{ hrdeltatime: [number, number] }> {
         const time = process.hrtime();
         await fs.ensureDir(`${cwd}/.gitlab-ci-local/builds/${target}`);
-        await Utils.spawn(`rsync -ah --delete --exclude-from=<(git -C . ls-files --exclude-standard -oi --directory) ./ .gitlab-ci-local/builds/${target}/`, cwd);
+        await Utils.spawn(`rsync -ah --delete --exclude-from=<(git -C . ls-files --exclude-standard -oi --directory) --exclude .gitlab-ci-local/builds/${target}/ . .gitlab-ci-local/builds/${target}/`, cwd);
         return {hrdeltatime: process.hrtime(time)};
     }
 


### PR DESCRIPTION
Since the target path is a sub directory of the source path, rsync is recursing into the copied directory causing an infinite loop.

Fixed by adding the target directory to the `rsync` exclude list.