### PR TITLE
Auto generate .gitlab-ci-local/.gitignore file If .gitignore file isn't git add'ed right away, make sure .gitlab-ci-local is excluded from rsync

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -21,6 +21,14 @@ const checkFolderAndFile = (cwd: string, file?: string) => {
     assert(fs.existsSync(gitlabFilePath), `${cwd} does not contain ${file ?? ".gitlab-ci.yml"}`);
 };
 
+const generateGitIgnore = (cwd: string) => {
+    const gitIgnoreFilePath = `${cwd}/.gitlab-ci-local/.gitignore`;
+    const gitIgnoreContent = "*\n!.gitignore\n";
+    if (!fs.existsSync(gitIgnoreFilePath)) {
+        fs.outputFileSync(gitIgnoreFilePath, gitIgnoreContent);
+    }
+};
+
 export async function handler(argv: any, writeStreams: WriteStreams) {
     assert(typeof argv.cwd != "object", "--cwd option cannot be an array");
     const cwd = argv.cwd?.replace(/\/$/, "") ?? ".";
@@ -61,6 +69,7 @@ export async function handler(argv: any, writeStreams: WriteStreams) {
         Commander.runList(parser, writeStreams);
     } else if (argv.job) {
         checkFolderAndFile(cwd, argv.file);
+        generateGitIgnore(cwd);
         if (argv.needs === true) {
             await fs.remove(`${cwd}/.gitlab-ci-local/artifacts`);
             await state.incrementPipelineIid(cwd);
@@ -74,6 +83,7 @@ export async function handler(argv: any, writeStreams: WriteStreams) {
     } else {
         const time = process.hrtime();
         checkFolderAndFile(cwd, argv.file);
+        generateGitIgnore(cwd);
         await fs.remove(`${cwd}/.gitlab-ci-local/artifacts`);
         await state.incrementPipelineIid(cwd);
         const pipelineIid = await state.getPipelineIid(cwd);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -152,7 +152,7 @@ export class Utils {
     static async rsyncNonIgnoredFilesToBuilds(cwd: string, target: string): Promise<{ hrdeltatime: [number, number] }> {
         const time = process.hrtime();
         await fs.ensureDir(`${cwd}/.gitlab-ci-local/builds/${target}`);
-        await Utils.spawn(`rsync -ah --delete --exclude-from=<(git -C . ls-files --exclude-standard -oi --directory) ./ .gitlab-ci-local/builds/${target}/`, cwd);
+        await Utils.spawn(`rsync -ah --delete --exclude-from=<(git -C . ls-files --exclude-standard -oi --directory) --exclude .gitlab-ci-local/ ./ .gitlab-ci-local/builds/${target}/`, cwd);
         return {hrdeltatime: process.hrtime(time)};
     }
 

--- a/tests/test-cases/.gitignore
+++ b/tests/test-cases/.gitignore
@@ -2,3 +2,4 @@
 artifacts/log.txt
 
 !custom-home/.home/.gitlab-ci-local
+!gitignore/.gitlab-ci-local

--- a/tests/test-cases/gitignore/.gitconfig
+++ b/tests/test-cases/gitignore/.gitconfig
@@ -1,0 +1,2 @@
+[remote "origin"]
+	url = git@gitlab.com/gcl/gitignore.git

--- a/tests/test-cases/gitignore/.gitlab-ci-local/.gitignore
+++ b/tests/test-cases/gitignore/.gitlab-ci-local/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test-cases/gitignore/.gitlab-ci.yml
+++ b/tests/test-cases/gitignore/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+test-job:
+  image: alpine
+  script:
+    - (! test -f .gitlab-ci-local/state.yml)

--- a/tests/test-cases/gitignore/integration.gitignore.test.ts
+++ b/tests/test-cases/gitignore/integration.gitignore.test.ts
@@ -1,0 +1,9 @@
+import {MockWriteStreams} from "../../../src/mock-write-streams";
+import {handler} from "../../../src/handler";
+
+test("gitignore", async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: "tests/test-cases/gitignore",
+    }, writeStreams);
+});


### PR DESCRIPTION
@bcouetil @JoyceBabu 

I was able to reproduce, when ever .gitlab-ci-local/.gitignore wasn't manually git add'ed, the recursive behavior occurs.