### PR TITLE
Fix included YAML download failing due to path starting with `/`.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -354,14 +354,15 @@ export class Parser {
     static async downloadIncludeProjectFile(cwd: string, writeStreams: WriteStreams, project: string, ref: string, file: string, gitRemoteDomain: string): Promise<void> {
         const time = process.hrtime();
         fs.ensureDirSync(`${cwd}/.gitlab-ci-local/includes/${gitRemoteDomain}/${project}/${ref}/`);
+        const normalizedFile = file.replace(/^\/+/, '');
         try {
-            await Utils.spawn(`git archive --remote=git@${gitRemoteDomain}:${project}.git ${ref} ${file} | tar -xC .gitlab-ci-local/includes/${gitRemoteDomain}/${project}/${ref}/`, cwd);
+            await Utils.spawn(`git archive --remote=git@${gitRemoteDomain}:${project}.git ${ref} ${normalizedFile} | tar -xC .gitlab-ci-local/includes/${gitRemoteDomain}/${project}/${ref}/`, cwd);
         } catch (e) {
-            throw new ExitError(`Project include could not be fetched { project: ${project}, ref: ${ref}, file: ${file} }`);
+            throw new ExitError(`Project include could not be fetched { project: ${project}, ref: ${ref}, file: ${normalizedFile} }`);
         }
 
         const endTime = process.hrtime(time);
-        const remoteUrl = `${gitRemoteDomain}/${project}/${file}`;
+        const remoteUrl = `${gitRemoteDomain}/${project}/${normalizedFile}`;
         writeStreams.stdout(chalk`{cyan downloaded} {magentaBright ${remoteUrl}} in {magenta ${prettyHrtime(endTime)}}\n`);
     }
 

--- a/tests/test-cases/include-project-file-ref/.gitlab-ci.yml
+++ b/tests/test-cases/include-project-file-ref/.gitlab-ci.yml
@@ -1,3 +1,4 @@
 ---
 include:
   - { project: firecow/gitlab-ci-local-includes, file: .gitlab-module.yml }
+  - { project: firecow/gitlab-ci-local-includes, file: /.gitlab-module.yml }


### PR DESCRIPTION
This normalizes the path to not start with `/` before being passed to
`git archive`. Otherwise it will complain about the path being outside
of the repository.

Fixes #190.