### PR TITLE
Propagate the --privileged flag to services

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -403,7 +403,7 @@ export class Job {
                 dockerCmd += `--network gitlab-ci-local-${this.jobId} `;
                 for (const service of this.services) {
                     await this.pullImage(writeStreams, service.getName(this.expandedVariables));
-                    await this.startService(writeStreams, service);
+                    await this.startService(writeStreams, service, privileged);
                 }
             }
 
@@ -609,8 +609,12 @@ export class Job {
         this._serviceNetworkId = networkId.replace(/\r?\n/g, "");
     }
 
-    private async startService(writeStreams: WriteStreams, service: Service) {
+    private async startService(writeStreams: WriteStreams, service: Service, privileged: boolean) {
         let dockerCmd = `docker run -d --network gitlab-ci-local-${this.jobId} `;
+
+        if (privileged) {
+            dockerCmd += "--privileged ";
+        }
 
         (service.getEntrypoint() ?? []).forEach((e) => {
             dockerCmd += `--entrypoint "${e}" `;


### PR DESCRIPTION
Services are working, but the `--privileged` do not affect them.  
This can be bad for docker-in-docker based jobs.

For example, with this `.gitlab-ci.yml` :
```yaml
myJob:
  image: docker:latest
  service:
    - docker:dind
  script:
    - docker build -t myRegistry/myImage:latest
    - docker push myRegistry/myImage:latest
```

The docker service will be launched but rapidly fail with few errors like this one :

> mount: permission denied (are you root?)

With the **gitlab-runner**, when the [privileged mode](https://docs.gitlab.com/runner/executors/docker.html#use-docker-in-docker-with-privileged-mode) is active, the services are also affected.

In a way to fix the dind use-case and to better emulate the **gitlab-runner** behavior, we should propagate the `--privileged` flag to services.