### PR TITLE
No more enforce manual rule for interactive jobs

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -125,8 +125,8 @@ export class Job {
             this.allowFailure = ruleResult.allowFailure;
         }
 
-        if (this.interactive && (this.when !== "manual" || this.imageName !== null)) {
-            throw new ExitError(`${this.chalkJobName} @Interactive decorator cannot have image: and must be when:manual`);
+        if (this.interactive && this.imageName !== null) {
+            throw new ExitError(`${this.chalkJobName} @Interactive decorator cannot have image:`);
         }
 
         if (this.injectSSHAgent && this.imageName === null) {


### PR DESCRIPTION
Sometimes, you won't run inside a docker because you cannot use the local environment facility, and you use an interactive job to do the job ;-)

But each time you want to run the pipeline, you should add the `--manual myJob` in the command line.  
This is tedious and error-prone because you can easily forget it !  
That why I want to remove the `manual` enforcement in interactive jobs.

My use case :
- **Remote pipeline**
    - **First job**: build a docker image and I send it to my company private docker registry
    - **Second job**: Implicitly fetch image from the private docker registry and run integration tests
- **Local pipeline**
    - **First job**: build a docker image on the local docker daemon
    - **Second job**: Use local docker image and run integration tests

I don't think that there are any drawbacks since you are still able to manually enforce the `manual` rule