### PR TITLE
Add CI_REGISTRY_IMAGE predefined image

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -74,6 +74,8 @@ export class Job {
         this.environment = typeof jobData.environment === "string" ? {name: jobData.environment} : jobData.environment;
         this.cache = jobData.cache || null;
 
+        let ciProjectPath = `${gitData.remote.group}/${camelCase(gitData.remote.project)}`;
+        let ciRegistry = `local-registry.${gitData.remote.domain}`;
         const predefinedVariables = {
             GITLAB_USER_LOGIN: gitData.user["GITLAB_USER_LOGIN"],
             GITLAB_USER_EMAIL: gitData.user["GITLAB_USER_EMAIL"],
@@ -83,7 +85,7 @@ export class Job {
             CI_PROJECT_DIR: this.imageName ? "/builds/" : `${this.cwd}`,
             CI_PROJECT_NAME: gitData.remote.project,
             CI_PROJECT_TITLE: `${camelCase(gitData.remote.project)}`,
-            CI_PROJECT_PATH: `${gitData.remote.group}/${camelCase(gitData.remote.project)}`,
+            CI_PROJECT_PATH: ciProjectPath,
             CI_PROJECT_PATH_SLUG: `${gitData.remote.group.replace(/\//g, "-")}-${gitData.remote.project}`,
             CI_PROJECT_NAMESPACE: `${gitData.remote.group}`,
             CI_PROJECT_VISIBILITY: "internal",
@@ -107,7 +109,8 @@ export class Job {
             CI_PIPELINE_URL: `https://${gitData.remote.domain}/${gitData.remote.group}/${gitData.remote.project}/pipelines/${this.pipelineIid}`,
             CI_JOB_NAME: `${this.name}`,
             CI_JOB_STAGE: `${this.stage}`,
-            CI_REGISTRY: `local-registry.${gitData.remote.domain}`,
+            CI_REGISTRY: ciRegistry,
+            CI_REGISTRY_IMAGE: `${ciRegistry}/${ciProjectPath}`,
             GITLAB_CI: "false",
         };
 


### PR DESCRIPTION
GitLab offers an internal docker repository, but since the variable `CI_REGISTRY_IMAGE` is not defined, we cannot emulate this functionality within the local pipeline.

That why I added this variable !

It's likely to be defined like `${CI_REGISTRY}/${CI_PROJECT_PATH}` in [here](https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/project.rb#L1010) and [here](https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/models/project.rb#L2093).