### PR TITLE
job: add support for artifacts: excludes

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -191,8 +191,8 @@ export class Job {
         return this.jobData["description"] ?? "";
     }
 
-    get artifacts(): { paths: string[] } {
-        return this.jobData["artifacts"] || {paths: []};
+    get artifacts(): { paths: string[], exclude: string[] } {
+        return this.jobData["artifacts"] || {paths: [], exclude: []};
     }
 
     get beforeScripts(): string[] {
@@ -546,6 +546,16 @@ export class Job {
                 cpCmd += "cd /builds/\n";
                 cpCmd += `cp -r --parents ${expandedPath} /artifacts\n`;
                 cpCmd += `echo Done copying ${expandedPath} to /artifacts\n`;
+            }
+
+            if (this.artifacts.exclude && this.artifacts.exclude.length > 0) {
+                for (const artifactExcludePath of this.artifacts.exclude) {
+                    const expandedPath = Utils.expandText(artifactExcludePath, this.expandedVariables);
+                    cpCmd += `echo Started removing excludes from ${expandedPath}\n`;
+                    cpCmd += "cd /artifacts/\n";
+                    cpCmd += `rm -d ${expandedPath}\n`;
+                    cpCmd += `echo Done removing excludes from ${expandedPath}\n`;
+                }
             }
 
             let cacheMount = "";

--- a/src/job.ts
+++ b/src/job.ts
@@ -549,7 +549,7 @@ export class Job {
             }
 
             if (this.artifacts.exclude && this.artifacts.exclude.length > 0) {
-                cpCmd += "shopt -s globstar nullglob\n";
+                cpCmd += "shopt -s globstar nullglob dotglob\n";
                 for (const artifactExcludePath of this.artifacts.exclude) {
                     const expandedPath = Utils.expandText(artifactExcludePath, this.expandedVariables);
                     cpCmd += `echo Started removing excludes from '${expandedPath}'\n`;

--- a/src/job.ts
+++ b/src/job.ts
@@ -549,12 +549,17 @@ export class Job {
             }
 
             if (this.artifacts.exclude && this.artifacts.exclude.length > 0) {
+                cpCmd += "shopt -s globstar nullglob\n";
                 for (const artifactExcludePath of this.artifacts.exclude) {
                     const expandedPath = Utils.expandText(artifactExcludePath, this.expandedVariables);
-                    cpCmd += `echo Started removing excludes from ${expandedPath}\n`;
+                    cpCmd += `echo Started removing excludes from '${expandedPath}'\n`;
                     cpCmd += "cd /artifacts/\n";
-                    cpCmd += `rm -d ${expandedPath}\n`;
-                    cpCmd += `echo Done removing excludes from ${expandedPath}\n`;
+		    cpCmd += `gcil_exclude=\\"${expandedPath}\\"\n`;
+		    cpCmd += "IFS=''\n";
+		    cpCmd += 'for f in \\\${gcil_exclude}; do\n';
+		    cpCmd += '\tprintf \\"%s\\0\\" \\"\\\$f\\"\n';
+                    cpCmd += 'done | sort --zero-terminated --reverse | xargs --no-run-if-empty --null rm --dir \n';
+                    cpCmd += `echo Done removing excludes from '${expandedPath}'\n`;
                 }
             }
 

--- a/tests/test-cases/artifacts-exclude/.gitconfig
+++ b/tests/test-cases/artifacts-exclude/.gitconfig
@@ -1,0 +1,2 @@
+[remote "origin"]
+	url = git@gitlab.com/gcl/artifacts-exclude.git

--- a/tests/test-cases/artifacts-exclude/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-exclude/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+---
+produce artifacts:
+  stage: build
+  image: debian:stable-slim
+  script:
+    - mkdir -p ux
+    - touch ux/{q,r,s,t}
+    - mkdir -p foo/bar/baz/.xyzzy
+    - mkdir -p "foo/qux/qu ux"
+    - touch foo/{a,b,c,d}
+    - touch foo/bar/{w,x,y,z}
+    - touch foo/bar/baz/{m,n,o,p}
+    - touch foo/qux/{qu,u,v,w,x}
+    - touch "foo/qux/qu ux/"{g,h,i,j}
+    - touch foo/bar/baz/.xyzzy/{.e,.f}
+    - ls -laR .
+  artifacts:
+    paths:
+      - foo
+      - ux
+    exclude:
+      - foo/qux/qu ux/**
+      - foo/bar/**
+      - foo/bar
+      - foo/d
+      - xyzzy/**/*
+
+consume artifacts:
+  stage: test
+  image: debian:stable-slim
+  needs: [produce artifacts]
+  dependencies: [produce artifacts]
+  script:
+    - ls -laR .
+    - '[ -e "ux" ]'
+    - '[ -e "foo/qux/qu" ]'
+    - '[ ! -e "foo/qux/qu ux" ]'
+    - '[ ! -e foo/bar ]'
+    - '[ ! -e foo/d ]'

--- a/tests/test-cases/artifacts-exclude/integration.artifacts-exclude.test.ts
+++ b/tests/test-cases/artifacts-exclude/integration.artifacts-exclude.test.ts
@@ -1,0 +1,13 @@
+import {MockWriteStreams} from "../../../src/mock-write-streams";
+import {handler} from "../../../src/handler";
+
+test("artifacts-exlude <consume artifacts> --needs", async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: "tests/test-cases/artifacts-exclude",
+        job: ["consume artifacts"],
+        needs: true,
+    }, writeStreams);
+
+    expect(writeStreams.stderrLines).toEqual([]);
+});


### PR DESCRIPTION
Add support for the gitlab-ci `artifacts: exclude:` syntax including globstar [as seen here](https://docs.gitlab.com/ee/ci/yaml/#artifactsexclude).

This is an example `.gitlab-ci.yml` that exercises this functionality.

``` yaml
stages:
  - stage1
  - stage2

job1:
  stage: stage1
  image: debian:stable-slim
  script:
    - mkdir -p ux
    - touch ux/{q,r,s,t}
    - mkdir -p foo/bar/baz/.xyzzy
    - mkdir -p "foo/qux/qu ux"
    - touch foo/{a,b,c,d}
    - touch foo/bar/{w,x,y,z}
    - touch foo/bar/baz/{m,n,o,p}
    - touch foo/qux/{qu,u,v,w,x}
    - touch "foo/qux/qu ux/"{g,h,i,j}
    - touch foo/bar/baz/.xyzzy/{.e,.f}
    - ls -laR .
  artifacts:
    name: "the-artifacts"
    paths:
      - foo
      - ux
    exclude:
      - foo/qux/qu ux/**
      - foo/bar/**
      - foo/bar
      - foo/d
      - xyzzy/**/*

job2:
  stage: stage2
  image: debian:stable-slim
  script:
    - ls -laR .
    - '[ -e "ux" ]'
    - '[ -e "foo/qux/qu" ]'
    - '[ ! -e "foo/qux/qu ux" ]'
    - '[ ! -e foo/bar ]'
    - '[ ! -e foo/d ]'

```