### PR TITLE
Custom home variables can now overwrite GitLab predefined ones

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -119,7 +119,7 @@ export class Job {
         const expandedGlobalVariables = Utils.expandVariables(globals.variables || {}, envs);
         const expandedJobVariables = Utils.expandVariables(jobData.variables || {}, envs);
 
-        this.expandedVariables = {...expandedGlobalVariables, ...expandedJobVariables, ...homeVariables, ...predefinedVariables};
+        this.expandedVariables = {...expandedGlobalVariables, ...expandedJobVariables, ...predefinedVariables, ...homeVariables};
 
         // Set {when, allowFailure} based on rules result
         if (this.rules) {

--- a/tests/test-cases/custom-home/.gitlab-ci.yml
+++ b/tests/test-cases/custom-home/.gitlab-ci.yml
@@ -10,3 +10,9 @@ test-normalize-key:
   script:
     - echo ${GROUP_VAR}
     - echo ${PROJECT_VAR}
+
+test-predefined-overwrite:
+  script:
+    - echo ${CI_PIPELINE_SOURCE}
+    - echo ${CI_PROJECT_ID}
+

--- a/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
+++ b/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
@@ -3,6 +3,7 @@ project:
   gitlab.com/gcl/custom-home:
     GROUP_VAR: project-group-var-override-value
     PROJECT_VAR: project-var-value
+    CI_PROJECT_ID: 12345678
   gitlab.com/gcl/no-match:
     PROJECT_VAR: no-match
 
@@ -10,6 +11,7 @@ group:
   gitlab.com/gcl/:
     GROUP_VAR: group-var-value
     GLOBAL_VAR: group-global-var-override-value
+    CI_PIPELINE_SOURCE: schedule
   gitlab.com/no-match/:
     GROUP_VAR: no-match
 

--- a/tests/test-cases/custom-home/integration.custom-home.test.ts
+++ b/tests/test-cases/custom-home/integration.custom-home.test.ts
@@ -11,10 +11,10 @@ test("custom-home <test-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{blueBright test-job          } {greenBright >} group-global-var-override-value`,
-        chalk`{blueBright test-job          } {greenBright >} project-group-var-override-value`,
-        chalk`{blueBright test-job          } {greenBright >} project-var-value`,
-        chalk`{blueBright test-job          } {greenBright >} Im content of a file variable`,
+        chalk`{blueBright test-job                 } {greenBright >} group-global-var-override-value`,
+        chalk`{blueBright test-job                 } {greenBright >} project-group-var-override-value`,
+        chalk`{blueBright test-job                 } {greenBright >} project-var-value`,
+        chalk`{blueBright test-job                 } {greenBright >} Im content of a file variable`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
@@ -32,4 +32,19 @@ test("custom-home <test-normalize-key>", async () => {
         chalk`{yellow WARNING: Interpreting 'gitlab.com:gcl/custom-home' as 'gitlab.com/gcl/custom-home'}`,
     ];
     expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expected));
+});
+
+test("custom-home <test-predefined-overwrite>", async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: "tests/test-cases/custom-home",
+        job: ["test-predefined-overwrite"],
+        home: "tests/test-cases/custom-home/.home",
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-predefined-overwrite} {greenBright >} schedule`,
+        chalk`{blueBright test-predefined-overwrite} {greenBright >} 12345678`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });


### PR DESCRIPTION
As a user I should be able to overwrite the default predefined variables by re-defining them in my ~/.gitlab-ci-local/variables.yml file.

Closes #220.