### PR TITLE
Fix PROJECT_PATH generation

### DIFF
--- a/src/types/git-data.ts
+++ b/src/types/git-data.ts
@@ -1,5 +1,3 @@
-import camelCase from "camelcase";
-
 interface GitRemote {
     domain: string;
     group: string;
@@ -30,7 +28,7 @@ export class GitData {
     }
 
     get CI_PROJECT_PATH() {
-        return `${this.remote.group}/${camelCase(this.remote.project)}`;
+        return `${this.remote.group}/${this.remote.project}`;
     }
 
     get CI_REGISTRY() {


### PR DESCRIPTION
`PROJECT_PATH` variable is camel case formatted, even if GitLab do not apply formatting.

I found this bug with a project named `camel-case` which translate in `PROJECT_PATH=camelCase`,
but in a real GitLab instance it was `PROJECT_PATH=camel-case`