### PR TITLE
rules evaluation does not support regex modifiers like case insensiti…

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,10 +139,10 @@ export class Utils {
             let subEval = subRule;
 
             if (subRule.includes("!~")) {
-                subEval = subRule.replace(/\s*!~\s*(\/.*\/)/, ".match($1) == null");
+                subEval = subRule.replace(/\s*!~\s*(\/.*\/[igmsuy]*)/, ".match($1) == null");
                 subEval = subEval.match(/^null/) ? "false" : subEval;
             } else if (subRule.includes("=~")) {
-                subEval = subRule.replace(/\s*=~\s*(\/.*\/)/, ".match($1) != null");
+                subEval = subRule.replace(/\s*=~\s*(\/.*\/[igmsuy]*)/, ".match($1) != null");
                 subEval = subEval.match(/^null/) ? "false" : subEval;
             } else if (!subRule.match(/==|!=/)) {
                 if (subRule.match(/null/)) {

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -99,8 +99,20 @@ test("VAR regex match success", () => {
     expect(val).toBe(true);
 });
 
+test("VAR regex match success - case insensitive", () => {
+    const ruleIf = "$VAR =~ /testvalue/i";
+    const val = Utils.evaluateRuleIf(ruleIf, {VAR: "testvalue"});
+    expect(val).toBe(true);
+});
+
 test("VAR regex match fail", () => {
     const ruleIf = "$VAR =~ /testvalue/";
+    const val = Utils.evaluateRuleIf(ruleIf, {VAR: "spiffy"});
+    expect(val).toBe(false);
+});
+
+test("VAR regex match fail - case insensitive", () => {
+    const ruleIf = "$VAR =~ /testvalue/i";
     const val = Utils.evaluateRuleIf(ruleIf, {VAR: "spiffy"});
     expect(val).toBe(false);
 });
@@ -111,8 +123,20 @@ test("VAR regex not match success", () => {
     expect(val).toBe(true);
 });
 
+test("VAR regex not match success - case insensitive", () => {
+    const ruleIf = "$VAR !~ /testvalue/i";
+    const val = Utils.evaluateRuleIf(ruleIf, {VAR: "notamatch"});
+    expect(val).toBe(true);
+});
+
 test("VAR regex not match fail", () => {
     const ruleIf = "$VAR !~ /testvalue/";
+    const val = Utils.evaluateRuleIf(ruleIf, {VAR: "testvalue"});
+    expect(val).toBe(false);
+});
+
+test("VAR regex not match fail - case insensitive", () => {
+    const ruleIf = "$VAR !~ /testvalue/i";
     const val = Utils.evaluateRuleIf(ruleIf, {VAR: "testvalue"});
     expect(val).toBe(false);
 });
@@ -159,8 +183,20 @@ test("Complex parentheses junctions regex success", () => {
     expect(val).toBe(true);
 });
 
+test("Complex parentheses junctions regex success - case insensitive", () => {
+    const ruleIf = "$VAR1 =~ /val/i && ($VAR2 =~ /val/ || $VAR3)";
+    const val = Utils.evaluateRuleIf(ruleIf, {VAR1: "VAL", VAR2: "val", VAR3: ""});
+    expect(val).toBe(true);
+});
+
 test("Complex parentheses junctions regex fail", () => {
     const ruleIf = "$VAR1 =~ /val/ && ($VAR2 =~ /val/ || $VAR3)";
     const val = Utils.evaluateRuleIf(ruleIf, {VAR1: "val", VAR2: "not", VAR3: ""});
+    expect(val).toBe(false);
+});
+
+test("Complex parentheses junctions regex fail - case insensitive", () => {
+    const ruleIf = "$VAR1 =~ /val/i && ($VAR2 =~ /val/ || $VAR3)";
+    const val = Utils.evaluateRuleIf(ruleIf, {VAR1: "VAL", VAR2: "not", VAR3: ""});
     expect(val).toBe(false);
 });


### PR DESCRIPTION
…vity #273

Improved regex to also allow the general available modifiers.

Closes: #273

Note: i am not really familiar with nodejs, specially i am not sure about the added testcases :)