### PR TITLE
Draft: Suggestions for better performance and more gitlab-ci-alike behavior

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -622,9 +622,28 @@ export class Job {
             }
         });
 
-        if (exitCode == 0) {
-            await this.copyCacheOut(writeStreams);
+        if (this.jobData.artifacts.when && this.jobData.artifacts.when === "always") {
             await this.copyArtifactsOut(writeStreams);
+        }
+
+        if (this.jobData.artifacts.when && this.jobData.artifacts.when === "on_failure" && exitCode != 0) {
+            await this.copyArtifactsOut(writeStreams);
+        }
+
+        if (!this.jobData.artifacts.when || this.jobData.artifacts.when === "on_success" && exitCode == 0) {
+            await this.copyArtifactsOut(writeStreams);
+        }
+
+        if (this.jobData.cache.when && this.jobData.cache.when === "always") {
+            await this.copyCacheOut(writeStreams);
+        }
+
+        if (this.jobData.cache.when && this.jobData.cache.when === "on_failure" && exitCode != 0) {
+            await this.copyCacheOut(writeStreams);
+        }
+
+        if (!this.jobData.cache.when || this.jobData.cache.when === "on_success" && exitCode == 0) {
+            await this.copyCacheOut(writeStreams);
         }
 
         return exitCode;

--- a/src/job.ts
+++ b/src/job.ts
@@ -719,7 +719,7 @@ export class Job {
         if (!this.imageName && this.shellIsolation) {
             return Utils.spawn(`rsync -a ${source}/. ${this.cwd}/.gitlab-ci-local/builds/${safeJobName}`);
         }
-        return Utils.spawn(`docker cp ${source}/. ${this._containerId}:/builds/${safeJobName}`);
+        return Utils.spawn(`docker cp ${source}/. ${this._containerId}:/builds/${this.gitData.remote.project}`);
     }
 
     private async copyCacheOut(writeStreams: WriteStreams) {
@@ -806,7 +806,7 @@ export class Job {
         await fs.mkdirp(`${this.cwd}/.gitlab-ci-local/${type}`);
 
         if (this.imageName) {
-            const {stdout: cid} = await Utils.spawn(`docker create -i ${dockerCmdExtras.join(" ")} -v ${buildVolumeName}:/builds/${safeJobName}/ -w /builds/${safeJobName}/ firecow/gitlab-ci-local-util bash -c "${cmd}"`, this.cwd);
+            const {stdout: cid} = await Utils.spawn(`docker create -i ${dockerCmdExtras.join(" ")} -v ${buildVolumeName}:/builds/${this.gitData.remote.project}/ -w /builds/${this.gitData.remote.project}/ firecow/gitlab-ci-local-util bash -c "${cmd}"`, this.cwd);
             const containerId = cid.replace(/\r?\n/g, "");
             this._containersToClean.push(containerId);
             await Utils.spawn(`docker start ${containerId} --attach`);

--- a/src/job.ts
+++ b/src/job.ts
@@ -488,14 +488,14 @@ export class Job {
 
             const volumePromises = [];
             volumePromises.push(Utils.spawn(`docker volume create ${buildVolumeName}`, this.cwd));
-            volumePromises.push(Utils.spawn(`docker volume create ${tmpVolumeName}`, this.cwd));
-            dockerCmd += `--volume ${buildVolumeName}:/builds/${safeJobName} `;
+            volumePromises.push(Utils.spawn(`docker volume create --opt type=tmpfs --opt device=tmpfs ${tmpVolumeName}`, this.cwd));
+            dockerCmd += `--volume ${buildVolumeName}:/builds/${this.gitData.remote.project} `;
             dockerCmd += `--volume ${tmpVolumeName}:/tmp/ `;
             this._containerVolumeNames.push(buildVolumeName);
             this._containerVolumeNames.push(tmpVolumeName);
             await Promise.all(volumePromises);
 
-            dockerCmd += `--workdir /builds/${safeJobName} `;
+            dockerCmd += `--workdir /builds/${this.gitData.remote.project} `;
 
             for (const volume of this.volumes) {
                 dockerCmd += `--volume ${volume} `;
@@ -546,7 +546,7 @@ export class Job {
 
             time = process.hrtime();
             // Copy source files into container.
-            await Utils.spawn(`docker cp .gitlab-ci-local/builds/.docker/. ${this._containerId}:/builds/${safeJobName}`, this.cwd);
+            await Utils.spawn(`docker cp .gitlab-ci-local/builds/.docker/. ${this._containerId}:/builds/${this.gitData.remote.project}`, this.cwd);
             this.refreshLongRunningSilentTimeout(writeStreams);
 
             // Copy file variables into container.

--- a/src/job.ts
+++ b/src/job.ts
@@ -873,6 +873,8 @@ export class Job {
             dockerCmd += `--entrypoint "${e}" `;
         });
 
+        dockerCmd += "--mount type=tmpfs,destination=/tmp ";
+
         dockerCmd += `${serviceName} `;
 
         (service.getCommand() ?? []).forEach((e) => dockerCmd += `"${e}" `);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,7 +155,8 @@ export class Utils {
     static async rsyncTrackedFiles(cwd: string, target: string): Promise<{ hrdeltatime: [number, number] }> {
         const time = process.hrtime();
         await fs.mkdirp(`${cwd}/.gitlab-ci-local/builds/${target}`);
-        await Utils.spawn(`rsync -a --delete-excluded --delete --exclude-from=<(git ls-files -o --directory) --exclude .gitlab-ci-local/ ./ .gitlab-ci-local/builds/${target}/`, cwd);
+        //await Utils.spawn(`rsync -a --delete-excluded --delete --exclude-from=<(git ls-files -o --directory) --exclude .gitlab-ci-local/ ./ .gitlab-ci-local/builds/${target}/`, cwd);
+        await Utils.spawn(`rsync -a --delete-excluded --delete --exclude-from=<(git ls-files -o --directory --deduplicate | awk '{print "./" $0}') --exclude .gitlab-ci-local/ ./ .gitlab-ci-local/builds/${target}/`, cwd);
         return {hrdeltatime: process.hrtime(time)};
     }
 


### PR DESCRIPTION
Changes:

- pass tmpfs to service containers
- expose cache and artifacts depending on 'when' keyword
- make default workdir the project name like in gitlab-ci
- dont export artifacts to source if not explicitly enabled
- corrected sync to container due to rsync matches scoping 'too global'

TODO:
  - [ ] further inspection of rsync cmd .build -> container
  - [ ] correct networking problems when running full stack instead of single jobs
  - [ ] adjust tests