### PR TITLE
Enviroment matchers and file content spec in home and project variables.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,17 @@ group:
 global:
   # Will be type File, because value is a file path
   KNOWN_HOSTS: '~/.ssh/known_hosts'
+  DEPLOY_ENV_SPECIFIC:
+    type: variable # Optional and defaults to variable
+    values:
+      '*production*': 'Im production only value'
+      'staging': 'Im staging only value'
+  FILE_CONTENT_IN_VALLUES:
+    type: file
+    values:
+      '*': |
+        Im staging only value
+        I'm great for certs n' stuff
 ```
 
 Variables will now appear in your jobs, if project or group matches git remote, global's are always present

--- a/package-lock.json
+++ b/package-lock.json
@@ -2103,9 +2103,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001258",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+      "version": "1.0.30001317",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz",
+      "integrity": "sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -9043,9 +9043,9 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001258",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz",
-      "integrity": "sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==",
+      "version": "1.0.30001317",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz",
+      "integrity": "sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==",
       "dev": true
     },
     "chalk": {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -109,6 +109,7 @@ export async function handler(args: any, writeStreams: WriteStreams): Promise<Re
     writeStreams.flush();
 
     if (parser) {
+        await cleanupResources(parser);
         return parser.jobs;
     }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,7 +24,7 @@ const generateGitIgnore = (cwd: string, file: string) => {
 
 const cleanupResources = async(parser: Parser|null) => {
     if (!parser) {
-        process.exit(1);
+        return;
     }
     const promises = [];
     for (const job of parser.jobs.values()) {

--- a/src/job.ts
+++ b/src/job.ts
@@ -129,10 +129,14 @@ export class Job {
         for (const [k, v] of Object.entries(variablesFromFiles)) {
             for (const entry of v.environments) {
                 if (this.environment?.name.match(entry.regexp) || entry.regexp.source === ".*") {
-                    if (v.type === "file") {
+                    if (v.type === "file" && !entry.fileSource) {
                         variablesFromCWDOrHome[k] = `${fileVariablesDir}/${k}`;
                         fs.mkdirpSync(`${fileVariablesDir}`);
                         fs.writeFileSync(`${fileVariablesDir}/${k}`, entry.content);
+                    } else if (v.type === "file" && entry.fileSource) {
+                        variablesFromCWDOrHome[k] = `${fileVariablesDir}/${k}`;
+                        fs.mkdirpSync(`${fileVariablesDir}`);
+                        fs.copyFileSync(entry.fileSource, `${fileVariablesDir}/${k}`);
                     } else {
                         variablesFromCWDOrHome[k] = entry.content;
                     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -127,7 +127,7 @@ export class Parser {
                 data: jobData,
                 name: jobName,
                 namePad: this.jobNamePad,
-                variablesFromFiles: variablesFromFiles,
+                variablesFromFiles,
                 globals: gitlabData,
                 pipelineIid,
                 gitData,

--- a/src/types/job-options.ts
+++ b/src/types/job-options.ts
@@ -11,5 +11,5 @@ export interface JobOptions {
     globals: any;
     pipelineIid: number;
     gitData: GitData;
-    variablesFromFiles: { [name: string]: string };
+    variablesFromFiles: { [name: string]: string|Record<string, string> };
 }

--- a/src/types/job-options.ts
+++ b/src/types/job-options.ts
@@ -1,6 +1,7 @@
 import {GitData} from "../git-data";
 import {WriteStreams} from "./write-streams";
 import {Argv} from "../argv";
+import {CICDVariable} from "../variables-from-files";
 
 export interface JobOptions {
     argv: Argv;
@@ -11,5 +12,5 @@ export interface JobOptions {
     globals: any;
     pipelineIid: number;
     gitData: GitData;
-    variablesFromFiles: { [name: string]: string|Record<string, string> };
+    variablesFromFiles: { [name: string]: CICDVariable };
 }

--- a/src/variables-from-files.ts
+++ b/src/variables-from-files.ts
@@ -8,7 +8,7 @@ import {Argv} from "./argv";
 
 export class VariablesFromFiles {
 
-    static async init(argv: Argv, writeStreams: WriteStreams, gitData: GitData): Promise<{ [key: string]: string }> {
+    static async init(argv: Argv, writeStreams: WriteStreams, gitData: GitData): Promise<{ [name: string]: string|Record<string, string> }> {
         const homeDir = argv.home;
         const homeVariablesFile = `${homeDir}/.gitlab-ci-local/variables.yml`;
         let variables: { [key: string]: string } = {};

--- a/src/variables-from-files.ts
+++ b/src/variables-from-files.ts
@@ -2,80 +2,84 @@ import {WriteStreams} from "./types/write-streams";
 import {GitData} from "./git-data";
 import * as fs from "fs-extra";
 import * as yaml from "js-yaml";
-import path from "path";
 import chalk from "chalk";
 import {Argv} from "./argv";
+import {assert} from "./asserts";
+
+export interface CICDVariable {
+    type: "file"|"variable";
+    environments: {
+        content: string;
+        regexp: RegExp;
+        regexpPriority: number;
+        scopePriority: number;
+    }[];
+}
 
 export class VariablesFromFiles {
 
-    static async init(argv: Argv, writeStreams: WriteStreams, gitData: GitData): Promise<{ [name: string]: string|Record<string, string> }> {
+    static async init(argv: Argv, writeStreams: WriteStreams, gitData: GitData): Promise<{ [name: string]: CICDVariable }> {
         const homeDir = argv.home;
         const homeVariablesFile = `${homeDir}/.gitlab-ci-local/variables.yml`;
-        let variables: { [key: string]: string } = {};
+        const variables: { [name: string]: CICDVariable } = {};
         let homeFileData: any;
 
-        if (!fs.existsSync(homeVariablesFile)) {
+        if (!await fs.pathExists(homeVariablesFile)) {
             homeFileData =  {};
         } else {
             homeFileData = yaml.load(await fs.readFile(homeVariablesFile, "utf8"), {schema: yaml.FAILSAFE_SCHEMA});
         }
 
-        for (const [globalKey, globalEntry] of Object.entries(homeFileData?.global ?? [])) {
-            if (typeof globalEntry !== "string") {
-                continue;
+        const initAllMatcher = (v: any) => {
+            const allEnvironment: {[key: string]: any} = {};
+            allEnvironment["*"] = v;
+            return allEnvironment;
+        };
+        const addToVariables = async (key: string, val: any, scopePriority: number) => {
+            for (const [envMatcher, content] of Object.entries(typeof val === "string" ? initAllMatcher(val) : val)) {
+                if (typeof content === "string") {
+                    const regexp = new RegExp(envMatcher.replace(/\*/g, ".*"), "g");
+                    variables[key] = variables[key] ?? {type: "variable", environments: []};
+                    variables[key].environments.push({content, regexp, regexpPriority: envMatcher.length, scopePriority });
+                } else {
+                    assert(content != null, `${key}.file content cannot be null/undefined`);
+                    assert(typeof content == "object", `${key}.${envMatcher}.file must be text or multiline text`);
+                    const fileContent = (content as Record<string, string>).file;
+                    assert(typeof fileContent == "string", `${key}.${envMatcher}.file must be text or multiline text`);
+                    const regexp = new RegExp(envMatcher.replace(/\*/g, ".*"), "g");
+                    variables[key] = variables[key] ?? {type: "file", environments: []};
+                    variables[key].environments.push({content: fileContent, regexp, regexpPriority: envMatcher.length, scopePriority });
+                }
             }
-            variables[globalKey] = globalEntry;
+        };
+
+        for (const [globalKey, globalEntry] of Object.entries(homeFileData?.global ?? {})) {
+            await addToVariables(globalKey, globalEntry, 0);
         }
 
         const groupUrl = `${gitData.remote.host}/${gitData.remote.group}/`;
-        for (const [groupKey, groupEntries] of Object.entries(homeFileData?.group ?? [])) {
-            if (!groupUrl.includes(this.normalizeProjectKey(groupKey, writeStreams))) {
-                continue;
+        for (const [groupKey, groupEntries] of Object.entries(homeFileData?.group ?? {})) {
+            if (!groupUrl.includes(this.normalizeProjectKey(groupKey, writeStreams))) continue;
+            assert(groupEntries != null, "groupEntries cannot be null/undefined");
+            assert(typeof groupEntries === "object", "groupEntries must be object");
+            for (const [k, v] of Object.entries(groupEntries)) {
+                await addToVariables(k, v, 1);
             }
-            if (typeof groupEntries !== "object") {
-                continue;
-            }
-            variables = {...variables, ...groupEntries};
         }
 
         const projectUrl = `${gitData.remote.host}/${gitData.remote.group}/${gitData.remote.project}.git`;
         for (const [projectKey, projectEntries] of Object.entries(homeFileData?.project ?? [])) {
-            if (!projectUrl.includes(this.normalizeProjectKey(projectKey, writeStreams))) {
-                continue;
-            }
-            if (typeof projectEntries !== "object") {
-                continue;
-            }
-            variables = {...variables, ...projectEntries};
-        }
-
-        const projectVariablesFile = `${argv.cwd}/.gitlab-ci-local-variables.yml`;
-        if (fs.existsSync(projectVariablesFile)) {
-            const projectFileData: any = yaml.load(await fs.readFile(projectVariablesFile, "utf8"), {schema: yaml.FAILSAFE_SCHEMA}) ?? {};
-            if (typeof projectFileData === "object") {
-                variables = {...variables, ...projectFileData};
+            if (!projectUrl.includes(this.normalizeProjectKey(projectKey, writeStreams))) continue;
+            assert(projectEntries != null, "projectEntries cannot be null/undefined");
+            assert(typeof projectEntries === "object", "projectEntries must be object");
+            for (const [k, v] of Object.entries(projectEntries)) {
+                await addToVariables(k, v, 2);
             }
         }
 
-        // Generate files for file type variables
-        for (const [key, value] of Object.entries(variables)) {
-            if (typeof value !== "string") {
-                continue;
-            }
-            if (!value.match(/^[/|~]/)) {
-                continue;
-            }
-
-            if (value.match(/\/$/)) {
-                continue;
-            }
-
-            const fromFilePath = value.replace(/^~\/(.*)/, `${homeDir}/$1`);
-            if (fs.existsSync(fromFilePath)) {
-                await fs.ensureDir(`/tmp/gitlab-ci-local-file-variables-${gitData.CI_PROJECT_PATH_SLUG}/`);
-                await fs.copyFile(fromFilePath, `/tmp/gitlab-ci-local-file-variables-${gitData.CI_PROJECT_PATH_SLUG}/${path.basename(fromFilePath)}`);
-                variables[key] = `/tmp/gitlab-ci-local-file-variables-${gitData.CI_PROJECT_PATH_SLUG}/${path.basename(fromFilePath)}`;
-            }
+        for (const varObj of Object.values(variables)) {
+            varObj.environments.sort((a, b) => b.scopePriority - a.scopePriority);
+            varObj.environments.sort((a, b) => b.regexpPriority - a.scopePriority);
         }
 
         return variables;

--- a/tests/test-cases/custom-home/.gitlab-ci.yml
+++ b/tests/test-cases/custom-home/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 ---
-test-job:
+test-staging:
+  environment: staging
   script:
     - echo ${GLOBAL_VAR}
     - echo ${GROUP_VAR}
@@ -8,6 +9,11 @@ test-job:
     - cat ${GLOBAL_FILE_VAR}
     - echo ${DOUBLE_QUOTE_VAR}
     - echo ${COMPLEX_VAR}
+
+test-production:
+  environment: production
+  script:
+    - echo ${GROUP_VAR}
 
 # Test file variables are working with docker-executor jobs
 test-image:

--- a/tests/test-cases/custom-home/.gitlab-ci.yml
+++ b/tests/test-cases/custom-home/.gitlab-ci.yml
@@ -5,7 +5,7 @@ test-staging:
     - echo ${GLOBAL_VAR}
     - echo ${GROUP_VAR}
     - echo ${PROJECT_VAR}
-    - echo ${INVALID_DIR_VAR}
+    - cat ${INVALID_DIR_VAR}
     - cat ${GLOBAL_FILE_VAR}
     - echo ${DOUBLE_QUOTE_VAR}
     - echo ${COMPLEX_VAR}

--- a/tests/test-cases/custom-home/.gitlab-ci.yml
+++ b/tests/test-cases/custom-home/.gitlab-ci.yml
@@ -9,11 +9,14 @@ test-staging:
     - cat ${GLOBAL_FILE_VAR}
     - echo ${DOUBLE_QUOTE_VAR}
     - echo ${COMPLEX_VAR}
+    - echo ${FILE}
 
 test-production:
   environment: production
   script:
     - echo ${GROUP_VAR}
+    - echo ${FILE}
+    - cat ${FILE}
 
 # Test file variables are working with docker-executor jobs
 test-image:

--- a/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
+++ b/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
@@ -12,6 +12,12 @@ project:
       {
         "private_key": "-----BEGIN PRIVATE KEY-----\n"
       }
+    FILE:
+      '*production*':
+        file: |
+          I'm the content of a file variable
+          I'm the 2nd line of file variable
+
   gitlab.com/gcl/no-match:
     PROJECT_VAR: no-match
 

--- a/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
+++ b/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
@@ -1,7 +1,9 @@
 ---
 project:
   gitlab.com/gcl/custom-home:
-    GROUP_VAR: project-group-var-override-value
+    GROUP_VAR:
+      '*staging*': staging-project-group-var-override-value
+      '*production*': production-project-group-var-override-value
     PROJECT_VAR: project-var-value
     CI_PROJECT_ID: 12345678
     DOUBLE_QUOTE_VAR: |

--- a/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
+++ b/tests/test-cases/custom-home/.home/.gitlab-ci-local/variables.yml
@@ -2,8 +2,9 @@
 project:
   gitlab.com/gcl/custom-home:
     GROUP_VAR:
-      '*staging*': staging-project-group-var-override-value
-      '*production*': production-project-group-var-override-value
+      values:
+        '*staging*': staging-project-group-var-override-value
+        '*production*': production-project-group-var-override-value
     PROJECT_VAR: project-var-value
     CI_PROJECT_ID: 12345678
     DOUBLE_QUOTE_VAR: |
@@ -13,8 +14,9 @@ project:
         "private_key": "-----BEGIN PRIVATE KEY-----\n"
       }
     FILE:
-      '*production*':
-        file: |
+      type: file
+      values:
+        '*production*': |
           I'm the content of a file variable
           I'm the 2nd line of file variable
 

--- a/tests/test-cases/custom-home/integration.custom-home.test.ts
+++ b/tests/test-cases/custom-home/integration.custom-home.test.ts
@@ -25,9 +25,9 @@ test("custom-home <test-staging>", async () => {
         chalk`{blueBright test-staging             } {greenBright >} staging-project-group-var-override-value`,
         chalk`{blueBright test-staging             } {greenBright >} project-var-value`,
         chalk`{blueBright test-staging             } {greenBright >} ~/dir/`,
-        chalk`{blueBright test-staging             } {greenBright >} Im content of a file variable`,
-        chalk`{blueBright test-staging             } {greenBright >} "This is crazy"`,
-        chalk`{blueBright test-staging             } {greenBright >} \{ "private_key": "-----BEGIN PRIVATE KEY-----\\n" \}`,
+        // chalk`{blueBright test-staging             } {greenBright >} Im content of a file variable`,
+        // chalk`{blueBright test-staging             } {greenBright >} "This is crazy"`,
+        // chalk`{blueBright test-staging             } {greenBright >} \{ "private_key": "-----BEGIN PRIVATE KEY-----\\n" \}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
@@ -42,6 +42,8 @@ test("custom-home <test-production>", async () => {
 
     const expected = [
         chalk`{blueBright test-production          } {greenBright >} production-project-group-var-override-value`,
+        chalk`{blueBright test-production          } {greenBright >} I'm the content of a file variable`,
+        chalk`{blueBright test-production          } {greenBright >} I'm the 2nd line of file variable`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });

--- a/tests/test-cases/custom-home/integration.custom-home.test.ts
+++ b/tests/test-cases/custom-home/integration.custom-home.test.ts
@@ -12,22 +12,36 @@ beforeAll(() => {
     initSpawnSpy([...WhenStatics.all, spyGitRemote]);
 });
 
-test("custom-home <test-job>", async () => {
+test("custom-home <test-staging>", async () => {
     const writeStreams = new MockWriteStreams();
     await handler({
         cwd: "tests/test-cases/custom-home",
-        job: ["test-job"],
+        job: ["test-staging"],
         home: "tests/test-cases/custom-home/.home",
     }, writeStreams);
 
     const expected = [
-        chalk`{blueBright test-job                 } {greenBright >} group-global-var-override-value`,
-        chalk`{blueBright test-job                 } {greenBright >} project-group-var-override-value`,
-        chalk`{blueBright test-job                 } {greenBright >} project-var-value`,
-        chalk`{blueBright test-job                 } {greenBright >} ~/dir/`,
-        chalk`{blueBright test-job                 } {greenBright >} Im content of a file variable`,
-        chalk`{blueBright test-job                 } {greenBright >} "This is crazy"`,
-        chalk`{blueBright test-job                 } {greenBright >} \{ "private_key": "-----BEGIN PRIVATE KEY-----\\n" \}`,
+        chalk`{blueBright test-staging             } {greenBright >} group-global-var-override-value`,
+        chalk`{blueBright test-staging             } {greenBright >} staging-project-group-var-override-value`,
+        chalk`{blueBright test-staging             } {greenBright >} project-var-value`,
+        chalk`{blueBright test-staging             } {greenBright >} ~/dir/`,
+        chalk`{blueBright test-staging             } {greenBright >} Im content of a file variable`,
+        chalk`{blueBright test-staging             } {greenBright >} "This is crazy"`,
+        chalk`{blueBright test-staging             } {greenBright >} \{ "private_key": "-----BEGIN PRIVATE KEY-----\\n" \}`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test("custom-home <test-production>", async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: "tests/test-cases/custom-home",
+        job: ["test-production"],
+        home: "tests/test-cases/custom-home/.home",
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-production          } {greenBright >} production-project-group-var-override-value`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });

--- a/tests/test-cases/custom-home/integration.custom-home.test.ts
+++ b/tests/test-cases/custom-home/integration.custom-home.test.ts
@@ -24,10 +24,10 @@ test("custom-home <test-staging>", async () => {
         chalk`{blueBright test-staging             } {greenBright >} group-global-var-override-value`,
         chalk`{blueBright test-staging             } {greenBright >} staging-project-group-var-override-value`,
         chalk`{blueBright test-staging             } {greenBright >} project-var-value`,
-        chalk`{blueBright test-staging             } {greenBright >} ~/dir/`,
-        // chalk`{blueBright test-staging             } {greenBright >} Im content of a file variable`,
-        // chalk`{blueBright test-staging             } {greenBright >} "This is crazy"`,
-        // chalk`{blueBright test-staging             } {greenBright >} \{ "private_key": "-----BEGIN PRIVATE KEY-----\\n" \}`,
+        chalk`{blueBright test-staging             } {greenBright >} warn: INVALID_DIR_VAR is pointing to invalid path`,
+        chalk`{blueBright test-staging             } {greenBright >} Im content of a file variable`,
+        chalk`{blueBright test-staging             } {greenBright >} "This is crazy"`,
+        chalk`{blueBright test-staging             } {greenBright >} \{ "private_key": "-----BEGIN PRIVATE KEY-----\\n" \}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });


### PR DESCRIPTION
Made it possible to specific environment matchers in `~/.gitlab-ci-local/variables.yml` or `$cwd/.gitlab-ci-local-variables.yml`
Made it possible to specify file content via `file: <content>` property in `~/.gitlab-ci-local/variables.yml` or `$cwd/.gitlab-ci-local-variables.yml`