### PR TITLE
Put various info messages into stderr

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -100,7 +100,7 @@ export async function handler(args: any, writeStreams: WriteStreams): Promise<Re
         await Utils.rsyncTrackedFiles(cwd, ".docker");
         await Commander.runJobs(argv, parser, writeStreams);
         if (argv.needs) {
-            writeStreams.stdout(chalk`{grey pipeline finished} in {grey ${prettyHrtime(process.hrtime(time))}}\n`);
+            writeStreams.stderr(chalk`{grey pipeline finished} in {grey ${prettyHrtime(process.hrtime(time))}}\n`);
         }
     } else {
         generateGitIgnore(cwd);
@@ -111,7 +111,7 @@ export async function handler(args: any, writeStreams: WriteStreams): Promise<Re
         parser = await Parser.create(argv, writeStreams, pipelineIid);
         await Utils.rsyncTrackedFiles(cwd, ".docker");
         await Commander.runPipeline(argv, parser, writeStreams);
-        writeStreams.stdout(chalk`{grey pipeline finished} in {grey ${prettyHrtime(process.hrtime(time))}}\n`);
+        writeStreams.stderr(chalk`{grey pipeline finished} in {grey ${prettyHrtime(process.hrtime(time))}}\n`);
     }
     writeStreams.flush();
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -55,7 +55,7 @@ export class Parser {
         await Validator.run(parser.jobs, parser.stages);
         const parsingTime = process.hrtime(time);
 
-        writeStreams.stdout(chalk`{grey parsing and downloads finished} in {grey ${prettyHrtime(parsingTime)}}\n`);
+        writeStreams.stderr(chalk`{grey parsing and downloads finished} in {grey ${prettyHrtime(parsingTime)}}\n`);
 
         return parser;
     }

--- a/tests/test-cases/after-script/integration.after-script.test.ts
+++ b/tests/test-cases/after-script/integration.after-script.test.ts
@@ -19,7 +19,6 @@ test("after-script <test-job>", async () => {
         chalk`{blueBright test-job } {greenBright >} Cleanup after test`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("after-script <build-job> (default)", async () => {
@@ -33,5 +32,4 @@ test("after-script <build-job> (default)", async () => {
         chalk`{blueBright build-job} {greenBright >} Cleanup after test`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/artifacts-docker/integration.artifacts-docker.test.ts
+++ b/tests/test-cases/artifacts-docker/integration.artifacts-docker.test.ts
@@ -14,6 +14,4 @@ test("artifacts-docker <consume artifacts> --needs", async () => {
         job: ["consume artifacts 🏗️"],
         needs: true,
     }, writeStreams);
-
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/artifacts-exclude/integration.artifacts-exclude.test.ts
+++ b/tests/test-cases/artifacts-exclude/integration.artifacts-exclude.test.ts
@@ -16,5 +16,4 @@ test("artifacts-exclude <consume-artifacts> --needs --exclude", async () => {
         shellIsolation: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/artifacts-globstar/integration.artifacts-globstar.test.ts
+++ b/tests/test-cases/artifacts-globstar/integration.artifacts-globstar.test.ts
@@ -21,7 +21,6 @@ test("artifacts-globstar <test-job> --needs --shell-isolation", async () => {
         chalk`{blueBright test-job} {greenBright >} Pre something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("artifacts-globstar <no-match> --shell-isolation", async () => {
@@ -36,5 +35,4 @@ test("artifacts-globstar <no-match> --shell-isolation", async () => {
         chalk`{blueBright no-match} {yellow !! no artifacts was copied !!}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/artifacts-reports-dotenv/integration.artifacts-reports-dotenv.test.ts
+++ b/tests/test-cases/artifacts-reports-dotenv/integration.artifacts-reports-dotenv.test.ts
@@ -15,7 +15,6 @@ test("artifacts-reports-dotenv <deploy-image> --needs", async () => {
         needs: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("artifacts-reports-dotenv <deploy-shell-iso> --needs", async () => {
@@ -27,7 +26,6 @@ test("artifacts-reports-dotenv <deploy-shell-iso> --needs", async () => {
         shellIsolation: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("artifacts-reports-dotenv <deploy-shell-noiso> --needs", async () => {
@@ -38,5 +36,4 @@ test("artifacts-reports-dotenv <deploy-shell-noiso> --needs", async () => {
         needs: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/artifacts-shell/integration.artifacts-shell.test.ts
+++ b/tests/test-cases/artifacts-shell/integration.artifacts-shell.test.ts
@@ -24,7 +24,6 @@ test.concurrent("artifacts-shell <consume> --needs --shell-isolation", async () 
     });
     expect(found.length).toEqual(1);
     expect(await fs.pathExists("tests/test-cases/artifacts-shell/path/file1")).toEqual(true);
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test.concurrent("artifacts-shell --file .gitlab-ci-when-never.yml --shell-isolation", async () => {
@@ -35,5 +34,5 @@ test.concurrent("artifacts-shell --file .gitlab-ci-when-never.yml --shell-isolat
         shellIsolation: true,
     }, writeStreams);
 
-     expect(writeStreams.stderrLines).toEqual([]);
+     
 });

--- a/tests/test-cases/artifacts-to-source-no/integration.artifacts-to-source-no.test.ts
+++ b/tests/test-cases/artifacts-to-source-no/integration.artifacts-to-source-no.test.ts
@@ -18,5 +18,4 @@ test.concurrent("artifacts-to-source-no <produce> --needs --shell-isolation", as
     }, writeStreams);
 
     expect(await fs.pathExists("tests/test-cases/artifacts-to-source-no/path/file1")).toEqual(false);
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/artifacts-with-cache/integration.artifacts-with-cache.test.ts
+++ b/tests/test-cases/artifacts-with-cache/integration.artifacts-with-cache.test.ts
@@ -22,5 +22,4 @@ test("artifacts-with-cache <test-job> --needs", async () => {
         chalk`{black.bgGreenBright  PASS } {blueBright test-job}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-
 });

--- a/tests/test-cases/before-script-default/integration.before-script-default.test.ts
+++ b/tests/test-cases/before-script-default/integration.before-script-default.test.ts
@@ -19,5 +19,4 @@ test("before-script-default <test-job>", async () => {
         chalk`{blueBright test-job} {greenBright >} Before test`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/before-script/integration.before-script.test.ts
+++ b/tests/test-cases/before-script/integration.before-script.test.ts
@@ -19,5 +19,4 @@ test("before-script <test-job>", async () => {
         chalk`{blueBright test-job} {greenBright >} Before test`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/cache-docker-mount/integration.cache-docker-mount.test.ts
+++ b/tests/test-cases/cache-docker-mount/integration.cache-docker-mount.test.ts
@@ -28,5 +28,4 @@ test("cache-docker-mount <consume-cache> --mount-cache --needs", async () => {
     expect(await fs.pathExists("tests/test-cases/cache-docker-mount/.gitlab-ci-local/cache/maven/")).toEqual(false);
     expect((await Utils.bash("docker volume ls | grep -w gcl-gcl-cache-docker-mount-maven")).exitCode).toBe(0);
 
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/cache-docker/integration.cache-docker.test.ts
+++ b/tests/test-cases/cache-docker/integration.cache-docker.test.ts
@@ -17,5 +17,4 @@ test.concurrent("cache-docker <consume-cache> --needs", async () => {
         needs: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/cache-double-run/integration.cache-double-run.test.ts
+++ b/tests/test-cases/cache-double-run/integration.cache-double-run.test.ts
@@ -29,5 +29,4 @@ test.concurrent("cache-double-run <test-job> --shell-isolation", async () => {
     }, writeStreams);
     const expectedStdout = [chalk`{blueBright test-job} {greenBright >} Cache warm`];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdout));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/cache-key-files/integration.key-files.test.ts
+++ b/tests/test-cases/cache-key-files/integration.key-files.test.ts
@@ -18,5 +18,4 @@ test.concurrent("cache-key-files <consume-cache> --shell-isolation --needs", asy
         shellIsolation: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/cache-shell-fail/integration.cache-shell-fail.test.ts
+++ b/tests/test-cases/cache-shell-fail/integration.cache-shell-fail.test.ts
@@ -21,5 +21,4 @@ test.concurrent("cache-shell-fail <consume-cache> --shell-isolation --needs", as
         chalk`{blueBright produce-cache} {yellow !! no cache was copied for cache/**/* !!}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/cache-shell/integration.cache-shell.test.ts
+++ b/tests/test-cases/cache-shell/integration.cache-shell.test.ts
@@ -18,5 +18,5 @@ test.concurrent("cache-shell <consume-cache> --shell-isolation --needs", async (
         shellIsolation: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
+    
 });

--- a/tests/test-cases/cli-option-variables/integration.cli-option-variables.test.ts
+++ b/tests/test-cases/cli-option-variables/integration.cli-option-variables.test.ts
@@ -21,5 +21,4 @@ test("cli-option-variables <test-job> --variable \"CLI_VAR=hello world\"", async
         chalk`{blueBright test-job} {greenBright >} dotdot`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/dotenv/integration.dotenv.test.ts
+++ b/tests/test-cases/dotenv/integration.dotenv.test.ts
@@ -20,5 +20,4 @@ test("dotenv <test-job>", async () => {
         chalk`{blueBright test-job} {greenBright >} doh`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/environment/integration.environment.test.ts
+++ b/tests/test-cases/environment/integration.environment.test.ts
@@ -19,7 +19,7 @@ test("environment <deploy-dev-job>", async () => {
         chalk`{blueBright deploy-dev-job} environment: \{ name: {bold dev-domain} \}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
+    
 });
 
 test("environment <deploy-stage-job>", async () => {
@@ -36,5 +36,5 @@ test("environment <deploy-stage-job>", async () => {
         chalk`{blueBright deploy-stage-job} environment: \{ name: {bold Stage Domain}, url: {bold http://stage.domain.com} \}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
+    
 });

--- a/tests/test-cases/extends/integration.extends.test.ts
+++ b/tests/test-cases/extends/integration.extends.test.ts
@@ -21,5 +21,5 @@ test("extends <test-job>", async () => {
         chalk`{blueBright test-job} {greenBright >} Test something (after_script)`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
+    
 });

--- a/tests/test-cases/hang-forever/integration.hang-forever.test.ts
+++ b/tests/test-cases/hang-forever/integration.hang-forever.test.ts
@@ -20,7 +20,6 @@ test("hang-forever <test-debian>", async() => {
     ];
 
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("hang-forever <test-alpine>", async() => {
@@ -35,7 +34,6 @@ test("hang-forever <test-alpine>", async() => {
     ];
 
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("hang-forever <test-shell>", async() => {
@@ -50,5 +48,4 @@ test("hang-forever <test-shell>", async() => {
     ];
 
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/image/integration.image.test.ts
+++ b/tests/test-cases/image/integration.image.test.ts
@@ -56,9 +56,11 @@ test("image <test-from-scratch>", async () => {
         job: ["test-from-scratch"],
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines[5]).toEqual(chalk`{blueBright test-from-scratch       } {greenBright >} 0:0 .gitlab-ci.yml`);
-    expect(writeStreams.stdoutLines[7]).toEqual(chalk`{blueBright test-from-scratch       } {greenBright >} 666 .gitlab-ci.yml`);
-    expect(writeStreams.stdoutLines[9]).toEqual(chalk`{blueBright test-from-scratch       } {greenBright >} 777 folder/`);
-    expect(writeStreams.stdoutLines[11]).toEqual(chalk`{blueBright test-from-scratch       } {greenBright >} 777 executable.sh`);
-    expect(writeStreams.stderrLines).toEqual([]);
+    const expected = [
+        chalk`{blueBright test-from-scratch       } {greenBright >} 0:0 .gitlab-ci.yml`,
+        chalk`{blueBright test-from-scratch       } {greenBright >} 666 .gitlab-ci.yml`,
+        chalk`{blueBright test-from-scratch       } {greenBright >} 777 folder/`,
+        chalk`{blueBright test-from-scratch       } {greenBright >} 777 executable.sh`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });

--- a/tests/test-cases/include-local/integration.include-local.test.ts
+++ b/tests/test-cases/include-local/integration.include-local.test.ts
@@ -21,7 +21,6 @@ test("include-local <build-job>", async () => {
     ];
 
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("include-local <test-job> (short-list)", async () => {
@@ -36,7 +35,6 @@ test("include-local <test-job> (short-list)", async () => {
         chalk`{blueBright test-job} {greenBright >} Test something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("include-local <deploy-job> (short-single)", async () => {
@@ -51,5 +49,4 @@ test("include-local <deploy-job> (short-single)", async () => {
         chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/include-project-file-ref-with-inner-local/integration.include-project-file-ref-with-inner-local.test.ts
+++ b/tests/test-cases/include-project-file-ref-with-inner-local/integration.include-project-file-ref-with-inner-local.test.ts
@@ -42,5 +42,4 @@ test("include-project-file-ref-with-inner-local", async () => {
         chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/include-project-file-ref/integration.include-project-file-ref.test.ts
+++ b/tests/test-cases/include-project-file-ref/integration.include-project-file-ref.test.ts
@@ -32,5 +32,4 @@ test("include-project-file-ref <deploy-job>", async () => {
         chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/include-remote/integration.include-remote.test.ts
+++ b/tests/test-cases/include-remote/integration.include-remote.test.ts
@@ -30,5 +30,4 @@ test("include-remote <test-job|build-job>", async () => {
         chalk`{blueBright build-job} {greenBright >} Build something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/include-template/integration.include-template.test.ts
+++ b/tests/test-cases/include-template/integration.include-template.test.ts
@@ -19,5 +19,4 @@ test("include-template <test-job>", async () => {
         chalk`{blueBright test-job} {greenBright >} Test something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/long-running-silent-build-job/long-running-silent-build-job.test.ts
+++ b/tests/test-cases/long-running-silent-build-job/long-running-silent-build-job.test.ts
@@ -17,16 +17,7 @@ test("long-running-silent-build-job <build-job>", async () => {
         job: ["build-job"],
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines[4]).toEqual(chalk`{blueBright build-job} {greenBright >} 1`);
-    expect(writeStreams.stdoutLines[7]).toEqual(chalk`{blueBright build-job} {greenBright >} 2`);
-    expect(writeStreams.stdoutLines[10]).toEqual(chalk`{blueBright build-job} {greenBright >} 3`);
-    expect(writeStreams.stdoutLines[13]).toEqual(chalk`{blueBright build-job} {greenBright >} 4`);
-    expect(writeStreams.stdoutLines[16]).toEqual(chalk`{blueBright build-job} {greenBright >} 5`);
-    expect(writeStreams.stdoutLines[19]).toEqual(chalk`{blueBright build-job} {greenBright >} 6`);
-    expect(writeStreams.stdoutLines[22]).toEqual(chalk`{blueBright build-job} {greenBright >} 7`);
-    expect(writeStreams.stdoutLines[25]).toEqual(chalk`{blueBright build-job} {greenBright >} 8`);
-    expect(writeStreams.stdoutLines[28]).toEqual(chalk`{blueBright build-job} {greenBright >} 9`);
-    expect(writeStreams.stdoutLines[31]).toEqual(chalk`{blueBright build-job} {greenBright >} 10`);
-    expect(writeStreams.stdoutLines[34]).toEqual(chalk`{blueBright build-job} {greenBright >} 11`);
-    expect(writeStreams.stderrLines).toEqual([]);
+    for (let i = 1; i <= 11; i ++) {
+        expect(writeStreams.stdoutLines[i * 3]).toEqual(chalk`{blueBright build-job} {greenBright >} ${i}`);
+    }
 });

--- a/tests/test-cases/long-running-silent-test-job/long-running-silent-test-job.test.ts
+++ b/tests/test-cases/long-running-silent-test-job/long-running-silent-test-job.test.ts
@@ -17,7 +17,9 @@ test("long-running-silent-test-job <test-job>", async () => {
         job: ["test-job"],
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines[3]).toEqual(chalk`{blueBright test-job} {grey > still running...}`);
-    expect(writeStreams.stdoutLines[5]).toEqual(chalk`{blueBright test-job} {greenBright >} Test something`);
-    expect(writeStreams.stderrLines).toEqual([]);
+    const expected = [
+        chalk`{blueBright test-job} {grey > still running...}`,
+        chalk`{blueBright test-job} {greenBright >} Test something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });

--- a/tests/test-cases/manual/integration.manual.test.ts
+++ b/tests/test-cases/manual/integration.manual.test.ts
@@ -21,7 +21,6 @@ test("manual --manual <build-job> --manual <pre-job>", async () => {
         chalk`{blueBright build-job } {greenBright >} Hello, build job manual!`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("manual --manual <build-job> --manual <build-job> --manual <pre-job>", async () => {
@@ -58,7 +57,6 @@ test("manual <deploy-job>", async () => {
         chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("manual <deploy-job> --needs", async () => {
@@ -88,7 +86,6 @@ test("manual <deploy-job> --needs", async () => {
         chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("manual <build-job>", async () => {
@@ -102,7 +99,6 @@ test("manual <build-job>", async () => {
         chalk`{blueBright build-job } {greenBright >} Hello, build job manual!`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("manual <test-job> --needs --manual <pre-job>", async () => {
@@ -119,7 +115,6 @@ test("manual <test-job> --needs --manual <pre-job>", async () => {
         chalk`{blueBright test-job  } {greenBright >} Test something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("manual --manual <pre-job>", async () => {
@@ -134,9 +129,7 @@ test("manual --manual <pre-job>", async () => {
         chalk`{blueBright test-job  } {greenBright >} Test something`,
         chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
     ];
-    expect(writeStreams.stdoutLines[3]).toBe(chalk`{blueBright pre-job   } {greenBright >} Hello, pre job manual!`);
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });
 
 test("manual", async () => {

--- a/tests/test-cases/needs-artifacts/integration.needs-artifacts.test.ts
+++ b/tests/test-cases/needs-artifacts/integration.needs-artifacts.test.ts
@@ -19,5 +19,4 @@ test("needs-artifacts <test-job> --needs --shell-isolation", async () => {
         needs: true,
         shellIsolation: true,
     }, writeStreams);
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/needs-empty/integration.needs-empty.test.ts
+++ b/tests/test-cases/needs-empty/integration.needs-empty.test.ts
@@ -15,5 +15,5 @@ test("needs-empty <deploy-job> --shell-isolation", async () => {
         shellIsolation: true,
     }, writeStreams);
 
-    expect(writeStreams.stderrLines).toEqual([]);
+    
 });

--- a/tests/test-cases/plain/integration.plain.test.ts
+++ b/tests/test-cases/plain/integration.plain.test.ts
@@ -16,8 +16,8 @@ test("plain", async () => {
         cwd: "tests/test-cases/plain",
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines.length).toEqual(16);
-    expect(writeStreams.stderrLines.length).toEqual(1);
+    expect(writeStreams.stdoutLines.length).toEqual(14);
+    expect(writeStreams.stderrLines.length).toEqual(3);
 
     expect(await fs.pathExists("tests/test-cases/plain/.gitlab-ci-local/builds/test-job")).toBe(false);
     expect(await fs.pathExists("tests/test-cases/plain/.gitlab-ci-local/builds/build-job")).toBe(false);

--- a/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
+++ b/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
@@ -16,11 +16,13 @@ test("predefined-variables <test-job>", async () => {
         job: ["test-job"],
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines[3]).toEqual(chalk`{blueBright test-job} {greenBright >} predefined-variables`);
-    expect(writeStreams.stdoutLines[5]).toEqual(chalk`{blueBright test-job} {greenBright >} gcl-predefined-variables`);
-    expect(writeStreams.stdoutLines[7]).toEqual(chalk`{blueBright test-job} {greenBright >} gcl`);
-    expect(writeStreams.stdoutLines[9]).toEqual(chalk`{blueBright test-job} {greenBright >} tests/test-cases/predefined-variables`);
-    expect(writeStreams.stderrLines).toEqual([]);
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} predefined-variables`,
+        chalk`{blueBright test-job} {greenBright >} gcl-predefined-variables`,
+        chalk`{blueBright test-job} {greenBright >} gcl`,
+        chalk`{blueBright test-job} {greenBright >} tests/test-cases/predefined-variables`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
 test("predefined-variables <test-job> --shell-isolation", async () => {
@@ -31,6 +33,8 @@ test("predefined-variables <test-job> --shell-isolation", async () => {
         shellIsolation: true,
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines[9]).toEqual(chalk`{blueBright test-job} {greenBright >} tests/test-cases/predefined-variables/.gitlab-ci-local/builds/test-job`);
-    expect(writeStreams.stderrLines).toEqual([]);
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} tests/test-cases/predefined-variables/.gitlab-ci-local/builds/test-job`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });

--- a/tests/test-cases/preview/integration.preview.test.ts
+++ b/tests/test-cases/preview/integration.preview.test.ts
@@ -19,5 +19,4 @@ test("preview", async () => {
         chalk`---\nstages:\n  - .pre\n  - build\n  - test\n  - deploy\n  - .post\nchild-job:\n  script:\n    - echo \"Irrelevant\"\n  before_script:\n    - echo \"Default before script\"`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });

--- a/tests/test-cases/reference/integration.reference.test.ts
+++ b/tests/test-cases/reference/integration.reference.test.ts
@@ -15,9 +15,12 @@ test("reference <test-job>", async () => {
         job: ["test-job"],
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines[3]).toEqual(chalk`{blueBright test-job} {greenBright >} Ancient`);
-    expect(writeStreams.stdoutLines[5]).toEqual(chalk`{blueBright test-job} {greenBright >} Base`);
-    expect(writeStreams.stdoutLines[7]).toEqual(chalk`{blueBright test-job} {greenBright >} Setting something general up`);
-    expect(writeStreams.stdoutLines[9]).toEqual(chalk`{blueBright test-job} {greenBright >} Yoyo`);
-    expect(writeStreams.stderrLines).toEqual([]);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Ancient`,
+        chalk`{blueBright test-job} {greenBright >} Base`,
+        chalk`{blueBright test-job} {greenBright >} Setting something general up`,
+        chalk`{blueBright test-job} {greenBright >} Yoyo`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });

--- a/tests/test-cases/script-multidimension/integration.script-multidimension.test.ts
+++ b/tests/test-cases/script-multidimension/integration.script-multidimension.test.ts
@@ -20,5 +20,4 @@ test("script-multidimension <test-job>", async () => {
         chalk`{blueBright test-job} {greenBright >} Test something else`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-    expect(writeStreams.stderrLines).toEqual([]);
 });


### PR DESCRIPTION
Removed a lot of useless empty stderr tests, and streamlined stdout/stderr ordering tests, that didn't make any sense.

closes #409 