### PR TITLE
Use generated gcl-entry script to better comply with entrypoint syntax

### DIFF
--- a/src/job-expanders.ts
+++ b/src/job-expanders.ts
@@ -77,8 +77,7 @@ export function services(gitlabData: any) {
                     entrypoint: expandedService.entrypoint,
                     command: expandedService.command,
                     alias: expandedService.alias,
-
-                });
+                }, Number(index));
             }
         }
     });

--- a/src/job.ts
+++ b/src/job.ts
@@ -685,7 +685,7 @@ export class Job {
             cp.on("error", (err) => reject(err));
 
             if (this.imageName) {
-                cp.stdin?.end(`/gcl-cmd`);
+                cp.stdin?.end("/gcl-cmd");
             } else {
                 cp.stdin?.end(`./${stateDir}/scripts/${safeJobName}`);
             }

--- a/src/job.ts
+++ b/src/job.ts
@@ -927,6 +927,7 @@ export class Job {
     private async startService(writeStreams: WriteStreams, service: Service) {
         const cwd = this.argv.cwd;
         const stateDir = this.argv.stateDir;
+        const safeJobName = this.safeJobName;
         let dockerCmd = `docker create -u 0:0 -i --network gitlab-ci-local-${this.jobId} `;
         this.refreshLongRunningSilentTimeout(writeStreams);
 
@@ -953,7 +954,7 @@ export class Job {
         }
 
         const serviceEntrypoint = service.getEntrypoint();
-        const serviceEntrypointFile = `${cwd}/${stateDir}/scripts/services/${serviceNameWithoutVersion}_entry`;
+        const serviceEntrypointFile = `${cwd}/${stateDir}/scripts/services_entry/${safeJobName}_${serviceNameWithoutVersion}_${service.index}`;
         if (serviceEntrypoint) {
             await fs.outputFile(serviceEntrypointFile, "#!/bin/sh\n");
             await fs.appendFile(serviceEntrypointFile, `${serviceEntrypoint.join(" ")}`);

--- a/src/service.ts
+++ b/src/service.ts
@@ -2,40 +2,42 @@ import {Utils} from "./utils";
 import {assert} from "./asserts";
 
 export class Service {
-    private readonly serviceData: any;
+    private readonly data: any;
+    public readonly index: number;
 
-    constructor(serviceData: any) {
-        this.serviceData = serviceData;
+    constructor(data: any, index: number) {
+        this.data = data;
+        this.index = index;
     }
 
     public getName(expandedVariables: { [key: string]: string }): string {
-        assert(this.serviceData.name, "Service should always have an image name");
-        const servicesName = Utils.expandText(this.serviceData.name, expandedVariables);
-        return servicesName.includes(":") ? servicesName : `${servicesName}:latest`;
+        assert(this.data.name, "Service should always have an image name");
+        const name = Utils.expandText(this.data.name, expandedVariables);
+        return name.includes(":") ? name : `${name}:latest`;
     }
 
     public getEntrypoint(): string[] | null {
-        if (!this.serviceData || !this.serviceData.entrypoint) {
+        if (!this.data || !this.data.entrypoint) {
             return null;
         }
-        assert(Array.isArray(this.serviceData.entrypoint), "services:entrypoint must be an array");
-        return this.serviceData.entrypoint;
+        assert(Array.isArray(this.data.entrypoint), "services:entrypoint must be an array");
+        return this.data.entrypoint;
     }
 
     public getCommand(): string[] | null {
-        if (!this.serviceData || !this.serviceData.command) {
+        if (!this.data || !this.data.command) {
             return null;
         }
-        assert(Array.isArray(this.serviceData.command), "service:command must be an array");
-        return this.serviceData.command;
+        assert(Array.isArray(this.data.command), "service:command must be an array");
+        return this.data.command;
     }
 
     public getAlias(expandedVariables: { [key: string]: string }): string | null {
-        if (!this.serviceData || !this.serviceData.alias) {
+        if (!this.data || !this.data.alias) {
             return null;
         }
 
-        return Utils.expandText(this.serviceData.alias, expandedVariables);
+        return Utils.expandText(this.data.alias, expandedVariables);
     }
 
 }

--- a/tests/test-cases/image/.gitlab-ci.yml
+++ b/tests/test-cases/image/.gitlab-ci.yml
@@ -39,3 +39,10 @@ test-from-scratch:
     - stat -c "%a %n" .gitlab-ci.yml
     - stat -c "%a %n" folder/
     - stat -c "%a %n" executable.sh
+
+issue-206:
+  image:
+    name: klakegg/hugo:0.83.1-busybox
+    entrypoint: ["/bin/sh", "-c"]
+  script:
+    - hugo -D --source hugo

--- a/tests/test-cases/image/integration.image.test.ts
+++ b/tests/test-cases/image/integration.image.test.ts
@@ -88,3 +88,17 @@ test("image <test-ignore-regression>", async () => {
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
+
+test("image <issue-206>", async () => {
+    const writeStreams = new MockWriteStreams();
+
+    await handler({
+        cwd: "tests/test-cases/image",
+        job: ["issue-206"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright issue-206               } {redBright >} Error: open /builds/issue-206/hugo: no such file or directory`,
+    ];
+    expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expected));
+});

--- a/tests/test-cases/services/.gitlab-ci.yml
+++ b/tests/test-cases/services/.gitlab-ci.yml
@@ -42,3 +42,15 @@ alias-job:
   script:
     - host redis
     - host redis-alias
+
+multie-job:
+  services:
+    - name: alpine
+      entrypoint: ["/bin/sh", "-c", "'echo Service 1'"]
+      command: ["sh"]
+    - name: alpine
+      entrypoint: ["/bin/sh", "-c", "'echo Service 2'"]
+      command: ["sh"]
+  image: tutum/dnsutils
+  script:
+    - echo "Hello"

--- a/tests/test-cases/services/.gitlab-ci.yml
+++ b/tests/test-cases/services/.gitlab-ci.yml
@@ -13,7 +13,10 @@ pre-job:
     - cat /foo.txt
 
 test-job:
-  services: []
+  services:
+    - name: alpine
+      entrypoint: ["/bin/sh", "-c"]
+      command: ["sh"]
   image: tutum/dnsutils
   script: host nginx
 

--- a/tests/test-cases/services/integration.services.test.ts
+++ b/tests/test-cases/services/integration.services.test.ts
@@ -82,3 +82,17 @@ test.concurrent("services <alias-job>", async () => {
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
+
+test.concurrent("services <multie-job>", async () => {
+    const writeStreams = new MockWriteStreams();
+    await handler({
+        cwd: "tests/test-cases/services",
+        job: ["multie-job"],
+    }, writeStreams);
+
+    const expectedStderr = [
+        chalk`{blueBright multie-job} {cyan >} Service 1`,
+        chalk`{blueBright multie-job} {cyan >} Service 2`,
+    ];
+    expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expectedStderr));
+});

--- a/tests/test-cases/services/integration.services.test.ts
+++ b/tests/test-cases/services/integration.services.test.ts
@@ -37,6 +37,11 @@ test.concurrent("services <test-job>", async () => {
         chalk`{black.bgRed  FAIL } {blueBright test-job  }`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+
+    const expectedStdErr = [
+        chalk`{blueBright test-job  } {yellow Could not find exposed tcp ports alpine:latest}`,
+    ];
+    expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expectedStdErr));
 });
 
 test.concurrent("services <build-job>", async () => {


### PR DESCRIPTION
closes #206 

remedy issue with podman https://github.com/firecow/gitlab-ci-local/issues/298

refactor pull image function to avoid `Utils.bash` and `docker image ls` slowness