### PR TITLE
Jobs that gets when:never because of rules.exist is shown in --list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "execa": "5.1.1",
         "fs-extra": "10.1.0",
         "js-yaml": "4.1.0",
-        "minimatch": "5.1.0",
+        "micromatch": "^4.0.5",
         "object-traversal": "1.0.1",
         "pretty-hrtime": "1.0.3",
         "source-map-support": "0.5.21",
@@ -37,6 +37,7 @@
         "@types/jest": "28.1.6",
         "@types/jest-when": "3.5.2",
         "@types/js-yaml": "4.0.5",
+        "@types/micromatch": "^4.0.2",
         "@types/pretty-hrtime": "1.0.1",
         "@types/source-map-support": "0.5.4",
         "@types/yargs": "17.0.11",
@@ -1317,6 +1318,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/braces": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.1.tgz",
+      "integrity": "sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==",
+      "dev": true
+    },
     "node_modules/@types/camelcase": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@types/camelcase/-/camelcase-5.2.0.tgz",
@@ -1411,6 +1418,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-oqXqVb0ci19GtH0vOA/U2TmHTcRY9kuZl4mqUxe0QmJAlIW13kzhuK5pi1i9+ngav8FjpSb9FVS/GE00GLX1VA==",
+      "dev": true,
+      "dependencies": {
+        "@types/braces": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.4",
@@ -2069,7 +2085,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2148,19 +2165,10 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -3391,7 +3399,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4021,7 +4028,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -5006,13 +5012,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -5055,17 +5060,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/minimist": {
@@ -5484,10 +5478,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -6574,7 +6567,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -8086,6 +8078,12 @@
         "@types/node": "*"
       }
     },
+    "@types/braces": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.1.tgz",
+      "integrity": "sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==",
+      "dev": true
+    },
     "@types/camelcase": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@types/camelcase/-/camelcase-5.2.0.tgz",
@@ -8179,6 +8177,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
+    },
+    "@types/micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-oqXqVb0ci19GtH0vOA/U2TmHTcRY9kuZl4mqUxe0QmJAlIW13kzhuK5pi1i9+ngav8FjpSb9FVS/GE00GLX1VA==",
+      "dev": true,
+      "requires": {
+        "@types/braces": "*"
+      }
     },
     "@types/minimatch": {
       "version": "3.0.4",
@@ -8671,7 +8678,8 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -8726,19 +8734,10 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
-    "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "requires": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -9652,7 +9651,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -10108,8 +10106,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -10881,13 +10878,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime-db": {
@@ -10913,14 +10909,6 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
       "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "dev": true
-    },
-    "minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "requires": {
-        "brace-expansion": "^2.0.1"
-      }
     },
     "minimist": {
       "version": "1.2.6",
@@ -11238,10 +11226,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pirates": {
       "version": "4.0.5",
@@ -12060,7 +12047,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
       "@typescript-eslint/indent": [
         "error",
         4
-      ]
+      ],
+      "space-in-parens": "error"
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "execa": "5.1.1",
     "fs-extra": "10.1.0",
     "js-yaml": "4.1.0",
-    "minimatch": "5.1.0",
+    "micromatch": "^4.0.5",
     "object-traversal": "1.0.1",
     "pretty-hrtime": "1.0.3",
     "source-map-support": "0.5.21",
@@ -46,6 +46,7 @@
     "@types/jest": "28.1.6",
     "@types/jest-when": "3.5.2",
     "@types/js-yaml": "4.0.5",
+    "@types/micromatch": "^4.0.2",
     "@types/pretty-hrtime": "1.0.1",
     "@types/source-map-support": "0.5.4",
     "@types/yargs": "17.0.11",
@@ -65,33 +66,59 @@
     "node": ">=16.10.0"
   },
   "pkg": {
-    "assets": ["package.json"],
-    "scripts": ["src/**/*.js"]
+    "assets": [
+      "package.json"
+    ],
+    "scripts": [
+      "src/**/*.js"
+    ]
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint"],
-    "ignorePatterns": ["*.js"],
-    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+    "plugins": [
+      "@typescript-eslint"
+    ],
+    "ignorePatterns": [
+      "*.js"
+    ],
+    "extends": [
+      "eslint:recommended",
+      "plugin:@typescript-eslint/recommended"
+    ],
     "rules": {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/explicit-module-boundary-types": "off",
       "@typescript-eslint/semi": "error",
       "@typescript-eslint/quotes": "error",
-      "@typescript-eslint/comma-dangle": ["error", "always-multiline"],
+      "@typescript-eslint/comma-dangle": [
+        "error",
+        "always-multiline"
+      ],
       "@typescript-eslint/object-curly-spacing": "error",
       "@typescript-eslint/space-before-function-paren": "error",
       "@typescript-eslint/space-before-blocks": "error",
       "@typescript-eslint/space-infix-ops": "error",
       "@typescript-eslint/member-delimiter-style": "error",
-      "@typescript-eslint/indent": ["error", 4]
+      "@typescript-eslint/indent": [
+        "error",
+        4
+      ]
     }
   },
   "jest": {
     "preset": "ts-jest",
-    "testMatch": ["**/*.test.ts"],
-    "testPathIgnorePatterns": ["/node_modules/", "/.gitlab-ci-local/"],
-    "coverageReporters": ["lcov", "json-summary", "text-summary"]
+    "testMatch": [
+      "**/*.test.ts"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/.gitlab-ci-local/"
+    ],
+    "coverageReporters": [
+      "lcov",
+      "json-summary",
+      "text-summary"
+    ]
   },
   "repository": {
     "type": "git",

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -21,8 +21,6 @@ export class Executor {
     static getStartCandidates (jobs: ReadonlyArray<Job>, stages: readonly string[], potentialStarters: readonly Job[], manuals: string[]) {
         const startCandidates = [];
 
-        potentialStarters = potentialStarters.filter(job => job.shouldExecuteBasedOnRuleExisting());
-
         for (const job of [...new Set<Job>(potentialStarters)]) {
             if (job.started) continue;
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -13,7 +13,7 @@ import {CacheEntry} from "./cache-entry";
 import {Mutex} from "./mutex";
 import {Argv} from "./argv";
 import execa from "execa";
-import minimatch from "minimatch";
+import micromatch from "micromatch";
 import {CICDVariable} from "./variables-from-files";
 
 interface JobOptions {
@@ -348,7 +348,7 @@ export class Job {
 
         function searchFiles (dirPath: string, arrayOfFiles: string[]): string[] {
             const filesTmp = fs.readdirSync(dirPath);
-    
+
             filesTmp.forEach(function (fileTmp: string) {
                 const filePath = dirPath + "/" + fileTmp;
                 if (fs.statSync(filePath).isDirectory()) {
@@ -357,12 +357,12 @@ export class Job {
                     arrayOfFiles.push(filePath);
                 }
             });
-    
+
             return arrayOfFiles;
         }
 
         const files = searchFiles(this.argv.cwd, []);
-        
+
         const strippedFiles: string[] = [];
         for (const file of files ) {
             strippedFiles.push(file.replace(this.argv.cwd + "/", ""));
@@ -370,7 +370,7 @@ export class Job {
 
         for (const pattern of this.exists) {
             for (const strippedFile of strippedFiles) {
-                if(minimatch(strippedFile,pattern, {dot: true})) {
+                if(micromatch.isMatch(strippedFile, pattern, {dot: true})) {
                     return true;
                 }
             }

--- a/src/job.ts
+++ b/src/job.ts
@@ -13,7 +13,6 @@ import {CacheEntry} from "./cache-entry";
 import {Mutex} from "./mutex";
 import {Argv} from "./argv";
 import execa from "execa";
-import micromatch from "micromatch";
 import {CICDVariable} from "./variables-from-files";
 
 interface JobOptions {
@@ -172,10 +171,9 @@ export class Job {
 
         // Set {when, allowFailure} based on rules result
         if (this.rules) {
-            const ruleResult = Utils.getRulesResult(this.rules, this.expandedVariables);
+            const ruleResult = Utils.getRulesResult({cwd, rules: this.rules, variables: this.expandedVariables});
             this.when = ruleResult.when;
             this.allowFailure = ruleResult.allowFailure;
-            this.exists = ruleResult.exists;
             this.expandedVariables = Utils.expandRecursive({...globalVariables || {}, ...jobData.variables || {}, ...ruleResult.variables, ...matrixVariables, ...predefinedVariables, ...envMatchedVariables, ...argvVariables});
         }
 
@@ -341,42 +339,6 @@ export class Job {
 
     get fileVariablesDir () {
         return `/tmp/gitlab-ci-local-file-variables-${this.gitData.CI_PROJECT_PATH_SLUG}-${this.jobId}`;
-    }
-
-    shouldExecuteBasedOnRuleExisting (): boolean {
-        if ( this.exists == undefined || this.exists.length == 0 ) return true;
-
-        function searchFiles (dirPath: string, arrayOfFiles: string[]): string[] {
-            const filesTmp = fs.readdirSync(dirPath);
-
-            filesTmp.forEach(function (fileTmp: string) {
-                const filePath = dirPath + "/" + fileTmp;
-                if (fs.statSync(filePath).isDirectory()) {
-                    arrayOfFiles = searchFiles(filePath, arrayOfFiles);
-                } else {
-                    arrayOfFiles.push(filePath);
-                }
-            });
-
-            return arrayOfFiles;
-        }
-
-        const files = searchFiles(this.argv.cwd, []);
-
-        const strippedFiles: string[] = [];
-        for (const file of files ) {
-            strippedFiles.push(file.replace(this.argv.cwd + "/", ""));
-        }
-
-        for (const pattern of this.exists) {
-            for (const strippedFile of strippedFiles) {
-                if(micromatch.isMatch(strippedFile, pattern, {dot: true})) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     async start (): Promise<void> {

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -7,7 +7,7 @@ import {assert} from "./asserts";
 import chalk from "chalk";
 import {Parser} from "./parser";
 import axios from "axios";
-import minimatch from "minimatch";
+import micromatch from "micromatch";
 
 export class ParserIncludes {
 
@@ -24,7 +24,7 @@ export class ParserIncludes {
         for (const value of include) {
             if (value["local"]) {
                 const filesStripped = Utils.searchFilesStripped(cwd);
-                const files = minimatch.match(filesStripped, `${value["local"]}`);
+                const files = micromatch.match(filesStripped, `${value["local"]}`);
                 if (files.length == 0) {
                     throw new ExitError(`Local include file cannot be found ${value["local"]}`);
                 }
@@ -47,7 +47,7 @@ export class ParserIncludes {
         for (const value of include) {
             if (value["local"]) {
                 const filesStripped = Utils.searchFilesStripped(cwd);
-                const files = minimatch.match(filesStripped, `${value["local"]}`);
+                const files = micromatch.match(filesStripped, `${value["local"]}`);
                 for (const localFile of files) {
                     const content = await Parser.loadYaml(`${cwd}/${localFile}`);
                     includeDatas = includeDatas.concat(await this.init(content, cwd, stateDir, writeStreams, gitData, depth, fetchIncludes));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,7 +239,7 @@ export class Utils {
         const files = searchFiles(cwd, []);
 
         const strippedFiles: string[] = [];
-        for (const file of files ) {
+        for (const file of files) {
             strippedFiles.push(file.replace(cwd + "/", ""));
         }
 
@@ -298,7 +298,7 @@ export class Utils {
         const files = Utils.searchFiles(dirPath, []);
 
         const strippedFiles: string[] = [];
-        for (const file of files ) {
+        for (const file of files) {
             strippedFiles.push(file.replace(dirPath + "/", ""));
         }
 

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -4,24 +4,27 @@ test("GITLAB_CI on_success", () => {
     const rules = [
         {if: "$GITLAB_CI == 'false'"},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {GITLAB_CI: "false"});
-    expect(rulesResult).toEqual({when: "on_success", allowFailure: false, exists: [], variables: undefined});
+    const variables = {GITLAB_CI: "false"};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "on_success", allowFailure: false, variables: undefined});
 });
 
 test("Regex on undef var", () => {
     const rules = [
         {if: "$CI_COMMIT_TAG =~ /^v\\d+.\\d+.\\d+/"},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {});
-    expect(rulesResult).toEqual({when: "never", allowFailure: false, exists: [], variables: undefined});
+    const variables = {};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "never", allowFailure: false, variables: undefined});
 });
 
 test("Negated regex on undef var", () => {
     const rules = [
         {if: "$CI_COMMIT_TAG !~ /^v\\d+.\\d+.\\d+/"},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {});
-    expect(rulesResult).toEqual({when: "never", allowFailure: false, exists: [], variables: undefined});
+    const variables = {};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "never", allowFailure: false, variables: undefined});
 });
 
 test("GITLAB_CI fail and fallback", () => {
@@ -29,24 +32,27 @@ test("GITLAB_CI fail and fallback", () => {
         {if: "$GITLAB_CI == 'true'"},
         {when: "manual"},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {GITLAB_CI: "false"});
-    expect(rulesResult).toEqual({when: "manual", allowFailure: false, exists: [], variables: undefined});
+    const variables = {GITLAB_CI: "false"};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "manual", allowFailure: false, variables: undefined});
 });
 
 test("Undefined if", () => {
     const rules = [
         {when: "on_success"},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {});
-    expect(rulesResult).toEqual({when: "on_success", allowFailure: false, exists: [], variables: undefined});
+    const variables = {};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "on_success", allowFailure: false, variables: undefined});
 });
 
 test("Undefined when", () => {
     const rules = [
         {if: "$GITLAB_CI", allow_failure: false},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {GITLAB_CI: "false"});
-    expect(rulesResult).toEqual({when: "on_success", allowFailure: false, exists: [], variables: undefined});
+    const variables = {GITLAB_CI: "false"};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "on_success", allowFailure: false, variables: undefined});
 });
 
 test("Early return", () => {
@@ -54,8 +60,9 @@ test("Early return", () => {
         {if: "$GITLAB_CI", when: "never"},
         {when: "on_success"},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {GITLAB_CI: "false"});
-    expect(rulesResult).toEqual({when: "never", allowFailure: false, exists: [], variables: undefined});
+    const variables = {GITLAB_CI: "false"};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "never", allowFailure: false, variables: undefined});
 });
 
 test("VAR exists positive", () => {
@@ -221,40 +228,44 @@ test("Complex parentheses junctions regex fail - case insensitive", () => {
 });
 
 test("https://github.com/firecow/gitlab-ci-local/issues/350", () => {
-    let rules, rulesResult;
-
+    let rules, rulesResult, variables;
     rules = [
         {if: "$CI_COMMIT_BRANCH =~ /master$/", when: "manual"},
     ];
-    rulesResult = Utils.getRulesResult(rules, {CI_COMMIT_BRANCH: "master"});
-    expect(rulesResult).toEqual({when: "manual", allowFailure: false, exists: [], variables: undefined});
+    variables = {CI_COMMIT_BRANCH: "master"};
+    rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "manual", allowFailure: false, variables: undefined});
 
     rules = [
         {if: "$CI_COMMIT_BRANCH =~ /$BRANCHNAME/", when: "manual"},
     ];
-    rulesResult = Utils.getRulesResult(rules, {CI_COMMIT_BRANCH: "master", BRANCHNAME: "master"});
-    expect(rulesResult).toEqual({when: "never", allowFailure: false, exists: [], variables: undefined});
+    variables = {CI_COMMIT_BRANCH: "master", BRANCHNAME: "master"};
+    rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "never", allowFailure: false, variables: undefined});
 });
 
 test("https://github.com/firecow/gitlab-ci-local/issues/300", () => {
-    let rules, rulesResult;
+    let rules, rulesResult, variables;
     rules = [
         {if: "$VAR1 && (($VAR3 =~ /ci-skip-job-/ && $VAR2 =~ $VAR3) || ($VAR3 =~ /ci-skip-stage-/ && $VAR2 =~ $VAR3))", when: "manual"},
     ];
-    rulesResult = Utils.getRulesResult(rules, {VAR1: "val", VAR2: "ci-skip-job-", VAR3: "ci-skip-job-"});
-    expect(rulesResult).toEqual({when: "manual", allowFailure: false, exists: [], variables: undefined});
+    variables = {VAR1: "val", VAR2: "ci-skip-job-", VAR3: "ci-skip-job-"};
+    rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "manual", allowFailure: false, variables: undefined});
 
     rules = [
         {if: "$VAR1 && (($VAR3 =~ /ci-skip-job-/ && $VAR2 =~ $VAR3) || ($VAR3 =~ /ci-skip-stage-/ && $VAR2 =~ $VAR3))", when: "manual"},
     ];
-    rulesResult = Utils.getRulesResult(rules, {VAR1: "val", VAR2: "ci-skip-stage-", VAR3: "ci-skip-stage-"});
-    expect(rulesResult).toEqual({when: "manual", allowFailure: false, exists: [], variables: undefined});
+    variables = {VAR1: "val", VAR2: "ci-skip-stage-", VAR3: "ci-skip-stage-"};
+    rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "manual", allowFailure: false, variables: undefined});
 });
 
 test("https://github.com/firecow/gitlab-ci-local/issues/424", () => {
     const rules = [
         {if: "$CI_COMMIT_REF_NAME =~ /^(develop$|release\\/.*|master$)/", when: "manual"},
     ];
-    const rulesResult = Utils.getRulesResult(rules, {CI_COMMIT_REF_NAME: "develop"});
-    expect(rulesResult).toEqual({when: "manual", allowFailure: false, exists: [], variables: undefined});
+    const variables = {CI_COMMIT_REF_NAME: "develop"};
+    const rulesResult = Utils.getRulesResult({cwd: "", rules, variables});
+    expect(rulesResult).toEqual({when: "manual", allowFailure: false, variables: undefined});
 });

--- a/tests/test-cases/rules-exists/integration.rules-exists.test.ts
+++ b/tests/test-cases/rules-exists/integration.rules-exists.test.ts
@@ -7,11 +7,10 @@ beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
 });
 
-test("rules-exists <all-jobs> --needs", async () => {
+test("rules-exists", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/rules-exists",
-        needs: true,
     }, writeStreams);
 
     const output = writeStreams.stdoutLines.join();


### PR DESCRIPTION
- Make sure rules.exist is evaluated on parse time, so `--list` and `--list-all` can show proper when value
- Use micromatch over minimatch