### PR TITLE
no-shell artifacts bugfix

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -841,7 +841,7 @@ export class Job {
         let time, endTime;
         let cpCmd = "shopt -s globstar nullglob dotglob\n";
         cpCmd += `mkdir -p ${artifactsPath}/${safeJobName}\n`;
-        cpCmd += "rsync --exclude '.gitlab-ci-local/**' -Ra "
+        cpCmd += "rsync --exclude '.gitlab-ci-local/**' -Ra ";
         for (const artifactExcludePath of this.artifacts?.exclude ?? []) {
             const expandedPath = Utils.expandText(artifactExcludePath, this.expandedVariables);
             cpCmd += `--exclude '${expandedPath}' `;
@@ -850,7 +850,7 @@ export class Job {
             const expandedPath = Utils.expandText(artifactPath, this.expandedVariables);
             cpCmd += `${expandedPath} `;
         }
-        cpCmd += `${artifactsPath}/${safeJobName}/. || true\n`
+        cpCmd += `${artifactsPath}/${safeJobName}/. || true\n`;
         const reportDotenv = Utils.expandText(this.artifacts.reports?.dotenv ?? null, this.expandedVariables);
         if (reportDotenv != null) {
             cpCmd += `mkdir -p ${artifactsPath}/${safeJobName}/.gitlab-ci-reports/dotenv\n`;

--- a/src/job.ts
+++ b/src/job.ts
@@ -841,15 +841,16 @@ export class Job {
         let time, endTime;
         let cpCmd = "shopt -s globstar nullglob dotglob\n";
         cpCmd += `mkdir -p ${artifactsPath}/${safeJobName}\n`;
-        for (const artifactPath of this.artifacts?.paths ?? []) {
-            const expandedPath = Utils.expandText(artifactPath, this.expandedVariables);
-            cpCmd += `rsync -Ra ${expandedPath} ${artifactsPath}/${safeJobName}/. || true\n`;
-        }
+        cpCmd += "rsync --exclude '.gitlab-ci-local/**' -Ra "
         for (const artifactExcludePath of this.artifacts?.exclude ?? []) {
             const expandedPath = Utils.expandText(artifactExcludePath, this.expandedVariables);
-            cpCmd += `ls -1d '${artifactsPath}/${safeJobName}/${expandedPath}' | xargs -n1 rm -rf || true\n`;
+            cpCmd += `--exclude '${expandedPath}' `;
         }
-
+        for (const artifactPath of this.artifacts?.paths ?? []) {
+            const expandedPath = Utils.expandText(artifactPath, this.expandedVariables);
+            cpCmd += `${expandedPath} `;
+        }
+        cpCmd += `${artifactsPath}/${safeJobName}/. || true\n`
         const reportDotenv = Utils.expandText(this.artifacts.reports?.dotenv ?? null, this.expandedVariables);
         if (reportDotenv != null) {
             cpCmd += `mkdir -p ${artifactsPath}/${safeJobName}/.gitlab-ci-reports/dotenv\n`;

--- a/tests/test-cases/artifacts-no-shell-out/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-no-shell-out/.gitlab-ci.yml
@@ -6,5 +6,5 @@ produce:
     - touch path/file1
     - touch path/file2
   artifacts:
-    paths: [path/]
+    paths: [path/, "**/file1"]
     exclude: [path/file2]

--- a/tests/test-cases/artifacts-no-shell-out/integration.artifacts-no-shell-out.test.ts
+++ b/tests/test-cases/artifacts-no-shell-out/integration.artifacts-no-shell-out.test.ts
@@ -9,6 +9,8 @@ beforeAll(() => {
 });
 
 test("artifacts-no-shell-out <produce> --no-shell-isolation", async () => {
+    await fs.promises.rm("tests/test-cases/artifacts-no-shell-out/.gitlab-ci-local/artifacts/produce/.gitlab-ci-local/artifacts/produce/path/file1", {force: true});
+
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/artifacts-no-shell-out",
@@ -18,4 +20,5 @@ test("artifacts-no-shell-out <produce> --no-shell-isolation", async () => {
 
     expect(await fs.pathExists("tests/test-cases/artifacts-no-shell-out/.gitlab-ci-local/artifacts/produce/path/file1")).toEqual(true);
     expect(await fs.pathExists("tests/test-cases/artifacts-no-shell-out/.gitlab-ci-local/artifacts/produce/path/file2")).toEqual(false);
+    expect(await fs.pathExists("tests/test-cases/artifacts-no-shell-out/.gitlab-ci-local/artifacts/produce/.gitlab-ci-local/artifacts/produce/path/file1")).toEqual(false);
 });


### PR DESCRIPTION
- Fix a bug, where files inside `.gitlab-ci-local` could be copied out as an artifact
- Simplify rsync command in `copyArtifactsOut` function