### PR TITLE
Use .replaceAll() instead of .replace() for aliases for containers wi…

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -936,8 +936,8 @@ export class Job {
         const serviceName = service.getName(this.expandedVariables);
         const serviceNameWithoutVersion = serviceName.replace(/(.*)(:.*)/, "$1");
         const aliases = new Set<string>();
-        aliases.add(serviceNameWithoutVersion.replace("/", "-"));
-        aliases.add(serviceNameWithoutVersion.replace("/", "__"));
+        aliases.add(serviceNameWithoutVersion.replaceAll("/", "-"));
+        aliases.add(serviceNameWithoutVersion.replaceAll("/", "__"));
         if (serviceAlias) {
             aliases.add(serviceAlias);
         }
@@ -995,7 +995,7 @@ export class Job {
         const serviceAlias = service.getAlias(this.expandedVariables);
         const serviceName = service.getName(this.expandedVariables);
         const serviceNameWithoutVersion = serviceName.replace(/(.*)(:.*)/, "$1");
-        const aliases = [serviceNameWithoutVersion.replace("/", "-"), serviceNameWithoutVersion.replace("/", "__")];
+        const aliases = [serviceNameWithoutVersion.replaceAll("/", "-"), serviceNameWithoutVersion.replaceAll("/", "__")];
         if (serviceAlias) {
             aliases.push(serviceAlias);
         }

--- a/tests/test-cases/services/.gitlab-ci.yml
+++ b/tests/test-cases/services/.gitlab-ci.yml
@@ -45,6 +45,17 @@ alias-job:
     - host redis
     - host redis-alias
 
+alias-job-multiple-slashes:
+  services:
+    - name: gcr.io/google-containers/redis
+      alias: redis-alias
+  stage: deploy
+  image: tutum/dnsutils
+  script:
+    - host gcr.io-google-containers-redis
+    - host gcr.io__google-containers__redis
+    - host redis-alias
+
 multie-job:
   services:
     - name: alpine

--- a/tests/test-cases/services/integration.services.test.ts
+++ b/tests/test-cases/services/integration.services.test.ts
@@ -19,8 +19,8 @@ test.concurrent("services <pre-job>", async () => {
     }, writeStreams);
 
     const expectedStdErr = [
-        chalk`{blueBright pre-job   } {yellow Could not find exposed tcp ports alpine:latest}`,
-        chalk`{blueBright pre-job   } {redBright >} cat: can't open '/foo.txt': No such file or directory`,
+        chalk`{blueBright pre-job                   } {yellow Could not find exposed tcp ports alpine:latest}`,
+        chalk`{blueBright pre-job                   } {redBright >} cat: can't open '/foo.txt': No such file or directory`,
     ];
     expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expectedStdErr));
 });
@@ -33,12 +33,12 @@ test.concurrent("services <test-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{black.bgRed  FAIL } {blueBright test-job  }`,
+        chalk`{black.bgRed  FAIL } {blueBright test-job                  }`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 
     const expectedStdErr = [
-        chalk`{blueBright test-job  } {yellow Could not find exposed tcp ports alpine:latest}`,
+        chalk`{blueBright test-job                  } {yellow Could not find exposed tcp ports alpine:latest}`,
     ];
     expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expectedStdErr));
 });
@@ -51,7 +51,7 @@ test.concurrent("services <build-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{black.bgGreenBright  PASS } {blueBright build-job }`,
+        chalk`{black.bgGreenBright  PASS } {blueBright build-job                 }`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
@@ -64,7 +64,7 @@ test.concurrent("services <deploy-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{black.bgGreenBright  PASS } {blueBright deploy-job}`,
+        chalk`{black.bgGreenBright  PASS } {blueBright deploy-job                }`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
@@ -77,7 +77,20 @@ test.concurrent("services <alias-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{black.bgGreenBright  PASS } {blueBright alias-job }`,
+        chalk`{black.bgGreenBright  PASS } {blueBright alias-job                 }`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test.concurrent("services <alias-job-multiple-slashes>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/services",
+        job: ["alias-job-multiple-slashes"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`{black.bgGreenBright  PASS } {blueBright alias-job-multiple-slashes}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
@@ -105,7 +118,7 @@ test.concurrent("services <no-tmp>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{black.bgGreenBright  PASS } {blueBright no-tmp    }`,
+        chalk`{black.bgGreenBright  PASS } {blueBright no-tmp                    }`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });


### PR DESCRIPTION
Fixes aliases with multiple slashes so the healthcheck container can connect correctly closes #649