### PR TITLE
Support artifacts:when:always

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -268,7 +268,7 @@ export class Job {
         return this.jobData["description"] ?? "";
     }
 
-    get artifacts (): {paths?: string[]; exclude?: string[]; reports?: {dotenv?: string}} | null {
+    get artifacts (): {paths?: string[]; exclude?: string[]; reports?: {dotenv?: string}; when?: string} | null {
         return this.jobData["artifacts"];
     }
 
@@ -675,6 +675,9 @@ export class Job {
 
         if (exitCode == 0) {
             await this.copyCacheOut(writeStreams);
+        }
+
+        if (exitCode == 0 || this.artifacts?.when === "always") {
             await this.copyArtifactsOut(writeStreams);
         }
 

--- a/tests/test-cases/artifacts-shell-fail-always/.gitignore
+++ b/tests/test-cases/artifacts-shell-fail-always/.gitignore
@@ -1,0 +1,1 @@
+/path/file1

--- a/tests/test-cases/artifacts-shell-fail-always/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-shell-fail-always/.gitlab-ci.yml
@@ -1,0 +1,17 @@
+---
+produce:
+  stage: build
+  script:
+    - mkdir -p path/
+    - touch path/file1
+    - exit 1
+  artifacts:
+    when: always
+    paths: [path/]
+
+consume:
+  stage: test
+  dependencies: [produce]
+  script:
+    - pwd
+    - test -f path/file1

--- a/tests/test-cases/artifacts-shell-fail-always/integration.artifacts-shell-fail-always.test.ts
+++ b/tests/test-cases/artifacts-shell-fail-always/integration.artifacts-shell-fail-always.test.ts
@@ -1,0 +1,21 @@
+import {WriteStreamsMock} from "../../../src/write-streams-mock";
+import {handler} from "../../../src/handler";
+import fs from "fs-extra";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("artifacts-shell-fail-always <consume> --needs --shell-isolation", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/artifacts-shell-fail-always",
+        job: ["consume"],
+        needs: true,
+        shellIsolation: true,
+    }, writeStreams);
+
+    expect(await fs.pathExists("tests/test-cases/artifacts-shell-fail-always/path/file1")).toEqual(true);
+});


### PR DESCRIPTION
Currently when artifacts:when is set to always the artifacts of a failed job aren't copied out.

Ref: https://docs.gitlab.com/ee/ci/yaml/#artifactswhen