### PR TITLE
fix(658): Don't run manual jobs if past jobs failed

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -31,6 +31,9 @@ export class Executor {
             if (job.when === "on_success" && Executor.isPastFailed(jobsToWaitFor)) {
                 continue;
             }
+            if (job.when === "manual" && Executor.isPastFailed(jobsToWaitFor)) {
+                continue;
+            }
             if (job.when === "on_failure" && !Executor.isPastFailed(jobsToWaitFor)) {
                 continue;
             }


### PR DESCRIPTION
When looking for starting candidates the executor only considers whether past jobs have failed or not when they are `on_success`  (the default) or `on_failure`. However for this purpose it should also check `manual` jobs.

Closes #658