### PR TITLE
Fix regexp to extract project information that fails on some cases.

### DIFF
--- a/src/git-data.ts
+++ b/src/git-data.ts
@@ -69,7 +69,7 @@ export class GitData {
     private async initRemoteData (cwd: string, writeStreams: WriteStreams): Promise<void> {
         try {
             const {stdout: gitRemote} = await Utils.spawn(["git", "remote", "-v"], cwd);
-            const gitRemoteMatch = gitRemote.match(/.*(?:\/\/|@)(?<host>[^:/]*)(:(?<port>\d+)\/|:|\/)(?<group>.*)\/(?<project>.*?)(?:\r?\n|\.git)/);
+            const gitRemoteMatch = gitRemote.match(/.*(?:\/\/|@)(?<host>[^:\/]*)(:(?<port>\d+)\/|:|\/)(?<group>.*)\/(?<project>[^ .]+)(|.git).*/);
 
             assert(gitRemoteMatch?.groups != null, "git remote -v didn't provide valid matches");
 

--- a/src/git-data.ts
+++ b/src/git-data.ts
@@ -69,7 +69,7 @@ export class GitData {
     private async initRemoteData (cwd: string, writeStreams: WriteStreams): Promise<void> {
         try {
             const {stdout: gitRemote} = await Utils.spawn(["git", "remote", "-v"], cwd);
-            const gitRemoteMatch = gitRemote.match(/.*(?:\/\/|@)(?<host>[^:\/]*)(:(?<port>\d+)\/|:|\/)(?<group>.*)\/(?<project>[^ .]+)(|.git).*/);
+            const gitRemoteMatch = gitRemote.match(/.*(?:\/\/|@)(?<host>[^:/]*)(:(?<port>\d+)\/|:|\/)(?<group>.*)\/(?<project>[^ .]+)(|.git).*/);
 
             assert(gitRemoteMatch?.groups != null, "git remote -v didn't provide valid matches");
 


### PR DESCRIPTION
For example, without the `.git` and the ` (fetch)` at the end: 
```
origin	ssh://git@gitlab.my.company.org/groupname/some-project (fetch)
```