### PR TITLE
Tolerate needs.pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 !/docker-npm
 
 /.gitlab-ci-local/
+
+.DS_Store
+
+.vscode

--- a/src/job.ts
+++ b/src/job.ts
@@ -188,15 +188,16 @@ export class Job {
         return Utils.safeDockerString(this.name);
     }
 
-    get needs (): {job: string; artifacts: boolean; optional: boolean}[] | null {
+    get needs (): {job: string; artifacts: boolean; optional: boolean; pipeline: string | null}[] | null {
         const needs = this.jobData["needs"];
         if (!needs) return null;
-        const list: {job: string; artifacts: boolean; optional: boolean}[] = [];
+        const list: {job: string; artifacts: boolean; optional: boolean; pipeline: string | null}[] = [];
         needs.forEach((need: any) => {
             list.push({
                 job: typeof need === "string" ? need : need.job,
                 artifacts: typeof need === "string" ? true : need.artifacts,
                 optional: typeof need === "string" ? false : need.optional,
+                pipeline: typeof need === "string" ? null : need.pipeline,
             });
         });
         return list;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -55,10 +55,13 @@ export class Parser {
         const parser = new Parser(argv, writeStreams, pipelineIid);
         const time = process.hrtime();
         await parser.init();
-        await Validator.run(parser.jobs, parser.stages);
+        const warnings = await Validator.run(parser.jobs, parser.stages);
         const parsingTime = process.hrtime(time);
 
         writeStreams.stderr(chalk`{grey parsing and downloads finished} in {grey ${prettyHrtime(parsingTime)}}\n`);
+        for (const warning of warnings) {
+            writeStreams.stderr(chalk`{yellow ${warning}}\n`);
+        }
 
         return parser;
     }

--- a/tests/test-cases/needs-pipeline/.gitlab-ci.yml
+++ b/tests/test-cases/needs-pipeline/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+---
+needed-job:
+  stage: build
+  script:
+    - echo "nothing"
+
+needs-pipeline-job:
+  stage: test
+  script:
+    - echo "Job executed!"
+  needs:
+    - job: needed-job
+    - job: other-pipeline-job
+      pipeline: "foobar"

--- a/tests/test-cases/needs-pipeline/integration.needs-pipeline.test.ts
+++ b/tests/test-cases/needs-pipeline/integration.needs-pipeline.test.ts
@@ -1,0 +1,26 @@
+import {WriteStreamsMock} from "../../../src/write-streams-mock";
+import {handler} from "../../../src/handler";
+import chalk from "chalk";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("needs-pipeline", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/needs-pipeline",
+        needs: true,
+    }, writeStreams);
+
+    const output = writeStreams.stdoutLines.join();
+    console.log(output);
+
+    const expected = [
+        chalk`{yellow needs-pipeline-job WARNING: Ignoring needs.job 'other-pipeline-job' because of unsupported needs.pipeline}`,
+    ];
+    expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expected));
+    expect(output).toContain("Job executed!");
+});


### PR DESCRIPTION

**Is your feature request related to a problem? Please describe.**
We currently cannot test a pipeline configuration that is part of a multi-project or parent-child pipeline configuration if a job has a `needs:pipeline` field, even if the dependency can be mocked somehow (e.g. passing some upstream variable on the CLI). The error is something like:
```
needs: [my-needed-job] for my-job could not be found
```

**Describe the solution you'd like**
When a job has needs.pipeline, because it depends in some way on a job from another pipeline we currently fail to validate the pipeline because the needed job isn't in the current list of jobs of the pipeline. However instead of failing, it is more useful to ignore the particular dependency and emit a warning.

**Describe alternatives you've considered**

An alternative would be to continue failing and force the user to manually edit the file to comment out the entry in `needs:pipeline` entry.

**Additional context**

I made a choice to include the pipeline attribute in the `Job.needs` data structure, which would indicate to the validator and executor that the specific dependency should be ignored. I also updated the Validator to generate a list of warnings that can be output all together. Alternatives I considered were a) updating the Job.needs method to just skip the entries of Job.needs that contained the pipeline field because that method isn't memoized so I couldn't emit a warning there (if you would prefer we memoize it then this alternative would be a good one), and b) passing the `writeStreams` object to the Validator so that it could output the warnings itself, but I feel the parser might be a better place to control the "interaction" with the user.