### PR TITLE
Add ulimit configuration option to env file

### DIFF
--- a/examples/docker-in-docker-build/.gitlab-ci-local-env
+++ b/examples/docker-in-docker-build/.gitlab-ci-local-env
@@ -1,3 +1,4 @@
 PRIVILEGED=true
+ULIMIT=8000:16000
 VOLUME=certs:/certs/client
 VARIABLE="DOCKER_TLS_CERTDIR=/certs"

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -110,6 +110,10 @@ export class Argv {
         return this.map.get("privileged") ?? false;
     }
 
+    get ulimit (): number {
+        return this.map.get("ulimit") ?? -1;
+    }
+
     get needs (): boolean {
         return this.map.get("needs") ?? false;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,11 @@ import {AssertionError} from "assert";
             description: "Set docker executor to privileged mode",
             requiresArg: false,
         })
+        .option("ulimit", {
+            type: "number",
+            description: "Set docker executor ulimit",
+            requiresArg: false,
+        })
         .option("volume", {
             type: "array",
             description: "Add volumes to docker executor",

--- a/src/job.ts
+++ b/src/job.ts
@@ -547,6 +547,10 @@ export class Job {
                 dockerCmd += "--privileged ";
             }
 
+            if (this.argv.ulimit > 0) {
+                dockerCmd += `--ulimit nofile=${this.argv.ulimit} `;
+            }
+
             if (this.argv.umask) {
                 dockerCmd += "--user 0:0 ";
             }
@@ -928,6 +932,10 @@ export class Job {
 
         if (this.argv.privileged) {
             dockerCmd += "--privileged ";
+        }
+
+        if (this.argv.ulimit > 0) {
+            dockerCmd += `--ulimit nofile=${this.argv.ulimit} `;
         }
 
         for (const volume of this.argv.volume) {

--- a/tests/test-cases/dind/.gitlab-ci-local-env
+++ b/tests/test-cases/dind/.gitlab-ci-local-env
@@ -1,3 +1,4 @@
 PRIVILEGED=true
+ULIMIT=8000:16000
 VOLUME=certs:/certs/client
 VARIABLE="DOCKER_TLS_CERTDIR=/certs"


### PR DESCRIPTION
I need the ulimit option for `docker run` because I don't want to change the ulimit of the whole system, just the docker images that I run. This commit would enable using this option in the env file to modify the execution of `docker` to contain the `--ulimit nofile=8000:16000` parameter/values.   

Currently, only the values can be modified in the env file like so:
`ULIMIT=8000:16000`  
If this is too specific, I could make it more general - so that the env file can be configured to contain 
`ULIMIT="nofile=8000:16000"`  
Or something similar so that the nofile or nprocs or whatever other option can be set by the user.  