### PR TITLE
Logs: Add option to add a max padding for the job name

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -169,4 +169,8 @@ export class Argv {
     get artifactsToSource (): boolean {
         return this.map.get("artifactsToSource") ?? true;
     }
+
+    get maxJobNameLength (): number | undefined {
+        return this.map.get("maxJobNameLength");
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,12 @@ import {AssertionError} from "assert";
         })
         .option("quiet", {
             type: "boolean",
-            description: "Suppres all job output",
+            description: "Suppress all job output",
+            requiresArg: false,
+        })
+        .option("maxJobNameLength", {
+            type: "number",
+            description: "Maximum padding for job name (use <= 0 for no padding)",
             requiresArg: false,
         })
         .completion("completion", false, async (_, yargsArgv) => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -160,10 +160,18 @@ export class Parser {
             }
         });
 
-        // Find jobNamePad
-        this.jobs.forEach((job) => {
-            this._jobNamePad = Math.max(job.name.length, this._jobNamePad ?? 0);
-        });
+        // Add some padding so that job logs are nicely aligned
+        // allow users to override this in case they have really long job name (see #840)
+        if (this.argv.maxJobNameLength !== undefined && this.argv.maxJobNameLength <= 0) {
+            this._jobNamePad = 0;
+        } else {
+            this.jobs.forEach((job) => {
+                this._jobNamePad = Math.max(job.name.length, this._jobNamePad ?? 0);
+            });
+            if (this.argv.maxJobNameLength !== undefined) {
+                this._jobNamePad = Math.min(this.argv.maxJobNameLength ?? 0, this._jobNamePad ?? 0);
+            }
+        }
 
         // Set jobNamePad on all jobs
         this.jobs.forEach((job) => {

--- a/tests/test-cases/logPadding/.gitlab-ci.yml
+++ b/tests/test-cases/logPadding/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+---
+my-job-with-a-very-long-long-long-long-name:
+  stage: .pre
+  script:
+    - echo "long-name"
+
+short-name:
+  stage: .pre
+  script:
+    - echo "short-name"

--- a/tests/test-cases/logPadding/__snapshots__/integration.plain.logPadding.test.ts.snap
+++ b/tests/test-cases/logPadding/__snapshots__/integration.plain.logPadding.test.ts.snap
@@ -4,7 +4,7 @@ exports[`logs - maxJobNameLength set to 0 1`] = `
 "[94mshort-name[39m [95mstarting[39m shell ([33m.pre[39m)
 [94mshort-name[39m [32m$ echo "short-name"[39m
 [94mshort-name[39m [92m>[39m short-name
-[94mshort-name[39m [95mfinished[39m in [35m15 ms[39m
+[94mshort-name[39m [95mfinished[39m in [35m1 ms[39m
 
 [30m[102m PASS [49m[39m [94mshort-name[39m"
 `;
@@ -13,7 +13,7 @@ exports[`logs - maxJobNameLength set to 30 1`] = `
 "[94mshort-name                    [39m [95mstarting[39m shell ([33m.pre[39m)
 [94mshort-name                    [39m [32m$ echo "short-name"[39m
 [94mshort-name                    [39m [92m>[39m short-name
-[94mshort-name                    [39m [95mfinished[39m in [35m13 ms[39m
+[94mshort-name                    [39m [95mfinished[39m in [35m1 ms[39m
 
 [30m[102m PASS [49m[39m [94mshort-name                    [39m"
 `;
@@ -22,7 +22,7 @@ exports[`logs - maxJobNameLength unset 1`] = `
 "[94mshort-name                                 [39m [95mstarting[39m shell ([33m.pre[39m)
 [94mshort-name                                 [39m [32m$ echo "short-name"[39m
 [94mshort-name                                 [39m [92m>[39m short-name
-[94mshort-name                                 [39m [95mfinished[39m in [35m14 ms[39m
+[94mshort-name                                 [39m [95mfinished[39m in [35m1 ms[39m
 
 [30m[102m PASS [49m[39m [94mshort-name                                 [39m"
 `;

--- a/tests/test-cases/logPadding/__snapshots__/integration.plain.logPadding.test.ts.snap
+++ b/tests/test-cases/logPadding/__snapshots__/integration.plain.logPadding.test.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`logs - maxJobNameLength set to 0 1`] = `
+"[94mshort-name[39m [95mstarting[39m shell ([33m.pre[39m)
+[94mshort-name[39m [32m$ echo "short-name"[39m
+[94mshort-name[39m [92m>[39m short-name
+[94mshort-name[39m [95mfinished[39m in [35m15 ms[39m
+
+[30m[102m PASS [49m[39m [94mshort-name[39m"
+`;
+
+exports[`logs - maxJobNameLength set to 30 1`] = `
+"[94mshort-name                    [39m [95mstarting[39m shell ([33m.pre[39m)
+[94mshort-name                    [39m [32m$ echo "short-name"[39m
+[94mshort-name                    [39m [92m>[39m short-name
+[94mshort-name                    [39m [95mfinished[39m in [35m13 ms[39m
+
+[30m[102m PASS [49m[39m [94mshort-name                    [39m"
+`;
+
+exports[`logs - maxJobNameLength unset 1`] = `
+"[94mshort-name                                 [39m [95mstarting[39m shell ([33m.pre[39m)
+[94mshort-name                                 [39m [32m$ echo "short-name"[39m
+[94mshort-name                                 [39m [92m>[39m short-name
+[94mshort-name                                 [39m [95mfinished[39m in [35m14 ms[39m
+
+[30m[102m PASS [49m[39m [94mshort-name                                 [39m"
+`;

--- a/tests/test-cases/logPadding/integration.plain.logPadding.test.ts
+++ b/tests/test-cases/logPadding/integration.plain.logPadding.test.ts
@@ -9,36 +9,26 @@ beforeAll(() => {
 
 const pipelineDirectory = "tests/test-cases/logPadding";
 
-// tip: just `cat __snapshots__/*` to inspect the results
-
-test("logs - maxJobNameLength set to 0", async () => {
+async function verifyLogs ({maxJobNameLength}: {maxJobNameLength?: number}) {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: pipelineDirectory,
         job: ["short-name"],
-        maxJobNameLength: 0,
+        maxJobNameLength,
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines.join("\n")).toMatchSnapshot();
+    // tip: use `cat __snapshots__/*` to inspect the results
+    expect(writeStreams.stdoutLines.join("\n").replace(/[0-9.]+ ms/g, "1 ms")).toMatchSnapshot();
+}
+
+test("logs - maxJobNameLength set to 0", async () => {
+    await verifyLogs({maxJobNameLength: 0});
 });
 
 test("logs - maxJobNameLength set to 30", async () => {
-    const writeStreams = new WriteStreamsMock();
-    await handler({
-        cwd: pipelineDirectory,
-        job: ["short-name"],
-        maxJobNameLength: 30,
-    }, writeStreams);
-
-    expect(writeStreams.stdoutLines.join("\n")).toMatchSnapshot();
+    await verifyLogs({maxJobNameLength: 30});
 });
 
 test("logs - maxJobNameLength unset", async () => {
-    const writeStreams = new WriteStreamsMock();
-    await handler({
-        cwd: pipelineDirectory,
-        job: ["short-name"],
-    }, writeStreams);
-
-    expect(writeStreams.stdoutLines.join("\n")).toMatchSnapshot();
+    await verifyLogs({maxJobNameLength: undefined});
 });

--- a/tests/test-cases/logPadding/integration.plain.logPadding.test.ts
+++ b/tests/test-cases/logPadding/integration.plain.logPadding.test.ts
@@ -1,0 +1,44 @@
+import {WriteStreamsMock} from "../../../src/write-streams-mock";
+import {handler} from "../../../src/handler";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+const pipelineDirectory = "tests/test-cases/logPadding";
+
+// tip: just `cat __snapshots__/*` to inspect the results
+
+test("logs - maxJobNameLength set to 0", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: pipelineDirectory,
+        job: ["short-name"],
+        maxJobNameLength: 0,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatchSnapshot();
+});
+
+test("logs - maxJobNameLength set to 30", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: pipelineDirectory,
+        job: ["short-name"],
+        maxJobNameLength: 30,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatchSnapshot();
+});
+
+test("logs - maxJobNameLength unset", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: pipelineDirectory,
+        job: ["short-name"],
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatchSnapshot();
+});


### PR DESCRIPTION
See #840 

In some case, the job names can get very long (e.g., for parallel matrix). In this case, it's better if we avoid padding the job name (or at least not try to add 150+ padding length, as it makes the output harder to read)

Example with this job
```yml
my-matrix-job:
  stage: .pre
  parallel:
    matrix:
      - MY_VARIABLE:
        - 'very long variable name, for example some URL or long command line parameters'
        - 'another one but shorter'
  script:
    - echo "line 1 - FOO=$MY_VARIABLE"
    - echo "line 2"
```

- Use `--maxJobNameLength=0` to disable any padding.
```shell
gitlab-ci-local --maxJobNameLength=0
```
![image](https://user-images.githubusercontent.com/9151470/235520498-7e80c99a-ee64-48f2-b70a-8441b71efacc.png)

- Use `--maxJobNameLength=50` to add a max padding
```shell
gitlab-ci-local --maxJobNameLength=50
```
![image](https://user-images.githubusercontent.com/9151470/235520558-e41097bf-26a0-4ea9-87fa-cac84389f312.png)


Leave empty to keep the current behavior
![image](https://user-images.githubusercontent.com/9151470/235520446-71889f5c-a4d3-44f9-af46-3bf0dca86a77.png)

