### PR TITLE
Add option "--timestamps" to show timestamps and job duration  in the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ echo "alias gcl='gitlab-ci-local'" >> ~/.bashrc
 gitlab-ci-local --completion >> ~/.bashrc 
 ```
 
+### Logging options
+
+```shell
+export GCL_TIMESTAMPS=true # or --timestamps: show timestamps in logs
+export GCL_MAX_JOB_NAME_LENGTH=30 # or --maxJobNameLength: limit padding around job name
+export GCL_QUIET=true # or --quiet: Suppress all job output
+```
+
 ### List Pipeline Jobs
 
 Sometimes there is the need of knowing which jobs will be added before actually executing the pipeline.

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -170,6 +170,10 @@ export class Argv {
         return this.map.get("artifactsToSource") ?? true;
     }
 
+    get showTimestamps (): boolean {
+        return this.map.get("timestamps") ?? false;
+    }
+
     get maxJobNameLength (): number | undefined {
         return this.map.get("maxJobNameLength");
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,11 @@ import {AssertionError} from "assert";
             description: "Suppress all job output",
             requiresArg: false,
         })
+        .option("timestamps", {
+            type: "boolean",
+            description: "Show timestamps and job duration in the logs",
+            requiresArg: false,
+        })
         .option("maxJobNameLength", {
             type: "number",
             description: "Maximum padding for job name (use <= 0 for no padding)",

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -54,7 +54,7 @@ export class Validator {
             const everyIncluded = dependencies.every((dep: string) => {
                 return needs.some(n => n.job === dep);
             });
-            const assertMsg = `${job.chalkJobName} needs: '${needs.map(n => n.job).join(",")}' doesn't fully contain dependencies: '${dependencies.join(",")}'`;
+            const assertMsg = `${job.formattedJobName} needs: '${needs.map(n => n.job).join(",")}' doesn't fully contain dependencies: '${dependencies.join(",")}'`;
             assert(everyIncluded, assertMsg);
         }
     }

--- a/tests/test-cases/logTimestamps/.gitlab-ci.yml
+++ b/tests/test-cases/logTimestamps/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+---
+build-job:
+  stage: build
+  script:
+    - sleep 1
+    - echo 'test done'
+
+failed-job:
+  stage: .post
+  script:
+    - exit 1

--- a/tests/test-cases/logTimestamps/integration.plain.logTimestamps.test.ts
+++ b/tests/test-cases/logTimestamps/integration.plain.logTimestamps.test.ts
@@ -1,0 +1,38 @@
+import {WriteStreamsMock} from "../../../src/write-streams-mock";
+import {handler} from "../../../src/handler";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+import assert from "assert";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+const pipelineDirectory = "tests/test-cases/logTimestamps";
+
+test("logs - show timestamps", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: pipelineDirectory,
+        timestamps: true,
+    }, writeStreams);
+
+
+    assert(writeStreams.stdoutLines.some(line => /\[\d\d:\d\d:\d\d\s+[0-9.ms ]+].*sleep 1/.test(line)));
+    assert(writeStreams.stdoutLines.some(line => /\[\d\d:\d\d:\d\d\s+[0-9.s ]+].*test done/.test(line)));
+    assert(writeStreams.stdoutLines.some(line => /PASS.*\[[0-9.s ]+].*build-job/.test(line)));
+    assert(writeStreams.stdoutLines.some(line => /FAIL.*\[[0-9.ms ]+].*failed-job/.test(line)));
+});
+
+test("logs - without timestamps", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: pipelineDirectory,
+    }, writeStreams);
+
+
+    // ensure we don't find timestamps by default
+    assert(writeStreams.stdoutLines.every(line => !/\[\d\d:\d\d:\d\d\s+[0-9.ms ]+].*sleep 1/.test(line)));
+    assert(writeStreams.stdoutLines.every(line => !/\[\d\d:\d\d:\d\d\s+[0-9.s ]+].*test done/.test(line)));
+    assert(writeStreams.stdoutLines.every(line => !/PASS.*\[[0-9.s ]+].*build-job/.test(line)));
+});


### PR DESCRIPTION
Resolves #846

Example output

![output with timestamps](https://user-images.githubusercontent.com/9151470/236468276-54e44667-9c49-4903-81be-4f2261ca1ee7.png)

```shell
❯ gcl --timestamps
parsing and downloads finished in 34 ms
[15:17:52 1.15 ms] build-job  starting shell (build)
[15:17:52 6.44 ms] build-job  $ sleep 1
[15:17:53  1.01 s] build-job  $ echo 'test done'
[15:17:53  1.01 s] build-job  > test done
[15:17:53  1.01 s] build-job  finished in 1.01 s
[15:17:53  838 μs] failed-job starting shell (.post)
[15:17:53 6.34 ms] failed-job $ exit 1
[15:17:53 6.73 ms] failed-job finished in 6.73 ms  FAIL 1

 PASS  [ 1.01 s] build-job
 FAIL  [6.73 ms] failed-job
pipeline finished in 1.11 s
```

