### PR TITLE
Add "build" alias to main container if services are enabled (with tests)

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -635,7 +635,7 @@ export class Job {
 
             if (this.services?.length) {
                 dockerCmd += `--network gitlab-ci-local-${this.jobId} `;
-                dockerCmd += `--network-alias=build `;
+                dockerCmd += "--network-alias=build ";
             }
 
             dockerCmd += `--volume ${buildVolumeName}:/gcl-builds `;

--- a/src/job.ts
+++ b/src/job.ts
@@ -635,6 +635,7 @@ export class Job {
 
             if (this.services?.length) {
                 dockerCmd += `--network gitlab-ci-local-${this.jobId} `;
+                dockerCmd += `--network-alias=build `;
             }
 
             dockerCmd += `--volume ${buildVolumeName}:/gcl-builds `;

--- a/tests/test-cases/network-alias-build/.gitlab-ci.yml
+++ b/tests/test-cases/network-alias-build/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+---
+# @Description Run Tests
+test-job:
+  services: [busybox]
+  image: busybox
+  stage: test
+  script:
+    - ping build -c 1 2>&1 >/dev/null
+    - exit $?
+  after_script:
+    - echo ${CI_JOB_STATUS} # success
+# @Description Run Tests
+test-job-failure:
+  services: [busybox]
+  image: busybox
+  stage: test
+  script:
+    - ping nope -c 1 2>&1 >/dev/null
+    - exit $?
+  after_script:
+    - echo ${CI_JOB_STATUS} # failed

--- a/tests/test-cases/network-alias-build/integration.network-alias-build.test.ts
+++ b/tests/test-cases/network-alias-build/integration.network-alias-build.test.ts
@@ -1,8 +1,6 @@
 import {WriteStreamsMock} from "../../../src/write-streams";
 import {handler} from "../../../src/handler";
 import chalk from "chalk";
-import fs from "fs-extra";
-import assert, {AssertionError} from "assert";
 import {initSpawnSpy} from "../../mocks/utils.mock";
 import {WhenStatics} from "../../mocks/when-statics";
 

--- a/tests/test-cases/network-alias-build/integration.network-alias-build.test.ts
+++ b/tests/test-cases/network-alias-build/integration.network-alias-build.test.ts
@@ -1,0 +1,38 @@
+import {WriteStreamsMock} from "../../../src/write-streams";
+import {handler} from "../../../src/handler";
+import chalk from "chalk";
+import fs from "fs-extra";
+import assert, {AssertionError} from "assert";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("succesfull-ping", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/network-alias-build",
+        job: ["test-job"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`{black.bgGreenBright  PASS } {blueBright test-job        }`,
+    ];
+
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test("unsuccesfull-ping", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/network-alias-build",
+        job: ["test-job-failure"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job-failure} {greenBright >} failed`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});


### PR DESCRIPTION
By default in gitlab the main job has an alias "build", added build alias to container when services are used.

See https://gitlab.com/gitlab-org/gitlab-runner/-/issues/27060

This enables connecting to the main container using the build alias for example for chromedriver by using "build" as the hostname. 