### PR TITLE
Allow single references in services field

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -146,9 +146,9 @@ export function servicesEach (jobName: string, gitlabData: any) {
     const services = jobData.services;
     if (!services) return;
 
+    jobData.services = Array.isArray(services) ? services : [services];
     reference(gitlabData, jobData.services);
     jobData.services = jobData.services.flat(5);
-    jobData.services = services;
 
     for (const [i, s] of Object.entries<any>(jobData.services)) {
         jobData.services[i] = servicesComplex(s);

--- a/tests/test-cases/services/.gitlab-ci.yml
+++ b/tests/test-cases/services/.gitlab-ci.yml
@@ -95,3 +95,8 @@ no-tmp:
     - name: greenmaid/basic_listen
   script:
     - echo "I should run normaly"
+
+issue-904:
+  services: !reference [.service-entry-ref]
+  script:
+    - echo "I shouldn't combust into flames"


### PR DESCRIPTION
Addresses https://github.com/firecow/gitlab-ci-local/issues/904, where `gitlab-ci-local` fails to correctly parse GitLab CI configuration if there is a singular `!reference` in the services field.

closes #904 