### PR TITLE
Add missing checks to tests

### DIFF
--- a/tests/test-cases/artifacts-exclude/integration.artifacts-exclude.test.ts
+++ b/tests/test-cases/artifacts-exclude/integration.artifacts-exclude.test.ts
@@ -16,4 +16,5 @@ test("artifacts-exclude <consume-artifacts> --needs --exclude", async () => {
         shellIsolation: true,
     }, writeStreams);
 
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });

--- a/tests/test-cases/artifacts-reports-dotenv/integration.artifacts-reports-dotenv.test.ts
+++ b/tests/test-cases/artifacts-reports-dotenv/integration.artifacts-reports-dotenv.test.ts
@@ -15,6 +15,7 @@ test("artifacts-reports-dotenv <deploy-image> --needs", async () => {
         needs: true,
     }, writeStreams);
 
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });
 
 test("artifacts-reports-dotenv <deploy-shell-iso> --needs", async () => {
@@ -26,6 +27,7 @@ test("artifacts-reports-dotenv <deploy-shell-iso> --needs", async () => {
         shellIsolation: true,
     }, writeStreams);
 
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });
 
 test("artifacts-reports-dotenv <deploy-shell-noiso> --needs", async () => {
@@ -37,4 +39,5 @@ test("artifacts-reports-dotenv <deploy-shell-noiso> --needs", async () => {
         shellIsolation: false,
     }, writeStreams);
 
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });

--- a/tests/test-cases/artifacts-shell/integration.artifacts-shell.test.ts
+++ b/tests/test-cases/artifacts-shell/integration.artifacts-shell.test.ts
@@ -33,4 +33,6 @@ test.concurrent("artifacts-shell --file .gitlab-ci-when-never.yml --shell-isolat
         file: ".gitlab-ci-when-never.yml",
         shellIsolation: true,
     }, writeStreams);
+
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });

--- a/tests/test-cases/cache-key-files/integration.key-files.test.ts
+++ b/tests/test-cases/cache-key-files/integration.key-files.test.ts
@@ -18,4 +18,5 @@ test.concurrent("cache-key-files <consume-cache> --shell-isolation --needs", asy
         shellIsolation: true,
     }, writeStreams);
 
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });

--- a/tests/test-cases/cache-shell/integration.cache-shell.test.ts
+++ b/tests/test-cases/cache-shell/integration.cache-shell.test.ts
@@ -17,4 +17,6 @@ test.concurrent("cache-shell <consume-cache> --shell-isolation --needs", async (
         needs: true,
         shellIsolation: true,
     }, writeStreams);
+
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });

--- a/tests/test-cases/interactive/integration.interactive.test.ts
+++ b/tests/test-cases/interactive/integration.interactive.test.ts
@@ -13,4 +13,6 @@ test("interactive <fake-shell-job>", async () => {
         cwd: "tests/test-cases/interactive",
         job: ["fake-shell-job"],
     }, writeStreams);
+
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });

--- a/tests/test-cases/needs-empty/integration.needs-empty.test.ts
+++ b/tests/test-cases/needs-empty/integration.needs-empty.test.ts
@@ -15,5 +15,5 @@ test("needs-empty <deploy-job> --shell-isolation", async () => {
         shellIsolation: true,
     }, writeStreams);
 
-
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });

--- a/tests/test-cases/never-needs/integration.never-needs.test.ts
+++ b/tests/test-cases/never-needs/integration.never-needs.test.ts
@@ -31,4 +31,6 @@ test("never-needs <test-job-optional> --needs", async () => {
         job: ["test-job-optional"],
         needs: true,
     }, writeStreams);
+
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });


### PR DESCRIPTION
https://github.com/firecow/gitlab-ci-local/pull/448 changed what written to stderr, and so removed the following line from all of the tests ```expect(writeStreams.stderrLines).toEqual([]);```. But, some tests had this line as the only check. So, now there are some tests which basically test nothing.  

For example, if you do the following change and you will see that `artifacts-exclude` still pass:
```diff
--- a/tests/test-cases/artifacts-exclude/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-exclude/.gitlab-ci.yml
@@ -30,8 +30,4 @@ consume-artifacts:
   dependencies: [produce-artifacts]
   script:
     - ls -laR .
-    - '[ -e "ux" ]'
-    - '[ -e "foo/qux/qu" ]'
-    - '[ -e "foo/qux/qu ux" ]'
-    - '[ ! -e foo/bar ]'
-    - '[ ! -e foo/d ]'
+    - '[ ! -e "ux" ]'
+    - '[ ! -e "foo/qux/qu" ]'
+    - '[ ! -e "foo/qux/qu ux" ]'
+    - '[ -e foo/bar ]'
+    - '[ -e foo/d ]'
```