### PR TITLE
Fix bug in on exit handler causing pipelines to return 0 (success)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {Job, cleanupJobResources} from "./job.js";
 
 const jobs: Job[] = [];
 
-process.on("exit", (_: string, code: number) => {
+process.on("exit", (code) => {
     cleanupJobResources(jobs).finally(process.exit(code));
 });
 process.on("SIGINT", (_: string, code: number) => {


### PR DESCRIPTION
closes #1012 

```
mjn@mjn-laptop:~/workspace/firecow-gitlab-ci-local$ node --version && node src/index.js --cwd ../mjn-gitlab-ci-debugging/; echo $?
v18.17.1
parsing and downloads finished in 49 ms
failing_job starting shell (test)
failing_job $ exit 1
failing_job finished in 11 ms  FAIL 1  

 FAIL  failing_job
pipeline finished in 129 ms
1
```

Still works in nodejs18