### PR TITLE
Print AggregateError's properly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ process.on("SIGINT", (_: string, code: number) => {
                 } catch (e: any) {
                     if (e instanceof AssertionError) {
                         process.stderr.write(chalk`{red ${e.message.trim()}}\n`);
+                    } else if (e instanceof AggregateError) {
+                        e.errors.forEach((aggE) => process.stderr.write(chalk`{red ${aggE.stack ?? aggE}}\n`));
                     } else {
                         process.stderr.write(chalk`{red ${e.stack ?? e}}\n`);
                     }


### PR DESCRIPTION
This PR will make it more clear what's going on in situations like this https://github.com/firecow/gitlab-ci-local/issues/371#issuecomment-1800126554

I can't really unittest it properly at the moment, so I'll leave screenshots on how I tested it here.

Added this to `job.ts` `execScripts` function

![image](https://github.com/firecow/gitlab-ci-local/assets/973602/757c8e18-0100-40bb-8c6a-8a42d35b816d)

Ran `node src/index.js --cwd <path-to-whatever>` and got the following output.

![image](https://github.com/firecow/gitlab-ci-local/assets/973602/5664c0cd-2f94-4e6c-8c62-7b0feb603d60)
