### PR TITLE
#1043: Allow script/before_script/after_script to be strings

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -349,15 +349,18 @@ export class Job {
     }
 
     get beforeScripts (): string[] {
-        return this.jobData["before_script"] || [];
+        const beforeScripts = this.jobData["before_script"] || [];
+        return typeof beforeScripts === "string" ? [beforeScripts] : beforeScripts;
     }
 
     get afterScripts (): string[] {
-        return this.jobData["after_script"] || [];
+        const afterScripts = this.jobData["after_script"] || [];
+        return typeof afterScripts === "string" ? [afterScripts] : afterScripts;
     }
 
     get scripts (): string[] {
-        return this.jobData["script"];
+        const script = this.jobData["script"];
+        return typeof script === "string" ? [script] : script;
     }
 
     get trigger (): any {

--- a/tests/test-cases/scripts-as-string/.gitlab-ci.yml
+++ b/tests/test-cases/scripts-as-string/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+test-job:
+  before_script: echo "Before test"
+  script: echo "Test something"
+  after_script: echo "After test"

--- a/tests/test-cases/scripts-as-string/integration.scripts-as-string.test.ts
+++ b/tests/test-cases/scripts-as-string/integration.scripts-as-string.test.ts
@@ -1,0 +1,24 @@
+import {WriteStreamsMock} from "../../../src/write-streams";
+import {handler} from "../../../src/handler";
+import chalk from "chalk";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("scripts-as-string <test-job>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/scripts-as-string",
+        job: ["test-job"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Before test`,
+        chalk`{blueBright test-job} {greenBright >} Test something`,
+        chalk`{blueBright test-job} {greenBright >} After test`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});


### PR DESCRIPTION
Fix #1043