### PR TITLE
Upgrade the example to use the new docker compose plugin.

### DIFF
--- a/examples/docker-compose-nodejs/.gitlab-ci.yml
+++ b/examples/docker-compose-nodejs/.gitlab-ci.yml
@@ -29,7 +29,7 @@ docker-compose-up:
     url: http://localhost:8891
     name: local
   script:
-    - docker-compose up -d
+    - docker compose up -d
 
 # @Description Down docker-compose services
 docker-compose-down:
@@ -40,4 +40,4 @@ docker-compose-down:
   environment:
     name: local
   script:
-    - docker-compose down
+    - docker compose down

--- a/examples/docker-compose-nodejs/README.md
+++ b/examples/docker-compose-nodejs/README.md
@@ -1,16 +1,16 @@
-# docker-compose nodejs example
+# docker compose nodejs example
 
 - Install npm packages
     - Copy those packages to host and child jobs, because of the artifacts fields (npm-install)
 - Check for security vulnerbilities in npm packages (npm-audit)
 - Check for outdated packages via npm-check-updates package (npm-outdated)
-- Deploy a webserver container via docker-compose (docker-compose-up)
+- Deploy a webserver container via docker compose (docker-compose-up)
 
 ```bash
 gitlab-ci-local --cwd examples/docker-compose-nodejs/
 ```
 
-If you want to down docker-compose service call.
+If you want to down docker compose service call.
 
 This job is only run locally, and only when manually triggered
 


### PR DESCRIPTION
According the documentation at https://docs.docker.com/compose/reference/:

> Effective July 2023, Compose V1 stopped receiving updates and is no longer in new Docker Desktop releases. Compose V2 has replaced it and is now integrated into all current Docker Desktop versions.

The example should not use the old docker-compose command (Compose V1).