### PR TITLE
argv.ts - respect stateDir when reading dotenv

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -13,7 +13,7 @@ export class Argv {
             this.map.set(key, value);
         }
 
-        this.injectDotenv(`${this.home}/.gitlab-ci-local/.env`, argv);
+        this.injectDotenv(`${this.home}/${this.stateDir}/.env`, argv);
         this.injectDotenv(`${this.cwd}/.gitlab-ci-local-env`, argv);
     }
 


### PR DESCRIPTION
if stateDir is redefined we'd look up for dotenv file under correct path