### PR TITLE
Lowercase `CI_REGISTRY_IMAGE`

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -164,7 +164,7 @@ export class Job {
         predefinedVariables["CI_NODE_INDEX"] = `${opt.nodeIndex}`;
         predefinedVariables["CI_NODE_TOTAL"] = `${opt.nodesTotal}`;
         predefinedVariables["CI_REGISTRY"] = `local-registry.${this.gitData.remote.host}`;
-        predefinedVariables["CI_REGISTRY_IMAGE"] = `$CI_REGISTRY/${this._variables["CI_PROJECT_PATH"]}`;
+        predefinedVariables["CI_REGISTRY_IMAGE"] = `$CI_REGISTRY/${this._variables["CI_PROJECT_PATH"]}`.toLowerCase();
 
         // Find environment matched variables
         if (this.environment) {


### PR DESCRIPTION
Container images have to be lowercased. A quick read of <https://docs.gitlab.com/ee/ci/variables/predefined_variables.html> does not mention that GitLab automatically lowercases `CI_REGISTRY_IMAGE`, but it does so in practice (see below)

![Screenshot 2024-02-01 194921](https://github.com/firecow/gitlab-ci-local/assets/7536431/8b2c8c6a-8e3f-4c2f-a8b4-b9db55961109)

I don't know if GitLab lowercases only the project path (as in the screenshot), or if it lowercases the `CI_SERVER_HOST` as well. I assume it does both, so I have placed the `toLowerCase` on the outside of the string, instead of after the `this._variables`.