### PR TITLE
Add `--extra-host` arguments to services

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1035,6 +1035,10 @@ export class Job {
             dockerCmd += `--volume ${volume} `;
         }
 
+        for (const extraHost of this.argv.extraHost) {
+            dockerCmd += `--add-host=${extraHost} `;
+        }
+
         const serviceAlias = service.alias;
         const serviceName = service.name;
         const serviceNameWithoutVersion = serviceName.replace(/(.*)(:.*)/, "$1");

--- a/tests/test-cases/extra-host/.gitlab-ci.yml
+++ b/tests/test-cases/extra-host/.gitlab-ci.yml
@@ -3,3 +3,12 @@ test-job:
   image: docker.io/curlimages/curl:7.69.1
   script:
     - curl -I http://fake-google.com
+
+service-job:
+  image: docker.io/curlimages/curl:7.69.1
+  services:
+    - name: docker.io/alpine:latest
+      entrypoint: ["/bin/sh", "-c"]
+      command: ["getent hosts fake-google.com"]
+  script:
+    - "true"

--- a/tests/test-cases/extra-host/integration.extra-host.test.ts
+++ b/tests/test-cases/extra-host/integration.extra-host.test.ts
@@ -3,6 +3,7 @@ import {handler} from "../../../src/handler";
 import chalk from "chalk";
 import {initSpawnSpy} from "../../mocks/utils.mock";
 import {WhenStatics} from "../../mocks/when-statics";
+import fs from "fs-extra";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
@@ -17,7 +18,22 @@ test("add-host <test-job>", async () => {
     }, writeStreams);
 
     const expected = [
-        chalk`{blueBright test-job} {greenBright >} HTTP/1.1 404 Not Found`,
+        chalk`{blueBright test-job   } {greenBright >} HTTP/1.1 404 Not Found`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+});
+
+test("add-host <service-job>", async () => {
+    await fs.promises.rm("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log", {force: true});
+
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/extra-host",
+        job: ["service-job"],
+        extraHost: ["fake-google.com:142.250.185.206"],
+    }, writeStreams);
+
+    expect(writeStreams.stderrLines.length).toEqual(2);
+    expect(await fs.pathExists("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log")).toEqual(true);
+    expect(await fs.readFile("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log", "utf-8")).toMatch(/142.250.185.206/);
 });


### PR DESCRIPTION
When running a `docker:dind` service I realized that the `--extra-host` arguments passed to `gitlab-ci-local` get passed to the running image, but not to the services, which broke the resolution for my finagled `$CI_REGISTRY_IMAGE` in the docker in docker container (since the registry was resolved in the service container when using `docker buildx build --push`).

Since the services already get the same volumes as the main container, I think it makes sense to pass the `extra-host` args as well. What do you think? I don't know how controversial this change is, so if you think this is a bad idea, feel free to close the PR 😅 .

P.S. Is the test fine like this? I mostly cobbled it together by combining the existing [`add-host <test-job>`](https://github.com/firecow/gitlab-ci-local/blob/51542a6a4ce6f394d45551af6a7db9be4e79540b/tests/test-cases/extra-host/integration.extra-host.test.ts#L11-L23) test with the [`services <multie-job>`](https://github.com/firecow/gitlab-ci-local/blob/51542a6a4ce6f394d45551af6a7db9be4e79540b/tests/test-cases/services/integration.services.test.ts#L112-L129) test.