### PR TITLE
Fix `CI_REGISTRY_IMAGE` (again)

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -164,7 +164,7 @@ export class Job {
         predefinedVariables["CI_NODE_INDEX"] = `${opt.nodeIndex}`;
         predefinedVariables["CI_NODE_TOTAL"] = `${opt.nodesTotal}`;
         predefinedVariables["CI_REGISTRY"] = `local-registry.${this.gitData.remote.host}`;
-        predefinedVariables["CI_REGISTRY_IMAGE"] = `$CI_REGISTRY/${this._variables["CI_PROJECT_PATH"]}`.toLowerCase();
+        predefinedVariables["CI_REGISTRY_IMAGE"] = `$CI_REGISTRY/${this._variables["CI_PROJECT_PATH"].toLowerCase()}`;
 
         // Find environment matched variables
         if (this.environment) {

--- a/src/predefined-variables.ts
+++ b/src/predefined-variables.ts
@@ -17,7 +17,7 @@ export function init ({gitData, argv}: PredefinedVariablesOpts): {[name: string]
         CI_PROJECT_NAME: gitData.remote.project,
         CI_PROJECT_TITLE: `${camelCase(gitData.remote.project)}`,
         CI_PROJECT_PATH: `${gitData.remote.group}/${gitData.remote.project}`,
-        CI_PROJECT_PATH_SLUG: `${gitData.remote.group.replace(/\//g, "-")}-${gitData.remote.project}`,
+        CI_PROJECT_PATH_SLUG: `${gitData.remote.group.replace(/\//g, "-")}-${gitData.remote.project}`.toLowerCase(),
         CI_PROJECT_NAMESPACE: `${gitData.remote.group}`,
         CI_PROJECT_VISIBILITY: "internal",
         CI_PROJECT_ID: "1217",

--- a/tests/test-cases/predefined-variables/.gitlab-ci.yml
+++ b/tests/test-cases/predefined-variables/.gitlab-ci.yml
@@ -2,6 +2,7 @@
 test-job:
   script:
     - echo ${CI_PROJECT_NAME}
+    - echo ${CI_PROJECT_PATH}
     - echo ${CI_PROJECT_PATH_SLUG}
     - echo ${CI_PROJECT_NAMESPACE}
     - echo ${CI_PROJECT_DIR}

--- a/tests/test-cases/predefined-variables/.gitlab-ci.yml
+++ b/tests/test-cases/predefined-variables/.gitlab-ci.yml
@@ -6,6 +6,7 @@ test-job:
     - echo ${CI_PROJECT_NAMESPACE}
     - echo ${CI_PROJECT_DIR}
     - echo ${CI_DEFAULT_BRANCH}
+    - echo ${CI_REGISTRY_IMAGE}
 
 test-job-commit-short-length:
   script:

--- a/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
+++ b/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
@@ -18,7 +18,8 @@ test("predefined-variables <test-job>", async () => {
 
     const expected = [
         chalk`{blueBright test-job                    } {greenBright >} predefined-variables`,
-        chalk`{blueBright test-job                    } {greenBright >} GCL-predefined-variables`,
+        chalk`{blueBright test-job                    } {greenBright >} GCL/predefined-variables`,
+        chalk`{blueBright test-job                    } {greenBright >} gcl-predefined-variables`,
         chalk`{blueBright test-job                    } {greenBright >} GCL`,
         chalk`{blueBright test-job                    } {greenBright >} ${process.cwd()}/tests/test-cases/predefined-variables`,
         chalk`{blueBright test-job                    } {greenBright >} main`,

--- a/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
+++ b/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
@@ -8,7 +8,7 @@ test("predefined-variables <test-job>", async () => {
     const writeStreams = new WriteStreamsMock();
     const spyGitRemote = {
         cmdArgs: ["git", "remote", "-v"],
-        returnValue: {stdout: "origin\tgit@gitlab.com:gcl/predefined-variables.git (fetch)\norigin\tgit@gitlab.com:gcl/predefined-variables.git (push)\n"},
+        returnValue: {stdout: "origin\tgit@gitlab.com:GCL/predefined-variables.git (fetch)\norigin\tgit@gitlab.com:GCL/predefined-variables.git (push)\n"},
     };
     initSpawnSpy([...WhenStatics.all, spyGitRemote]);
     await handler({
@@ -18,10 +18,11 @@ test("predefined-variables <test-job>", async () => {
 
     const expected = [
         chalk`{blueBright test-job                    } {greenBright >} predefined-variables`,
-        chalk`{blueBright test-job                    } {greenBright >} gcl-predefined-variables`,
-        chalk`{blueBright test-job                    } {greenBright >} gcl`,
+        chalk`{blueBright test-job                    } {greenBright >} GCL-predefined-variables`,
+        chalk`{blueBright test-job                    } {greenBright >} GCL`,
         chalk`{blueBright test-job                    } {greenBright >} ${process.cwd()}/tests/test-cases/predefined-variables`,
         chalk`{blueBright test-job                    } {greenBright >} main`,
+        chalk`{blueBright test-job                    } {greenBright >} local-registry.gitlab.com/gcl/predefined-variables`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });


### PR DESCRIPTION
Hi, while running the master branch locally, I realized that my change in #1085 actually broke `CI_REGISTRY_IMAGE`. The reason is that the full string gets lowercased (i.e. something like `$ci_registry/some/lowercased/path`), which means `$CI_REGISTRY` does not get resolved (because the variable name was lowercased) 😅 . Thats what I get for not testing properly 🤦 .

I have added some tests now to make sure the behaviour is correct now (incidentally, I checked the [gitlab source code](https://gitlab.com/gitlab-org/gitlab/-/blob/0c47378a58c35c234c4eae0d9274763db1cdc7f1/app/models/project.rb#L1291-1295) and it seems they only lowercase the path, not the host, so this code matches the upstream behaviour more closely).

While writing the test I realized that `CI_PROJECT_PATH_SLUG` also needs to be lowercased to match [the upstream behaviour](https://gitlab.com/gitlab-org/gitlab/-/blob/5f43fbc0042ec34e37fbe2531b314b4708a9bbe2/doc/ci/variables/predefined_variables.md#L109).

Sorry for the trouble 😓 