### PR TITLE
fix: some of before_script/after_script failed to be flattened

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -221,7 +221,8 @@ export function globalVariables (gitlabData: any) {
 
 export function flattenLists (gitlabData: any) {
     traverse(gitlabData, ({parent, key, value}) => {
-        if (!Array.isArray(value) || parent == null || typeof key != "string") return;
-        parent[key] = value.flat(5);
-    });
+        if (parent != null && key != null && Array.isArray(value)) {
+            parent[key] = value.flat(5);
+        }
+    }, {cycleHandling: false});
 }

--- a/tests/test-cases/reference/.gitlab-ci-issue-954.yml
+++ b/tests/test-cases/reference/.gitlab-ci-issue-954.yml
@@ -1,0 +1,14 @@
+---
+.hidden:
+  script:
+    - echo Hello from ${CI_JOB_NAME}
+
+normal_job:
+  image: alpine
+  before_script:
+    - !reference [.hidden, script]  # before_script and after_script under a job work
+  script:
+    - !reference [.hidden, script]  # This also works
+
+after_script:
+  - !reference [.hidden, script]  # before_script and after_script in root of YAML document fail

--- a/tests/test-cases/reference/integration.reference.test.ts
+++ b/tests/test-cases/reference/integration.reference.test.ts
@@ -1,6 +1,5 @@
 import {WriteStreamsMock} from "../../../src/write-streams";
 import {handler} from "../../../src/handler";
-import chalk from "chalk";
 import {initSpawnSpy} from "../../mocks/utils.mock";
 import {WhenStatics} from "../../mocks/when-statics";
 
@@ -13,17 +12,30 @@ test("reference <test-job>", async () => {
     await handler({
         cwd: "tests/test-cases/reference",
         job: ["test-job"],
+        preview: true,
     }, writeStreams);
 
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - test
+  - deploy
+  - .post
+test-job:
+  variables:
+    MYVAR: Yoyo
+  script:
+    - echo "Ancient"
+    - echo "Base"
+    - echo "Setting something general up"
+    - echo "array root"
+    - echo \${MYVAR}
+issue-909:
+  script:
+    - echo TEST`;
 
-    const expected = [
-        chalk`{blueBright test-job } {greenBright >} Ancient`,
-        chalk`{blueBright test-job } {greenBright >} Base`,
-        chalk`{blueBright test-job } {greenBright >} Setting something general up`,
-        chalk`{blueBright test-job } {greenBright >} array root`,
-        chalk`{blueBright test-job } {greenBright >} Yoyo`,
-    ];
-    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
 
 test("reference --file .gitlab-ci-complex.yml (issue 644)", async () => {
@@ -31,12 +43,22 @@ test("reference --file .gitlab-ci-complex.yml (issue 644)", async () => {
     await handler({
         cwd: "tests/test-cases/reference",
         file: ".gitlab-ci-complex.yml",
+        preview: true,
     }, writeStreams);
 
-    const expected = [
-        chalk`{blueBright job} {greenBright >} foo`,
-    ];
-    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - test
+  - deploy
+  - .post
+job:
+  variables:
+    FOO: foo
+  script:
+    - echo $FOO`;
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
 
 test("reference --file .gitlab-ci-issue-899.yml", async () => {
@@ -44,10 +66,20 @@ test("reference --file .gitlab-ci-issue-899.yml", async () => {
     await handler({
         cwd: "tests/test-cases/reference",
         file: ".gitlab-ci-issue-899.yml",
+        preview: true,
     }, writeStreams);
 
-    const expected = [
-        chalk`{blueBright job} {greenBright >} works`,
-    ];
-    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - test
+  - deploy
+  - .post
+job:
+  image:
+    name: docker.io/library/bash
+  script:
+    - echo "works"`;
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });

--- a/tests/test-cases/reference/integration.reference.test.ts
+++ b/tests/test-cases/reference/integration.reference.test.ts
@@ -83,3 +83,30 @@ job:
     - echo "works"`;
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
+
+test("reference --file .gitlab-ci-issue-954.yml", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/reference",
+        file: ".gitlab-ci-issue-954.yml",
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - test
+  - deploy
+  - .post
+normal_job:
+  image:
+    name: alpine
+  before_script:
+    - echo Hello from \${CI_JOB_NAME}
+  script:
+    - echo Hello from \${CI_JOB_NAME}
+  after_script:
+    - echo Hello from \${CI_JOB_NAME}`;
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});


### PR DESCRIPTION
make use of `--preview` in test cases to make it easier to write expected test output and also speed up test suites
and fixes some yaml referenced tag's value did not get flattened which closes #954 