### PR TITLE
Allow inclusion of the same file multiple times when `inputs:` is used

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -72,7 +72,11 @@ export class ParserIncludes {
                 const files = await globby([value["local"].replace(/^\//, ""), ...excludedGlobs], {dot: true, cwd});
                 for (const localFile of files) {
                     const content = await Parser.loadYaml(`${cwd}/${localFile}`, {inputs: value.inputs || {}});
-                    excludedGlobs.push(`!${localFile}`);
+                    // If the file is included with `inputs:` set, the user might want to include it
+                    // again with different values, so we cannot exclude it.
+                    if(!value["inputs"]) {
+                        excludedGlobs.push(`!${localFile}`);
+                    }
                     includeDatas = includeDatas.concat(await this.init(content, depth, opts));
                 }
             } else if (value["project"]) {

--- a/tests/test-cases/include-inputs/input-templates/basic-example/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/basic-example/.gitlab-ci.yml
@@ -2,8 +2,12 @@
 include:
   - local: './.gitlab-ci-input-template.yml'
     inputs:
-      message: hello world
+      message: hello website
       options_input: website
+  - local: './.gitlab-ci-input-template.yml'
+    inputs:
+      message: hello db
+      options_input: db
 
 stages:
   - test

--- a/tests/test-cases/include-inputs/integration.include-inputs.test.ts
+++ b/tests/test-cases/include-inputs/integration.include-inputs.test.ts
@@ -23,9 +23,14 @@ stages:
   - .post
 scan-website:
   script:
-    - echo hello world
-    - echo hello world
-    - echo hello world`;
+    - echo hello website
+    - echo hello website
+    - echo hello website
+scan-db:
+  script:
+    - echo hello db
+    - echo hello db
+    - echo hello db`;
 
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });


### PR DESCRIPTION
Fixes #1121 .

This is the simplest solution I could think of to fix the issue (though I am not too sure about the reason for the exclusion being used in the first place, so I might have overlooked something).