### PR TITLE
fix: add validation for include local to prevent false valid configurations

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -32,6 +32,7 @@ export class Argv {
     get cwd (): string {
         let cwd = this.map.get("cwd") ?? ".";
         assert(typeof cwd != "object", "--cwd option cannot be an array");
+        assert(!cwd.startsWith("/") && !cwd.startsWith("~"), "Please use relative path for the --cwd option");
         cwd = path.normalize(`${process.cwd()}/${cwd}`);
         cwd = cwd.replace(/\/$/, "");
         assert(fs.pathExistsSync(cwd), `${cwd} is not a directory`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,4 +252,3 @@ process.on("SIGINT", (_: string, code: number) => {
         })
         .parse();
 })();
-

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -40,6 +40,7 @@ export class ParserIncludes {
                 }
             }
             if (value["local"]) {
+                validateIncludeLocal(value["local"]);
                 const files = await globby(value["local"].replace(/^\//, ""), {dot: true, cwd});
                 if (files.length == 0) {
                     throw new AssertionError({message: `Local include file cannot be found ${value["local"]}`});
@@ -195,4 +196,9 @@ export class ParserIncludes {
             throw new AssertionError({message: `Project include could not be fetched { project: ${project}, ref: ${ref}, file: ${normalizedFile} }\n${e}`});
         }
     }
+}
+
+function validateIncludeLocal (filePath: string) {
+    assert(!filePath.startsWith("./"), `\`${filePath}\` for include:local is invalid. Gitlab does not support relative path (ie. cannot start with \`./\`).`);
+    assert(!filePath.includes(".."), `\`${filePath}\` for include:local is invalid. Gitlab does not support directory traversal.`);
 }

--- a/tests/test-cases/include-inputs/input-templates/basic-example/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/basic-example/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       message: hello world
       options_input: website

--- a/tests/test-cases/include-inputs/input-templates/default/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/default/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       default_can_be_overwritten: "overwrite default value"
 stages:

--- a/tests/test-cases/include-inputs/input-templates/options-validation/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/options-validation/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       options_input: "fizz"
 stages:

--- a/tests/test-cases/include-inputs/input-templates/required-inputs/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/required-inputs/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
 stages:
   - test

--- a/tests/test-cases/include-inputs/input-templates/too-many-functions-in-interpolation-block/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/too-many-functions-in-interpolation-block/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       foo: "fizz"
 stages:

--- a/tests/test-cases/include-inputs/input-templates/type-validation/boolean/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/type-validation/boolean/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       boolean_input: "true"
 stages:

--- a/tests/test-cases/include-inputs/input-templates/type-validation/number/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/type-validation/number/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       number_input: "1"
 stages:

--- a/tests/test-cases/include-inputs/input-templates/type-validation/string/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/type-validation/string/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       string_input: 1
 stages:

--- a/tests/test-cases/include-inputs/input-templates/type-validation/unsupported/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/type-validation/unsupported/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
     inputs:
       unsupported_type_input: "true"
 stages:

--- a/tests/test-cases/include-inputs/input-templates/unknown-interpolation-key-1/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/unknown-interpolation-key-1/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
 stages:
   - test

--- a/tests/test-cases/include-inputs/input-templates/unknown-interpolation-key-2/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/unknown-interpolation-key-2/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
 include:
-  - local: './.gitlab-ci-input-template.yml'
+  - local: '/.gitlab-ci-input-template.yml'
 stages:
   - test

--- a/tests/test-cases/include-local/.gitlab-ci-invalid-config-directory-traversal.yml
+++ b/tests/test-cases/include-local/.gitlab-ci-invalid-config-directory-traversal.yml
@@ -1,0 +1,3 @@
+---
+include:
+  local: "../include-local/.gitlab-ci.yml"

--- a/tests/test-cases/include-local/.gitlab-ci-invalid-config-relative-path.yml
+++ b/tests/test-cases/include-local/.gitlab-ci-invalid-config-relative-path.yml
@@ -1,0 +1,3 @@
+---
+include:
+  local: "./.gitlab-ci.yml"


### PR DESCRIPTION
- `gitlab-ci-local` generates false positive. 
  For the two new test cases for the `include-input` test suites,  
  when running the config via `gitlab-ci-local` it has no issue, but Gitlab is unable to parse these configs.


- smuggled a [one liner](https://github.com/firecow/gitlab-ci-local/pull/1124/commits/03f84733a31ddd50a0db6ce3fa41f661bc9c038f)