### PR TITLE
fix(#1137): only add image.docker.user if the value exists

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -163,7 +163,7 @@ export function imageComplex (data: any) {
     return {
         name: typeof data === "string" ? data : data.name,
         entrypoint: data.entrypoint,
-        docker: {user: data.docker?.user ?? null},
+        ...(data.docker?.user ? { docker: {user: data.docker?.user}} : {}),
     };
 }
 

--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -163,7 +163,7 @@ export function imageComplex (data: any) {
     return {
         name: typeof data === "string" ? data : data.name,
         entrypoint: data.entrypoint,
-        ...(data.docker?.user ? { docker: {user: data.docker?.user}} : {}),
+        ...(data.docker?.user ? {docker: {user: data.docker?.user}} : {}),
     };
 }
 

--- a/tests/test-cases/reference/integration.reference.test.ts
+++ b/tests/test-cases/reference/integration.reference.test.ts
@@ -79,8 +79,6 @@ stages:
 job:
   image:
     name: docker.io/library/bash
-    docker:
-      user: null
   script:
     - echo "works"`;
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
@@ -104,8 +102,6 @@ stages:
 normal_job:
   image:
     name: alpine
-    docker:
-      user: null
   before_script:
     - echo Hello from \${CI_JOB_NAME}
   script:


### PR DESCRIPTION
This fixes #1137

With the original YML in the ticket:

```yaml
my_job:
  image: node:lts
  script:
    - echo 'test'
```
The rendering of the `--preview` option is now safe (no more `image.docker.user: null`):

```bash
$ node ../test-gitlab-ci-local/gitlab-ci-local/src/index.js --preview
---
stages:
  - .pre
  - build
  - test
  - deploy
  - .post
my_job:
  image:
    name: node:lts
  script:
    - echo 'test'
```
And it passes the `ci/lint` validation:

```bash
$ jq --null-input --arg yaml "$(node ../test-gitlab-ci-local/gitlab-ci-local/src/index.js --preview)" '.content=$yaml' \
| curl "https://gitlab.com/api/v4/projects/${PROJECT_ID}/ci/lint" \
	--header "Authorization: Bearer ${GITLAB_TOKEN}" \
	--header 'Content-Type: application/json' \
	--data @- | jq '.errors'

[]
```

I also deleted the `image.docker.user: null` in the test cases.