### PR TITLE
fix(#1139): only add needs.need.pipeline and needs.need.project if the value exists

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -90,8 +90,8 @@ export function needsComplex (data: any) {
         job: data.job ?? data,
         artifacts: data.artifacts ?? true,
         optional: data.optional ?? false,
-        pipeline: data.pipeline ?? null,
-        project: data.project ?? null,
+        ...(data.pipeline ? { pipeline: data.pipeline } : {}),
+        ...(data.project ? { project: data.project } : {}),
     };
 }
 

--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -90,8 +90,8 @@ export function needsComplex (data: any) {
         job: data.job ?? data,
         artifacts: data.artifacts ?? true,
         optional: data.optional ?? false,
-        ...(data.pipeline ? { pipeline: data.pipeline } : {}),
-        ...(data.project ? { project: data.project } : {}),
+        ...(data.pipeline ? {pipeline: data.pipeline} : {}),
+        ...(data.project ? {project: data.project} : {}),
     };
 }
 


### PR DESCRIPTION
This fixes #1139 

With the original YML in the ticket:

```yml
my_job:
  script:
    - echo 'test'

my_job2:
  needs:
  	- my_job
  script:
    - echo 'test'
```

The rendering of the `--preview` option is now safe (no more `needs.need.pipeline: null` and `needs.need.project: null`):

```bash
$ node ../test-gitlab-ci-local/gitlab-ci-local/src/index.js --preview
---
stages:
  - .pre
  - build
  - test
  - deploy
  - .post
my_job:
  script:
    - echo 'test'
my_job2:
  needs:
    - job: my_job
      artifacts: true
      optional: false
  script:
    - echo 'test'
```
And it passes the ci/lint validation:

```bash
$ jq --null-input --arg yaml "$(node ../test-gitlab-ci-local/gitlab-ci-local/src/index.js --preview)" '.content=$yaml' \
| curl "https://gitlab.com/api/v4/projects/${PROJECT_ID}/ci/lint" \
	--header "Authorization: Bearer ${GITLAB_TOKEN}" \
	--header 'Content-Type: application/json' \
	--data @- | jq '.errors'

[]
```
 