### PR TITLE
allow gcl to work with duplicated keys but with warnings

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -259,7 +259,18 @@ export class Parser {
             },
         });
         const schema = yaml.DEFAULT_SCHEMA.extend([referenceType]);
-        const fileData = yaml.loadAll(fileSplitClone.join("\n"), null, {schema}) as any[];
+        let fileData;
+
+        try {
+            fileData = yaml.loadAll(fileSplitClone.join("\n"), null, {schema}) as any[];
+        } catch (e: any) {
+            if (e instanceof yaml.YAMLException && e.reason === "duplicated mapping key") {
+                console.log(chalk`{black.bgYellowBright  WARN } duplicated mapping key detected! Values will be overwritten!`);
+                fileData = yaml.loadAll(fileSplitClone.join("\n"), null, {schema, json: true}) as any[];
+            } else {
+                throw e;
+            }
+        }
 
         if (fileData.length == 1) return fileData[0];
 

--- a/tests/test-cases/duplicated-keys/.gitlab-ci.yml
+++ b/tests/test-cases/duplicated-keys/.gitlab-ci.yml
@@ -1,0 +1,25 @@
+---
+variables: &foo
+  FOO: "1"
+
+variables: &bar  # yamllint disable-line rule:key-duplicates
+  BAR: "2"
+
+duplicated-keys:
+  script:
+    - echo "$FOO"
+    - echo "$BAR"
+  variables:
+    <<: *bar
+
+duplicated-keys anchor tag can still be referenced:
+  script:
+    - echo "$FOO"
+    - echo "$BAR"
+  variables:
+    <<: *foo
+
+duplicated-keys variables overwritten:
+  script:
+    - echo "$FOO"
+    - echo "$BAR"

--- a/tests/test-cases/duplicated-keys/integration.environment.test.ts
+++ b/tests/test-cases/duplicated-keys/integration.environment.test.ts
@@ -1,0 +1,64 @@
+import {WriteStreamsMock} from "../../../src/write-streams";
+import {handler} from "../../../src/handler";
+import chalk from "chalk";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+
+test("duplicated-keys <duplicated-keys>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/duplicated-keys",
+        job: ["duplicated-keys"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`\n{blueBright duplicated-keys} {green $ echo \"$FOO\"}`,
+        chalk`{blueBright duplicated-keys} {greenBright >} `,
+        chalk`{blueBright duplicated-keys} {green $ echo \"$BAR\"}`,
+        chalk`{blueBright duplicated-keys} {greenBright >} 2`,
+    ];
+
+
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
+});
+
+test("duplicated-keys <duplicated-keys variables overwritten>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/duplicated-keys",
+        job: ["duplicated-keys variables overwritten"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`\n{blueBright duplicated-keys variables overwritten} {green $ echo \"$FOO\"}`,
+        chalk`{blueBright duplicated-keys variables overwritten} {greenBright >} `,
+        chalk`{blueBright duplicated-keys variables overwritten} {green $ echo \"$BAR\"}`,
+        chalk`{blueBright duplicated-keys variables overwritten} {greenBright >} 2`,
+    ];
+
+
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
+});
+
+test("duplicated-keys <duplicated-keys anchor tag can still be referenced>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/duplicated-keys",
+        job: ["duplicated-keys anchor tag can still be referenced"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`\n{blueBright duplicated-keys anchor tag can still be referenced} {green $ echo \"$FOO\"}`,
+        chalk`{blueBright duplicated-keys anchor tag can still be referenced} {greenBright >} 1`,
+        chalk`{blueBright duplicated-keys anchor tag can still be referenced} {green $ echo \"$BAR\"}`,
+        chalk`{blueBright duplicated-keys anchor tag can still be referenced} {greenBright >} 2`,
+    ];
+
+
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
+});


### PR DESCRIPTION
fixes #1047

Just because gitlab supports this

but personally i find that it is very error prone so added a `WARN` message to alert the users