### PR TITLE
fix: cleanupJobResource

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ process.on("SIGINT", async (_: string, code: number) => {
     process.exit(code);
 });
 
+// Graceful shutdown for nodemon
+process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
+
 (() => {
     const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, "../package.json"), "utf8"));
     yargs(process.argv.slice(2))

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,8 @@ process.on("SIGINT", async (_: string, code: number) => {
                     } else {
                         process.stderr.write(chalk`{red ${e.stack ?? e}}\n`);
                     }
-                    cleanupJobResources(jobs).finally(process.exit(1));
+                    await cleanupJobResources(jobs);
+                    process.exit(1);
                 }
             },
             builder: (y: any) => {

--- a/src/job.ts
+++ b/src/job.ts
@@ -506,12 +506,10 @@ export class Job {
 
         if (!this.argv.cleanup) return;
 
-        for (const id of this._containersToClean) {
-            try {
-                await Utils.spawn([this.argv.containerExecutable, "rm", "-vf", `${id}`]);
-            } catch (e) {
-                assert(e instanceof Error, "e is not instanceof Error");
-            }
+        try {
+            await Utils.spawn([this.argv.containerExecutable, "rm", "-vf", ...this._containersToClean]);
+        } catch (e) {
+            assert(e instanceof Error, "e is not instanceof Error");
         }
 
         if (this._serviceNetworkId) {
@@ -522,14 +520,10 @@ export class Job {
             }
         }
 
-        if (this._containerVolumeNames.length > 0) {
-            try {
-                for (const containerVolume of this._containerVolumeNames) {
-                    await Utils.spawn([this.argv.containerExecutable, "volume", "rm", `${containerVolume}`]);
-                }
-            } catch (e) {
-                assert(e instanceof Error, "e is not instanceof Error");
-            }
+        try {
+            await Utils.spawn([this.argv.containerExecutable, "volume", "rm", ...this._containerVolumeNames]);
+        } catch (e) {
+            assert(e instanceof Error, "e is not instanceof Error");
         }
 
         const rmPromises = [];


### PR DESCRIPTION
`docker rm` and `docker volume rm` supports multiple args. 

this should probably be slightly more efficient.



Not too sure why, but the current cleanup also seemed to leave some `docker volume` undeleted

To replicated the issue:

```yaml
# .gitlab-ci.yml
job0:
  image: bash
  script: echo hi
```

```bash
for i in $(seq 1 9); do
 gitlab-ci-local
done
```


Run `docker volume ls` and observe that there are remaing `xxxxx-tmp` volume that are not cleaned up
