### PR TITLE
fix: escape single quote env var for docker executor

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -691,7 +691,8 @@ export class Job {
             }
 
             for (const [key, val] of Object.entries(expanded)) {
-                dockerCmd += `-e '${key}=${val}' `;
+                // Replacing `'` with `'\''` to correctly handle single quotes(if `val` contains `'`) in shell commands
+                dockerCmd += `-e '${key}=${val.replace(/'/g, "'\\''")}' `;
             }
 
             if (this.imageEntrypoint) {
@@ -1116,7 +1117,8 @@ export class Job {
         }
 
         for (const [key, val] of Object.entries(expanded)) {
-            dockerCmd += `-e '${key}=${val}' `;
+            // Replacing `'` with `'\''` to correctly handle single quotes(if `val` contains `'`) in shell commands
+            dockerCmd += `-e '${key}=${val.replace(/'/g, "'\\''")}' `;
         }
 
         const serviceEntrypoint = service.entrypoint;

--- a/src/job.ts
+++ b/src/job.ts
@@ -692,7 +692,7 @@ export class Job {
 
             for (const [key, val] of Object.entries(expanded)) {
                 // Replacing `'` with `'\''` to correctly handle single quotes(if `val` contains `'`) in shell commands
-                dockerCmd += `-e '${key}=${val.replace(/'/g, "'\\''")}' `;
+                dockerCmd += `  -e '${key}=${val.replace(/'/g, "'\\''")}' \\\n`;
             }
 
             if (this.imageEntrypoint) {
@@ -1118,7 +1118,7 @@ export class Job {
 
         for (const [key, val] of Object.entries(expanded)) {
             // Replacing `'` with `'\''` to correctly handle single quotes(if `val` contains `'`) in shell commands
-            dockerCmd += `-e '${key}=${val.replace(/'/g, "'\\''")}' `;
+            dockerCmd += `  -e '${key}=${val.replace(/'/g, "'\\''")}' \\\n`;
         }
 
         const serviceEntrypoint = service.entrypoint;

--- a/tests/test-cases/variable-expansion/.gitlab-ci.yml
+++ b/tests/test-cases/variable-expansion/.gitlab-ci.yml
@@ -18,3 +18,15 @@ test ${${ENV}_URL}:
   variables:
     URL: ${${ENV}_URL}
     ENV: DEV
+
+docker-executor variables with ':
+  image: alpine
+  script:
+    - echo $CI_JOB_NAME
+
+docker-executor services variables with ':
+  services:
+    - nginx
+  image: alpine
+  script:
+    - echo $CI_JOB_NAME

--- a/tests/test-cases/variable-expansion/integration.variable-expansion.test.ts
+++ b/tests/test-cases/variable-expansion/integration.variable-expansion.test.ts
@@ -39,3 +39,31 @@ test(`variable-expansion <${test_job_2}>`, async () => {
 
     expect(writeStreams.stdoutLines.slice(1, -3)).toEqual(expected);
 });
+
+const test_job_3 = "docker-executor services variables with '";
+test(`variable-expansion <${test_job_3}>`, async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/variable-expansion",
+        job: [test_job_3],
+    }, writeStreams);
+
+    const expected = chalk`{blueBright ${test_job_3}} {green $ echo $CI_JOB_NAME}
+{blueBright ${test_job_3}} {greenBright >} ${test_job_3}`;
+
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected);
+});
+
+const test_job_4 = "docker-executor variables with '";
+test(`variable-expansion <${test_job_4}>`, async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/variable-expansion",
+        job: [test_job_4],
+    }, writeStreams);
+
+    const expected = chalk`{blueBright ${test_job_4}} {green $ echo $CI_JOB_NAME}
+{blueBright ${test_job_4}} {greenBright >} ${test_job_4}`;
+
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected);
+});

--- a/tests/test-cases/variable-expansion/integration.variable-expansion.test.ts
+++ b/tests/test-cases/variable-expansion/integration.variable-expansion.test.ts
@@ -16,12 +16,10 @@ test(`variable-expansion <${test_job_1}>`, async () => {
         job: [test_job_1],
     }, writeStreams);
 
-    const expected = [
-        chalk`{blueBright ${test_job_1}} {green $ echo $URL}`,
-        chalk`{blueBright ${test_job_1}} {greenBright >} url-dev`,
-    ];
+    const expected = chalk`{blueBright ${test_job_1}} {green $ echo $URL}
+{blueBright ${test_job_1}} {greenBright >} url-dev`;
 
-    expect(writeStreams.stdoutLines.slice(1, -3)).toEqual(expected);
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected);
 });
 
 const test_job_2 = "test ${${ENV}_URL}";
@@ -32,12 +30,10 @@ test(`variable-expansion <${test_job_2}>`, async () => {
         job: [test_job_2],
     }, writeStreams);
 
-    const expected = [
-        chalk`{blueBright ${test_job_2}} {green $ echo $URL}`,
-        chalk`{blueBright ${test_job_2}} {greenBright >} dev-url`,
-    ];
+    const expected = chalk`{blueBright ${test_job_2}} {green $ echo $URL}
+{blueBright ${test_job_2}} {greenBright >} dev-url`;
 
-    expect(writeStreams.stdoutLines.slice(1, -3)).toEqual(expected);
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected);
 });
 
 const test_job_3 = "docker-executor services variables with '";


### PR DESCRIPTION
Fixes the error for the following `gitlab-ci.yml`
```
docker-executor variables with ':
  image: alpine
  script:
    - echo $CI_JOB_NAME
```

```
docker-executor services variables with ':
  services:
    - nginx
  image: alpine
  script:
    - echo $CI_JOB_NAME
 ```