### PR TITLE
refactor(umask integration tests): use non root images instead of building it

### DIFF
--- a/tests/test-cases/umask/.gitlab-ci.yml
+++ b/tests/test-cases/umask/.gitlab-ci.yml
@@ -1,22 +1,13 @@
 ---
-build-job:
-  script:
-    - |
-      docker build -q -t debug:ci-${CI_PIPELINE_IID} -f - . <<EOF
-      FROM alpine
-      USER guest
-      EOF
-
 alpine-guest:
-  needs: [build-job]
-  image: debug:ci-${CI_PIPELINE_IID}
+  image: nginxinc/nginx-unprivileged:alpine3.18
   script:
     - stat -c "%a %n %u %g" one.txt
     - stat -c "%a %n %u %g" script.sh
 
 alpine-root:
   needs: []
-  image: alpine
+  image: nginx:alpine3.18
   script:
     - stat -c "%a %n %u %g" one.txt
     - stat -c "%a %n %u %g" script.sh

--- a/tests/test-cases/umask/integration.umask.test.ts
+++ b/tests/test-cases/umask/integration.umask.test.ts
@@ -10,12 +10,11 @@ beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
 });
 
-test.concurrent("umask <alpine-guest> --umask --needs", async () => {
+test.concurrent("umask <alpine-guest> --umask", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/umask/",
         umask: true,
-        needs: true,
         job: ["alpine-guest"],
     }, writeStreams);
 
@@ -26,27 +25,25 @@ test.concurrent("umask <alpine-guest> --umask --needs", async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdOut));
 });
 
-test.concurrent("umask <alpine-guest> --no-umask --needs", async () => {
+test.concurrent("umask <alpine-guest> --no-umask", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/umask/",
         umask: false,
-        needs: true,
         job: ["alpine-guest"],
     }, writeStreams);
 
     const expectedStdOut = [
-        chalk`{blueBright alpine-guest} {greenBright >} 666 one.txt 405 100`,
-        chalk`{blueBright alpine-guest} {greenBright >} 777 script.sh 405 100`,
+        chalk`{blueBright alpine-guest} {greenBright >} 666 one.txt 101 101`,
+        chalk`{blueBright alpine-guest} {greenBright >} 777 script.sh 101 101`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdOut));
 });
 
-test.concurrent("umask <alpine-root> --umask --needs", async () => {
+test.concurrent("umask <alpine-root> --umask", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/umask/",
-        needs: true,
         umask: true,
         job: ["alpine-root"],
     }, writeStreams);
@@ -58,11 +55,10 @@ test.concurrent("umask <alpine-root> --umask --needs", async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdOut));
 });
 
-test.concurrent("umask <alpine-root> --no-umask --needs", async () => {
+test.concurrent("umask <alpine-root> --no-umask", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/umask/",
-        needs: true,
         umask: false,
         job: ["alpine-root"],
     }, writeStreams);


### PR DESCRIPTION
a small refactor to the unit test as a pre-requisite to  https://github.com/firecow/gitlab-ci-local/issues/1171

on a side note, should'nt `--umask` be default to `false` instead ? Which should be closer to gitlab-ci default
