### PR TITLE
fix: cast global variable values to string

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -224,7 +224,9 @@ export function globalVariables (gitlabData: any) {
         if (value === null) {
             gitlabData.variables[key] = ""; // variable's values are nullable
         } else if (Utils.isObject(value)) {
-            gitlabData.variables[key] = value["value"];
+            gitlabData.variables[key] = String(value["value"]);
+        } else {
+            gitlabData.variables[key] = String(value);
         }
     }
 }


### PR DESCRIPTION
### Description
Running the following, 
```yaml
---
variables:
  FOO: 1

job:
  image: alpine
  script:
    - echo hello
```

throws the following error,
```
TypeError: val.replace is not a function.
```

### Additional context
Job's variables are casted to `String` as seen:
 https://github.com/firecow/gitlab-ci-local/blob/0286e76abe7bd85cb744bb5500904d58029d0de5/src/parser.ts#L121

We might have forgotten to cast the global variable
