### PR TITLE
fix: remove extra spaces in the yaml dump when ajv validation fails

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -19,10 +19,10 @@ export class Validator {
         const validate = ajv.compile(schema);
         const valid = validate(data);
         assert(valid,
-            chalk`
-    Invalid gitlab-ci configuration! It have failed the json schema validation. Dump the following to the pipeline editor to debug:
-    ${yaml.dump(data)}
-    `);
+            chalk`Invalid gitlab-ci configuration! It have failed the json schema validation. Dump the following to the pipeline editor to debug:
+
+${yaml.dump(data)}
+`);
     }
 
     private static needs (jobs: ReadonlyArray<Job>, stages: readonly string[]): string[] {


### PR DESCRIPTION
![image](https://github.com/firecow/gitlab-ci-local/assets/28011783/336c9ae9-d446-44c1-82fa-41302d01fbd6)