### PR TITLE
fix: Allow specifying multiple networks

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -677,10 +677,6 @@ export class Job {
                 dockerCmd += "--network-alias=build ";
             }
 
-            for (const network of this.argv.network) {
-                dockerCmd += `--network ${network} `;
-            }
-
             dockerCmd += `--volume ${buildVolumeName}:/gcl-builds `;
             dockerCmd += `--volume ${tmpVolumeName}:${this.fileVariablesDir} `;
             dockerCmd += "--workdir /gcl-builds ";
@@ -736,6 +732,11 @@ export class Job {
             dockerCmd += "fi\n\"";
 
             const {stdout: containerId} = await Utils.bash(dockerCmd, cwd);
+
+            for (const network of this.argv.network) {
+                await Utils.spawn([this.argv.containerExecutable, "network", "connect", network, `${containerId}`]);
+            }
+
             this._containerId = containerId;
             this._containersToClean.push(this._containerId);
         }
@@ -1163,6 +1164,10 @@ export class Job {
 
         const {stdout: containerId} = await Utils.bash(dockerCmd, cwd);
         this._containersToClean.push(containerId);
+
+        for (const network of this.argv.network) {
+            await Utils.spawn([this.argv.containerExecutable, "network", "connect", network, `${containerId}`]);
+        }
 
         await Utils.spawn([this.argv.containerExecutable, "start", `${containerId}`]);
 


### PR DESCRIPTION
[Apparently](https://stackoverflow.com/questions/34110416/start-container-with-multiple-network-interfaces) one cannot pass multiple `--network` flags to `docker create`. I stumbled across this when attempting to add a network to a `.gitlab-ci.yml` with a `service` (since the service definition makes gitlab-ci-local create a custom network).

## Issue Reproduction

```yml
# .gitlab-ci.yml
job:
  services:
    - docker:dind
  image: alpine
  script:
    - ip a
```

```console
$ docker network create custom-net
$ gitlab-ci-local --network custom-net
parsing and downloads finished in 37 ms
job starting alpine:latest (test)
job copied to docker volumes in 909 ms
job started service image: docker:dind with aliases: docker in 395 ms
job service image: docker:dind healthcheck passed in 1.76 s
Error: Command failed with exit code 1: docker create --interactive  --privileged --user 0:0 --network gitlab-ci-local-98064 --network-alias=build --network custom-net --volume gcl-job-98064-build:/gcl-builds --volume gcl-job-98064-tmp:/tmp/gitlab-ci-local-file-variables-pigeonf-dotfiles-98064 --workdir /gcl-builds
...
Error response from daemon: Container cannot be connected to network endpoints: gitlab-ci-local-98064, custom-net
    at makeError (/nix/store/47ggy1w98zgi64cfn8n8spbk7k832i32-gitlab-ci-local-4.48.2/lib/node_modules/gitlab-ci-local/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/nix/store/47ggy1w98zgi64cfn8n8spbk7k832i32-gitlab-ci-local-4.48.2/lib/node_modules/gitlab-ci-local/node_modules/execa/index.js:118:26)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Job.execScripts (/nix/store/47ggy1w98zgi64cfn8n8spbk7k832i32-gitlab-ci-local-4.48.2/lib/node_modules/gitlab-ci-local/src/job.ts:744:43)
    at Job.execPreScripts (/nix/store/47ggy1w98zgi64cfn8n8spbk7k832i32-gitlab-ci-local-4.48.2/lib/node_modules/gitlab-ci-local/src/job.ts:608:36)
    at Job.start (/nix/store/47ggy1w98zgi64cfn8n8spbk7k832i32-gitlab-ci-local-4.48.2/lib/node_modules/gitlab-ci-local/src/job.ts:505:9)
    at /nix/store/47ggy1w98zgi64cfn8n8spbk7k832i32-gitlab-ci-local-4.48.2/lib/node_modules/gitlab-ci-local/node_modules/p-map/index.js:57:22
```

## Solution

The networks can be connected after creation of the container with `docker network connect`. This should work regardless of the number of networks. The only network that is connected "directly" is the service network.

I have also made sure to connect the service container to the specified networks as well.