### PR TITLE
fix: git remote get-url origin for git:// can contain dots

### DIFF
--- a/src/git-data.ts
+++ b/src/git-data.ts
@@ -117,7 +117,7 @@ export class GitData {
                 this.remote.schema = gitRemoteMatch.groups.schema;
                 this.remote.port = gitRemoteMatch.groups.port ?? "22";
             } else {
-                gitRemoteMatch = /(?<username>\S+)@(?<host>[^:]+):(?<group>\S+)\/(?<project>[^ .]+)\.git/.exec(gitRemote); // regexr.com/7vjoq
+                gitRemoteMatch = /(?<username>\S+)@(?<host>[^:]+):(?<group>\S+)\/(?<project>\S+)\.git/.exec(gitRemote); // regexr.com/7vjoq
                 assert(gitRemoteMatch?.groups != null, "git remote get-url origin didn't provide valid matches");
 
                 const {stdout} = await Utils.spawn(["ssh", "-G", `${gitRemoteMatch.groups.username}@${gitRemoteMatch.groups.host}`]);


### PR DESCRIPTION
The regexr comment actually had the solution. @ANGkeith 
// regexr.com/7vjoq

Our current solution dosn't work if projects containers a `.`

`git@github.com:fire/cow/example.com.git`