### PR TITLE
Implement plain `parallel:` keyword

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -169,7 +169,9 @@ export class Job {
         predefinedVariables["CI_ENVIRONMENT_NAME"] = this.environment?.name ?? "";
         predefinedVariables["CI_ENVIRONMENT_SLUG"] = this.environment?.name?.replace(/[^a-z\d]+/ig, "-").replace(/^-/, "").slice(0, 23).replace(/-$/, "").toLowerCase() ?? "";
         predefinedVariables["CI_ENVIRONMENT_URL"] = this.environment?.url ?? "";
-        predefinedVariables["CI_NODE_INDEX"] = `${opt.nodeIndex}`;
+        if (opt.nodeIndex !== null) {
+            predefinedVariables["CI_NODE_INDEX"] = `${opt.nodeIndex}`;
+        }
         predefinedVariables["CI_NODE_TOTAL"] = `${opt.nodesTotal}`;
         predefinedVariables["CI_REGISTRY"] = `local-registry.${this.gitData.remote.host}`;
         predefinedVariables["CI_REGISTRY_IMAGE"] = `$CI_REGISTRY/${this._variables["CI_PROJECT_PATH"].toLowerCase()}`;

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -1,12 +1,16 @@
 import assert from "assert";
 import deepExtend from "deep-extend";
 
-export function matrixVariablesList (jobData: any, jobName: string) {
-    if (Number.isInteger(jobData.parallel)) {
+export function isPlainParallel (jobData: any) {
+    return Number.isInteger(jobData.parallel);
+}
+
+export function matrixVariablesList (jobData: any, jobName: string): {[key: string]: string}[] | null[] {
+    if (isPlainParallel(jobData)) {
         return Array(jobData.parallel).fill(null);
     }
     if (jobData?.parallel?.matrix == null) {
-        return null;
+        return [null];
     }
     assert(Array.isArray(jobData.parallel.matrix), `${jobName} parallel.matrix is not an array`);
 

--- a/src/parallel.ts
+++ b/src/parallel.ts
@@ -2,6 +2,9 @@ import assert from "assert";
 import deepExtend from "deep-extend";
 
 export function matrixVariablesList (jobData: any, jobName: string) {
+    if (Number.isInteger(jobData.parallel)) {
+        return Array(jobData.parallel).fill(null);
+    }
     if (jobData?.parallel?.matrix == null) {
         return null;
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -151,11 +151,11 @@ export class Parser {
 
             let nodeIndex = 1;
             const parallelMatrixVariablesList = parallel.matrixVariablesList(jobData, jobName);
-            for (const parallelMatrixVariables of (parallelMatrixVariablesList ?? [null])) {
+            for (const parallelMatrixVariables of parallelMatrixVariablesList) {
                 let matrixJobName = jobName;
                 if (parallelMatrixVariables) {
                     matrixJobName = `${jobName}: [${Object.values(parallelMatrixVariables ?? []).join(",")}]`;
-                } else if (parallelMatrixVariablesList) {
+                } else if (parallel.isPlainParallel(jobData)) {
                     matrixJobName = `${jobName}: [${nodeIndex}/${parallelMatrixVariablesList.length}]`;
                 }
 
@@ -171,8 +171,8 @@ export class Parser {
                     gitData,
                     variablesFromFiles,
                     matrixVariables: parallelMatrixVariables,
-                    nodeIndex: (parallelMatrixVariablesList) ? nodeIndex : null,
-                    nodesTotal: parallelMatrixVariablesList?.length ?? 1,
+                    nodeIndex: (jobData.parallel != null) ? nodeIndex : null,
+                    nodesTotal: parallelMatrixVariablesList.length,
                     expandVariables: this.expandVariables,
                 });
                 const foundStage = this.stages.includes(job.stage);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -150,11 +150,13 @@ export class Parser {
             assert(variablesFromFiles != null, "homeVariables must be set");
 
             let nodeIndex = 1;
-            const parallelMatrixVariablesList = parallel.matrixVariablesList(jobData, jobName) ?? [null];
-            for (const parallelMatrixVariables of parallelMatrixVariablesList) {
+            const parallelMatrixVariablesList = parallel.matrixVariablesList(jobData, jobName);
+            for (const parallelMatrixVariables of (parallelMatrixVariablesList ?? [null])) {
                 let matrixJobName = jobName;
                 if (parallelMatrixVariables) {
                     matrixJobName = `${jobName}: [${Object.values(parallelMatrixVariables ?? []).join(",")}]`;
+                } else if (parallelMatrixVariablesList) {
+                    matrixJobName = `${jobName}: [${nodeIndex}/${parallelMatrixVariablesList.length}]`;
                 }
 
                 const job = new Job({
@@ -169,8 +171,8 @@ export class Parser {
                     gitData,
                     variablesFromFiles,
                     matrixVariables: parallelMatrixVariables,
-                    nodeIndex: parallelMatrixVariables !== null ? nodeIndex : null,
-                    nodesTotal: parallelMatrixVariablesList.length,
+                    nodeIndex: (parallelMatrixVariablesList) ? nodeIndex : null,
+                    nodesTotal: parallelMatrixVariablesList?.length ?? 1,
                     expandVariables: this.expandVariables,
                 });
                 const foundStage = this.stages.includes(job.stage);

--- a/src/schema/schema.json
+++ b/src/schema/schema.json
@@ -1272,7 +1272,7 @@
           "type": "integer",
           "description": "Creates N instances of the job that run in parallel.",
           "default": 0,
-          "minimum": 2,
+          "minimum": 1,
           "maximum": 200
         },
         {

--- a/tests/test-cases/parallel/.gitlab-ci.yml
+++ b/tests/test-cases/parallel/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+---
+test-job:
+  stage: build
+  script:
+    - echo "$CI_NODE_INDEX/$CI_NODE_TOTAL"
+  parallel: 2

--- a/tests/test-cases/parallel/.gitlab-ci.yml
+++ b/tests/test-cases/parallel/.gitlab-ci.yml
@@ -4,3 +4,9 @@ test-job:
   script:
     - echo "$CI_NODE_INDEX/$CI_NODE_TOTAL"
   parallel: 2
+
+single-job:
+  stage: build
+  script:
+    - echo "$CI_NODE_INDEX/$CI_NODE_TOTAL"
+  parallel: 1

--- a/tests/test-cases/parallel/integration.parallel.test.ts
+++ b/tests/test-cases/parallel/integration.parallel.test.ts
@@ -32,3 +32,16 @@ test("parallel 'test-job [1/2]'", async () => {
         chalk`{blueBright test-job: [2/2]} {greenBright >} 2/2`,
     ]));
 });
+
+test("parallel 'single-job'", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/parallel",
+        job: ["single-job"],
+        shellIsolation: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining([
+        chalk`{blueBright single-job: [1/1]} {greenBright >} 1/1`,
+    ]));
+});

--- a/tests/test-cases/parallel/integration.parallel.test.ts
+++ b/tests/test-cases/parallel/integration.parallel.test.ts
@@ -1,0 +1,34 @@
+import {WriteStreamsMock} from "../../../src/write-streams";
+import {handler} from "../../../src/handler";
+import chalk from "chalk";
+
+test("parallel <test-job>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/parallel",
+        job: ["test-job"],
+        shellIsolation: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining([
+        chalk`{blueBright test-job: [1/2]} {greenBright >} 1/2`,
+        chalk`{blueBright test-job: [2/2]} {greenBright >} 2/2`,
+    ]));
+});
+
+test("parallel 'test-job [1/2]'", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/parallel",
+        job: ["test-job: [1/2]"],
+        shellIsolation: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining([
+        chalk`{blueBright test-job: [1/2]} {greenBright >} 1/2`,
+    ]));
+
+    expect(writeStreams.stdoutLines).not.toEqual(expect.arrayContaining([
+        chalk`{blueBright test-job: [2/2]} {greenBright >} 2/2`,
+    ]));
+});

--- a/tests/test-cases/predefined-variables/.gitlab-ci.yml
+++ b/tests/test-cases/predefined-variables/.gitlab-ci.yml
@@ -8,6 +8,7 @@ test-job:
     - echo ${CI_PROJECT_DIR}
     - echo ${CI_DEFAULT_BRANCH}
     - echo ${CI_REGISTRY_IMAGE}
+    - echo ${CI_NODE_INDEX}/${CI_NODE_TOTAL}
 
 test-job-commit-short-length:
   script:

--- a/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
+++ b/tests/test-cases/predefined-variables/integration.predefined-variables.test.ts
@@ -24,6 +24,7 @@ test("predefined-variables <test-job>", async () => {
         chalk`{blueBright test-job} {greenBright >} ${process.cwd()}/tests/test-cases/predefined-variables`,
         chalk`{blueBright test-job} {greenBright >} main`,
         chalk`{blueBright test-job} {greenBright >} local-registry.gitlab.com/gcl/predefined-variables`,
+        chalk`{blueBright test-job} {greenBright >} /1`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });


### PR DESCRIPTION
See <https://docs.gitlab.com/ee/ci/yaml/#parallel>.

When writing the test I saw that there was some verification of the schema (e.g. I could not set `parallel: 1`), but when running `gitlab-ci-local` directly it works fine. Is this intended behaviour? There is now an edge case here, which I cannot test for at the moment: Setting `parallel: 1` works on <https://gitlab.com>, but I cannot write a test for it because it does not match the official schema (which is apparently wrong, I have filed <https://gitlab.com/gitlab-org/gitlab/-/issues/462979>).

This fixes #1227 .