### PR TITLE
Remove defaults from yargs, they cannot be overridden by other GCL mechanism

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -254,8 +254,8 @@ export class Argv {
         return this.map.get("containerExecutable") ?? "docker";
     }
 
-    get enableJsonSchemaValidation (): boolean {
-        return this.map.get("enableJsonSchemaValidation") ?? false;
+    get jsonSchemaValidation (): boolean {
+        return this.map.get("jsonSchemaValidation") ?? false;
     }
 
     get shellExecutorNoImage (): boolean {

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -255,7 +255,7 @@ export class Argv {
     }
 
     get enableJsonSchemaValidation (): boolean {
-        return this.map.get("enableJsonSchemaValidation") ?? true;
+        return this.map.get("enableJsonSchemaValidation") ?? false;
     }
 
     get shellExecutorNoImage (): boolean {

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -213,6 +213,7 @@ export class Argv {
     }
 
     get shellIsolation (): boolean {
+        // TODO: default to true in 5.x.x
         return this.map.get("shellIsolation") ?? false;
     }
 
@@ -225,6 +226,7 @@ export class Argv {
     }
 
     get artifactsToSource (): boolean {
+        // TODO: default to false in 5.x.x
         return this.map.get("artifactsToSource") ?? true;
     }
 
@@ -255,6 +257,7 @@ export class Argv {
     }
 
     get jsonSchemaValidation (): boolean {
+        // TODO: default to true in 5.x.x
         return this.map.get("jsonSchemaValidation") ?? false;
     }
 

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -159,6 +159,7 @@ export class Argv {
     }
 
     get umask (): boolean {
+        // TODO: default to false in 5.x.x
         return this.map.get("umask") ?? true;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,6 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             type: "boolean",
             description: "Whether to use shell executor when no image is specified.",
             requiresArg: false,
-            // TODO: default to false in 5.x.x
-            default: true,
         })
         .option("mount-cache", {
             type: "boolean",
@@ -172,8 +170,6 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             type: "boolean",
             description: "Sets docker user to 0:0",
             requiresArg: false,
-            // TODO: default to false in 5.x.x
-            default: true,
         })
         .option("privileged", {
             type: "boolean",
@@ -214,13 +210,11 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             type: "boolean",
             description: "Copy the generated artifacts into cwd",
             requiresArg: false,
-            default: true,
         })
         .option("cleanup", {
             type: "boolean",
             description: "Remove docker resources after they've been used",
             requiresArg: false,
-            default: true,
         })
         .option("quiet", {
             type: "boolean",
@@ -241,7 +235,6 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             type: "boolean",
             description: "Whether to enable json schema validation",
             requiresArg: false,
-            default: false,
         })
         .option("concurrency", {
             type: "number",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -66,7 +66,7 @@ export class Parser {
         }
 
         // # Second layer of check for errors that are not caught in Validator.run
-        if (parser.argv.enableJsonSchemaValidation) {
+        if (parser.argv.jsonSchemaValidation) {
             const time = process.hrtime();
             Validator.jsonSchemaValidation(parser.gitlabData);
             writeStreams.stderr(chalk`{grey json schema validated} in {grey ${prettyHrtime(process.hrtime(time))}}\n`);

--- a/tests/test-cases/artifacts-dotenv/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-dotenv/.gitlab-ci.yml
@@ -22,6 +22,6 @@ use-service-ref:
   services:
     - name: $SERVICE_IMAGE_REF
       alias: $SERVICE_IMAGE_ALIAS
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script:
     - host $SERVICE_IMAGE_ALIAS

--- a/tests/test-cases/extra-host/integration.extra-host.test.ts
+++ b/tests/test-cases/extra-host/integration.extra-host.test.ts
@@ -9,7 +9,7 @@ beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
 });
 
-test("add-host <test-job>", async () => {
+test("extra-host <test-job>", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/extra-host",
@@ -23,7 +23,7 @@ test("add-host <test-job>", async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test("add-host <service-job>", async () => {
+test("extra-host <service-job>", async () => {
     await fs.promises.rm("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log", {force: true});
 
     const writeStreams = new WriteStreamsMock();
@@ -33,7 +33,7 @@ test("add-host <service-job>", async () => {
         extraHost: ["fake-google.com:142.250.185.206"],
     }, writeStreams);
 
-    expect(writeStreams.stderrLines.length).toEqual(3);
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/true/);
     expect(await fs.pathExists("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log")).toEqual(true);
     expect(await fs.readFile("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log", "utf-8")).toMatch(/142.250.185.206/);
 });

--- a/tests/test-cases/plain/integration.plain.test.ts
+++ b/tests/test-cases/plain/integration.plain.test.ts
@@ -14,6 +14,7 @@ test("plain", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/plain",
+        jsonSchemaValidation: true,
     }, writeStreams);
 
     expect(writeStreams.stdoutLines.length).toEqual(16);

--- a/tests/test-cases/services/.gitlab-ci.yml
+++ b/tests/test-cases/services/.gitlab-ci.yml
@@ -22,18 +22,18 @@ test-job:
     - name: docker.io/library/alpine
       entrypoint: ["/bin/sh", "-c"]
       command: ["sh"]
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script: host docker.io-library-nginx
 
 build-job:
   stage: build
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script: host docker.io-library-nginx
 
 deploy-job:
   services: [docker.io/library/redis]
   stage: deploy
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script:
     - host docker.io-library-nginx && exit 1
     - host docker.io-library-redis
@@ -46,7 +46,7 @@ multiport-job:
       variables:
         MYSQL_ROOT_PASSWORD: secret
   stage: deploy
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script:
     - host docker.io-library-mysql
 
@@ -55,7 +55,7 @@ alias-job:
     - name: docker.io/library/redis
       alias: redis-alias
   stage: deploy
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script:
     - host docker.io-library-redis
     - host redis-alias
@@ -65,7 +65,7 @@ alias-job-multiple-slashes:
     - name: gcr.io/google-containers/redis
       alias: redis-alias
   stage: deploy
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script:
     - host gcr.io-google-containers-redis
     - host gcr.io__google-containers__redis
@@ -84,7 +84,7 @@ multie-job:
         ENV_TEST: Service 3
       entrypoint: ["/bin/sh", "-c"]
       command: ["echo $ENV_TEST"]
-  image: docker.io/tutum/dnsutils
+  image: docker.io/massenz/dnsutils:2.4.0
   script:
     - echo "Hello"
 

--- a/tests/test-cases/services/integration.services.test.ts
+++ b/tests/test-cases/services/integration.services.test.ts
@@ -120,7 +120,7 @@ test.concurrent("services <multie-job>", async () => {
         job: ["multie-job"],
     }, writeStreams);
 
-    expect(writeStreams.stderrLines.length).toEqual(5);
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/Hello/);
     expect(await fs.pathExists("tests/test-cases/services/.gitlab-ci-local/services-output/multie-job/docker.io/library/alpine:latest-0.log")).toEqual(true);
     expect(await fs.pathExists("tests/test-cases/services/.gitlab-ci-local/services-output/multie-job/docker.io/library/alpine:latest-1.log")).toEqual(true);
     expect(await fs.pathExists("tests/test-cases/services/.gitlab-ci-local/services-output/multie-job/docker.io/library/alpine:latest-2.log")).toEqual(true);


### PR DESCRIPTION
- Remove the enable part from enableJsonSchemaValidation CLI option, no other bool CLI options has the word enable so it seems redundant

- Replace line count in all tests other than plain  (less assertion roulette)

- Replace dnsutils with a maintained one

closes https://github.com/firecow/gitlab-ci-local/issues/1233