### PR TITLE
update example for docker-in-docker-build-with-local-registry

### DIFF
--- a/examples/docker-in-docker-build-with-local-registry/.gitlab-ci-local-variables.yml
+++ b/examples/docker-in-docker-build-with-local-registry/.gitlab-ci-local-variables.yml
@@ -1,2 +1,2 @@
 ---
-CI_REGISTRY_IMAGE: "10.11.22.33:5000/docker-in-docker-build-with-local-registry"
+CI_REGISTRY_IMAGE: "gitlab-ci-local-registry:5000/docker-in-docker-build-with-local-registry"

--- a/examples/docker-in-docker-build-with-local-registry/.gitlab-ci-local-variables.yml
+++ b/examples/docker-in-docker-build-with-local-registry/.gitlab-ci-local-variables.yml
@@ -1,2 +1,2 @@
 ---
-CI_REGISTRY_IMAGE: "gitlab-ci-local-registry:5000/docker-in-docker-build-with-local-registry"
+CI_REGISTRY: "gitlab-ci-local-registry:5000"

--- a/examples/docker-in-docker-build-with-local-registry/.gitlab-ci.yml
+++ b/examples/docker-in-docker-build-with-local-registry/.gitlab-ci.yml
@@ -4,7 +4,7 @@ alpine-image:
   services:
     - name: docker:dind
       command:
-        - --insecure-registry=10.11.22.33:5000
+        - --insecure-registry=gitlab-ci-local-registry:5000
   needs: []
   image: docker:latest
   stage: build

--- a/examples/docker-in-docker-build-with-local-registry/README.md
+++ b/examples/docker-in-docker-build-with-local-registry/README.md
@@ -5,7 +5,7 @@ See how the project is configured in [.gitlab-ci-local-env](.gitlab-ci-local-env
 
 #### Before you can run if you don't have any local registry.
 ```bash
-docker network create --driver bridge gitlab-ci-local-registry
+docker network create gitlab-ci-local-registry
 docker run -d --network gitlab-ci-local-registry --name gitlab-ci-local-registry registry:2
 ```
 

--- a/examples/docker-in-docker-build-with-local-registry/README.md
+++ b/examples/docker-in-docker-build-with-local-registry/README.md
@@ -5,11 +5,11 @@ See how the project is configured in [.gitlab-ci-local-env](.gitlab-ci-local-env
 
 #### Before you can run if you don't have any local registry.
 ```bash
-docker network create gitlab-ci-local-registry --subnet=10.11.22.0/24
-docker run -d -p 5000:5000 --network gitlab-ci-local-registry --ip=10.11.22.33 --name gitlab-ci-local-registry registry
+docker network create --driver bridge gitlab-ci-local-registry
+docker run -d --network gitlab-ci-local-registry --name gitlab-ci-local-registry registry:2
 ```
 
 #### Start by calling.
 ```bash
-gitlab-ci-local --cwd examples/docker-in-docker-build-with-local-registry/
+gitlab-ci-local --network gitlab-ci-local-registry --cwd examples/docker-in-docker-build-with-local-registry/
 ```


### PR DESCRIPTION
The current example was failing with the CI unable to connect to the registry.

Updating the example to avoid hardcoding IP and exposing 5000 to external network.