### PR TITLE
Change jsonSchemaValidation default to false

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -253,7 +253,8 @@ export class Argv {
     }
 
     get jsonSchemaValidation (): boolean {
-        return this.map.get("jsonSchemaValidation") ?? true;
+        // TODO: defaults to true in 5.x.x
+        return this.map.get("jsonSchemaValidation") ?? false;
     }
 
     get shellExecutorNoImage (): boolean {


### PR DESCRIPTION
Our developers found many issues today with this approach, a lot of local pipelines was failing.

I'll compile a list of issues tomorrow, but let's disable this and publish a 4.50.1 for now, so developers can get on with their work.

