### PR TITLE
Do not validate formats and remove all string patterns from schema.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "4.50.0",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.14.0",
-        "ajv-formats": "^3.0.1",
+        "ajv": "8.x.x",
         "axios": "0.28.x",
         "base64url": "3.x.x",
         "camelcase": "6.x.x",
@@ -1909,22 +1908,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "dev": "touch .gitlab-ci.yml && nodemon -e ts --watch src --watch .gitlab-ci.yml --exec ts-node src/index.ts"
   },
   "dependencies": {
-    "ajv": "^8.14.0",
-    "ajv-formats": "^3.0.1",
+    "ajv": "8.x.x",
     "axios": "0.28.x",
     "base64url": "3.x.x",
     "camelcase": "6.x.x",

--- a/src/schema/schema.json
+++ b/src/schema/schema.json
@@ -396,8 +396,7 @@
             "local": {
               "description": "Relative path from local repository root (`/`) to the `yaml`/`yml` file template. The file must be on the same branch, and does not work across git submodules.",
               "type": "string",
-              "format": "uri-reference",
-              "pattern": "\\.ya?ml$"
+              "format": "uri-reference"
             },
             "rules": {
               "$ref": "#/definitions/includeRules"
@@ -416,8 +415,7 @@
           "properties": {
             "project": {
               "description": "Path to the project, e.g. `group/project`, or `group/sub-group/project` [Learn more](https://docs.gitlab.com/ee/ci/yaml/index.html#includefile).",
-              "type": "string",
-              "pattern": "(?:\\S/\\S|\\$\\S+)"
+              "type": "string"
             },
             "ref": {
               "description": "Branch/Tag/Commit-hash for the target project.",
@@ -427,15 +425,13 @@
               "oneOf": [
                 {
                   "description": "Relative path from project root (`/`) to the `yaml`/`yml` file template.",
-                  "type": "string",
-                  "pattern": "\\.ya?ml$"
+                  "type": "string"
                 },
                 {
                   "description": "List of files by relative path from project root (`/`) to the `yaml`/`yml` file template.",
                   "type": "array",
                   "items": {
-                    "type": "string",
-                    "pattern": "\\.ya?ml$"
+                    "type": "string"
                   }
                 }
               ]
@@ -459,8 +455,7 @@
             "template": {
               "description": "Use a `.gitlab-ci.yml` template as a base, e.g. `Nodejs.gitlab-ci.yml`.",
               "type": "string",
-              "format": "uri-reference",
-              "pattern": "\\.ya?ml$"
+              "format": "uri-reference"
             },
             "rules": {
               "$ref": "#/definitions/includeRules"
@@ -500,8 +495,7 @@
             "remote": {
               "description": "URL to a `yaml`/`yml` template file using HTTP/HTTPS.",
               "type": "string",
-              "format": "uri-reference",
-              "pattern": "^https?://.+\\.ya?ml$"
+              "format": "uri-reference"
             },
             "rules": {
               "$ref": "#/definitions/includeRules"
@@ -1352,8 +1346,7 @@
           "markdownDescription": "Use the `cache:key` keyword to give each cache a unique identifying key. All jobs that use the same cache key use the same cache, including in different pipelines. Must be used with `cache:path`, or nothing is cached. [Learn More](https://docs.gitlab.com/ee/ci/yaml/#cachekey).",
           "oneOf": [
             {
-              "type": "string",
-              "pattern": "^(?!.*\\/)^(.*[^.]+.*)$"
+              "type": "string"
             },
             {
               "type": "object",
@@ -1385,8 +1378,7 @@
         "policy": {
           "type": "string",
           "markdownDescription": "Determines the strategy for downloading and updating the cache. [Learn More](https://docs.gitlab.com/ee/ci/yaml/#cachepolicy)",
-          "default": "pull-push",
-          "pattern": "pull-push|pull|push|\\$\\w{1,255}"
+          "default": "pull-push"
         },
         "unprotect": {
           "type": "boolean",
@@ -1861,8 +1853,7 @@
                 "url": {
                   "type": "string",
                   "description": "When set, this will expose buttons in various places for the current environment in Gitlab, that will take you to the defined URL.",
-                  "format": "uri",
-                  "pattern": "^(https?://.+|\\$[A-Za-z]+)"
+                  "format": "uri"
                 },
                 "on_stop": {
                   "type": "string",
@@ -1949,8 +1940,7 @@
             "released_at": {
               "type": "string",
               "description": "The date and time when the release is ready. Defaults to the current date and time if not defined. Should be enclosed in quotes and expressed in ISO 8601 format.",
-              "format": "date-time",
-              "pattern": "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:Z|[+-][01]\\d:[0-5]\\d)$"
+              "format": "date-time"
             },
             "assets": {
               "type": "object",
@@ -2009,8 +1999,7 @@
         "coverage": {
           "type": "string",
           "description": "Must be a regular expression, optionally but recommended to be quoted, and must be surrounded with '/'. Example: '/Code coverage: \\d+\\.\\d+/'",
-          "format": "regex",
-          "pattern": "^/.+/$"
+          "format": "regex"
         },
         "retry": {
           "$ref": "#/definitions/retry"
@@ -2035,8 +2024,7 @@
               "properties": {
                 "project": {
                   "description": "Path to the project, e.g. `group/project`, or `group/sub-group/project`.",
-                  "type": "string",
-                  "pattern": "(?:\\S/\\S|\\$\\S+)"
+                  "type": "string"
                 },
                 "branch": {
                   "description": "The branch name that a downstream pipeline will use",
@@ -2086,8 +2074,7 @@
                     {
                       "description": "Relative path from local repository root (`/`) to the local YAML file to define the pipeline configuration.",
                       "type": "string",
-                      "format": "uri-reference",
-                      "pattern": "\\.ya?ml$"
+                      "format": "uri-reference"
                     },
                     {
                       "type": "array",
@@ -2102,8 +2089,7 @@
                               "local": {
                                 "description": "Relative path from local repository root (`/`) to the local YAML file to define the pipeline configuration.",
                                 "type": "string",
-                                "format": "uri-reference",
-                                "pattern": "\\.ya?ml$"
+                                "format": "uri-reference"
                               }
                             }
                           },
@@ -2114,8 +2100,7 @@
                               "template": {
                                 "description": "Name of the template YAML file to use in the pipeline configuration.",
                                 "type": "string",
-                                "format": "uri-reference",
-                                "pattern": "\\.ya?ml$"
+                                "format": "uri-reference"
                               }
                             }
                           },
@@ -2126,8 +2111,7 @@
                               "artifact": {
                                 "description": "Relative path to the generated YAML file which is extracted from the artifacts and used as the configuration for triggering the child pipeline.",
                                 "type": "string",
-                                "format": "uri-reference",
-                                "pattern": "\\.ya?ml$"
+                                "format": "uri-reference"
                               },
                               "job": {
                                 "description": "Job name which generates the artifact",
@@ -2145,8 +2129,7 @@
                             "properties": {
                               "project": {
                                 "description": "Path to another private project under the same GitLab instance, like `group/project` or `group/sub-group/project`.",
-                                "type": "string",
-                                "pattern": "(?:\\S/\\S|\\$\\S+)"
+                                "type": "string"
                               },
                               "ref": {
                                 "description": "Branch/Tag/Commit hash for the target project.",
@@ -2156,8 +2139,7 @@
                               "file": {
                                 "description": "Relative path from repository root (`/`) to the pipeline configuration YAML file.",
                                 "type": "string",
-                                "format": "uri-reference",
-                                "pattern": "\\.ya?ml$"
+                                "format": "uri-reference"
                               }
                             },
                             "required": [
@@ -2198,8 +2180,7 @@
             },
             {
               "markdownDescription": "Path to the project, e.g. `group/project`, or `group/sub-group/project`. [Learn More](https://docs.gitlab.com/ee/ci/yaml/index.html#trigger).",
-              "type": "string",
-              "pattern": "(?:\\S/\\S|\\$\\S+)"
+              "type": "string"
             }
           ]
         },

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -3,7 +3,6 @@ import {Job} from "./job";
 import assert from "assert";
 import chalk from "chalk";
 import * as yaml from "js-yaml";
-import addFormats from "ajv-formats";
 import schema from "./schema";
 
 export class Validator {
@@ -12,17 +11,13 @@ export class Validator {
             verbose: true,
             allErrors: true,
             allowUnionTypes: true,
+            validateFormats: false,
             strictTypes: false, // to suppress the missing types defined in the gitlab-ci json schema
+            keywords: ["markdownDescription"],
         });
-        ajv.addKeyword("markdownDescription");
-        addFormats(ajv);
         const validate = ajv.compile(schema);
         const valid = validate(data);
-        assert(valid,
-            chalk`Invalid gitlab-ci configuration! It have failed the json schema validation. Dump the following to the pipeline editor to debug:
-
-${yaml.dump(data)}
-`);
+        assert(valid, chalk`Invalid gitlab-ci configuration! It have failed the json schema validation. Dump the following to the pipeline editor to debug: ${yaml.dump(data)}`);
     }
 
     private static needs (jobs: ReadonlyArray<Job>, stages: readonly string[]): string[] {


### PR DESCRIPTION
```yml
---
test:
  environment:
    name: test
    url: ''
  script: hello
```

This make gitlab-ci-local go boom.

But gitlab is fine with it :smile: Which leaves me to believe that they aren't enforcing their json schema string patterns or formats, so let's ignore them for now.