### PR TITLE
fix: gitRemoteMatch scp style does not need to end with .git

### DIFF
--- a/src/git-data.ts
+++ b/src/git-data.ts
@@ -123,14 +123,14 @@ export class GitData {
                 this.remote.schema = gitRemoteMatch.groups.schema as GitSchema;
                 this.remote.port = gitRemoteMatch.groups.port ?? "22";
             } else {
-                gitRemoteMatch = /(?<username>\S+)@(?<host>[^:]+):(?<group>\S+)\/(?<project>\S+)\.git/.exec(gitRemote); // regexr.com/7vjoq
+                gitRemoteMatch = /(?<username>\S+)@(?<host>[^:]+):(?<group>\S+)\/(?<project>\S+)/.exec(gitRemote); // regexr.com/7vjoq
                 assert(gitRemoteMatch?.groups != null, "git remote get-url origin didn't provide valid matches");
 
                 const {stdout} = await Utils.spawn(["ssh", "-G", `${gitRemoteMatch.groups.username}@${gitRemoteMatch.groups.host}`]);
                 const port = stdout.split("\n").filter((line) => line.startsWith("port "))[0].split(" ")[1];
                 this.remote.host = gitRemoteMatch.groups.host;
                 this.remote.group = gitRemoteMatch.groups.group;
-                this.remote.project = gitRemoteMatch.groups.project;
+                this.remote.project = Utils.trimSuffix(gitRemoteMatch.groups.project, ".git");
                 this.remote.schema = "git";
                 this.remote.port = port;
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -310,4 +310,7 @@ export class Utils {
             }
         }
     }
+    static trimSuffix (str: string, suffix: string) {
+        return str.endsWith(suffix) ? str.slice(0, -suffix.length) : str;
+    }
 }

--- a/tests/git-data.test.ts
+++ b/tests/git-data.test.ts
@@ -35,6 +35,26 @@ const tests = [
         },
     },
     {
+        input: "git@github.com:firecow/gitlab-ci.local.git", // project can contain .
+        expected: {
+            schema: "git",
+            port: "22",
+            host: "github.com",
+            group: "firecow",
+            project: "gitlab-ci.local",
+        },
+    },
+    {
+        input: "git@github.com:firecow/gitlab-ci-local", // does not need to end with .git
+        expected: {
+            schema: "git",
+            port: "22",
+            host: "github.com",
+            group: "firecow",
+            project: "gitlab-ci-local",
+        },
+    },
+    {
         input: "https://oauth2:glpat-qwerty12345@somegitlab.com/vendor/package.git",
         expected: {
             schema: "https",


### PR DESCRIPTION
fixes #1251 