### PR TITLE
Fix nested component includes

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -99,6 +99,7 @@ export class ParserIncludes {
                             project: value["project"],
                             file: inner["local"].replace(/^\//, ""),
                             ref: value["ref"],
+                            inputs: inner.inputs || {},
                         };
                     });
 
@@ -116,6 +117,7 @@ export class ParserIncludes {
                             project: projectPath,
                             file: f,
                             ref: ref,
+                            inputs: value.inputs || {},
                         },
                     };
                     includeDatas = includeDatas.concat(await this.init(fileDoc, opts));

--- a/tests/test-cases/include-component/component/.gitlab-ci.yml
+++ b/tests/test-cases/include-component/component/.gitlab-ci.yml
@@ -2,13 +2,12 @@
 include:
   - component: gitlab.com/components/go/full-pipeline@0.3.1
     inputs:
-      stage_format: format
-      stage_build: build
-      stage_test: test
+      stage_format: format-override
+      stage_build: build-override
+      stage_test: test-override
       go_version: latest
 
 stages:
-  - format
-  - build
-  - test
-  - latest
+  - format-override
+  - build-override
+  - test-override

--- a/tests/test-cases/include-component/integration.include-component.test.ts
+++ b/tests/test-cases/include-component/integration.include-component.test.ts
@@ -37,22 +37,21 @@ test.concurrent("include-component component (protocol: https)", async () => {
     const expected = `---
 stages:
   - .pre
-  - format
-  - build
-  - test
-  - latest
+  - format-override
+  - build-override
+  - test-override
   - .post
 format-latest:
   image:
     name: golang:latest
-  stage: format
+  stage: format-override
   script:
     - go fmt $(go list ./... | grep -v /vendor/)
     - go vet $(go list ./... | grep -v /vendor/)
 build-latest:
   image:
     name: golang:latest
-  stage: build
+  stage: build-override
   script:
     - mkdir -p mybinaries
     - go build -o mybinaries ./...
@@ -62,7 +61,7 @@ build-latest:
 test-latest:
   image:
     name: golang:latest
-  stage: test
+  stage: test-override
   script:
     - go test -race $(go list ./... | grep -v /vendor/)`;
 


### PR DESCRIPTION
Previously the `inputs` were not passed along correctly when transforming the include directives.