### PR TITLE
Support for testing local component

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -113,12 +113,20 @@ export class ParserIncludes {
                     assert(f !== null, `This GitLab CI configuration is invalid: component: \`${value["component"]}\`. One of the file [${files}] must exists in \`${domain}/${projectPath}\``);
 
                     const isLocalComponent = projectPath === `${gitData.remote.group}/${gitData.remote.project}` && ref === gitData.commit.SHA;
-                    if (isLocalComponent && await fs.pathExists(`${cwd}/${f}`)) {
-                        const content = await Parser.loadYaml(`${cwd}/${f}`, {inputs: value.inputs || {}}, expandVariables);
+                    if (isLocalComponent) {
+                        const localComponentInclude = `${cwd}/${f}`;
+                        if (!(await fs.pathExists(localComponentInclude))) {
+                            continue;
+                        }
+
+                        const content = await Parser.loadYaml(localComponentInclude, {inputs: value.inputs || {}}, expandVariables);
                         includeDatas = includeDatas.concat(await this.init(content, opts));
                         break;
                     } else {
-                        if (!(await Utils.remoteFileExist(cwd, f, ref, domain, projectPath, gitData.remote.schema, gitData.remote.port))) continue;
+                        if (!(await Utils.remoteFileExist(cwd, f, ref, domain, projectPath, gitData.remote.schema, gitData.remote.port))) {
+                            continue;
+                        }
+
                         const fileDoc = {
                             include: {
                                 project: projectPath,

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -108,18 +108,27 @@ export class ParserIncludes {
                 const {domain, projectPath, componentName, ref} = this.parseIncludeComponent(value["component"]);
                 // converts component to project
                 const files = [`${componentName}.yml`, `${componentName}/template.yml`, null];
+
                 for (const f of files) {
                     assert(f !== null, `This GitLab CI configuration is invalid: component: \`${value["component"]}\`. One of the file [${files}] must exists in \`${domain}/${projectPath}\``);
-                    if (!(await Utils.remoteFileExist(cwd, f, ref, domain, projectPath, gitData.remote.schema, gitData.remote.port))) continue;
-                    const fileDoc = {
-                        include: {
-                            project: projectPath,
-                            file: f,
-                            ref: ref,
-                            inputs: value.inputs || {},
-                        },
-                    };
-                    includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
+
+                    const isLocalComponent = projectPath === `${gitData.remote.group}/${gitData.remote.project}` && ref === gitData.commit.SHA;
+                    if (isLocalComponent && await fs.pathExists(`${cwd}/${f}`)) {
+                        const content = await Parser.loadYaml(`${cwd}/${f}`, {inputs: value.inputs || {}}, expandVariables);
+                        includeDatas = includeDatas.concat(await this.init(content, opts));
+                        break;
+                    } else {
+                        if (!(await Utils.remoteFileExist(cwd, f, ref, domain, projectPath, gitData.remote.schema, gitData.remote.port))) continue;
+                        const fileDoc = {
+                            include: {
+                                project: projectPath,
+                                file: f,
+                                ref: ref,
+                                inputs: value.inputs || {},
+                            },
+                        };
+                        includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
+                    }
                     break;
                 }
             } else if (value["template"]) {

--- a/src/predefined-variables.ts
+++ b/src/predefined-variables.ts
@@ -30,6 +30,7 @@ export function init ({gitData, argv}: PredefinedVariablesOpts): {[name: string]
         CI_COMMIT_DESCRIPTION: "More commit text",
         CI_DEFAULT_BRANCH: gitData.branches.default,
         CI_PIPELINE_SOURCE: "push",
+        CI_SERVER_FQDN: `${gitData.remote.host}`,
         CI_SERVER_HOST: `${gitData.remote.host}`,
         CI_SERVER_PORT: `${gitData.remote.port}`,
         CI_SERVER_URL: `https://${gitData.remote.host}:443`,

--- a/tests/test-cases/include-component/component-local/.gitlab-ci.yml
+++ b/tests/test-cases/include-component/component-local/.gitlab-ci.yml
@@ -1,0 +1,8 @@
+---
+include:
+  - component: $CI_SERVER_HOST/$CI_PROJECT_PATH/my-component@$CI_COMMIT_SHA
+    inputs:
+      stage: my-stage
+
+stages:
+  - my-stage

--- a/tests/test-cases/include-component/component-local/templates/my-component.yml
+++ b/tests/test-cases/include-component/component-local/templates/my-component.yml
@@ -1,0 +1,9 @@
+---
+spec:
+  inputs:
+    stage:
+      default: test
+---
+component-job:
+  script: echo job 1
+  stage: $[[ inputs.stage ]]

--- a/tests/test-cases/include-component/integration.include-component.test.ts
+++ b/tests/test-cases/include-component/integration.include-component.test.ts
@@ -67,3 +67,24 @@ test-latest:
 
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
+
+test.concurrent("include-component local component", async () => {
+    const writeStreams = new WriteStreamsMock();
+
+    await handler({
+        cwd: "tests/test-cases/include-component/component-local",
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - my-stage
+  - .post
+component-job:
+  script:
+    - echo job 1
+  stage: my-stage`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});


### PR DESCRIPTION
Fix #1272

If the project path is the current project and same commit sha, use the local definition of the component.
This makes it possible to test the component locally: https://docs.gitlab.com/ee/ci/components/#test-the-component