### PR TITLE
Improve validation for default and artifacts

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -208,7 +208,11 @@ export function defaults (gitlabData: any) {
     const afterScript = gitlabData.default?.after_script ?? gitlabData.after_script;
 
     for (const [jobName, jobData] of Object.entries<any>(gitlabData)) {
-        if (Job.illegalJobNames.has(jobName)) continue;
+        if (Job.illegalJobNames.has(jobName) || jobName.startsWith(".")) {
+            // skip hidden jobs as they might just contain shared yaml
+            // see https://github.com/firecow/gitlab-ci-local/issues/1277
+            continue;
+        }
         if (typeof jobData === "string") continue;
         if (!jobData.artifacts && artifacts) jobData.artifacts = artifacts;
         if (!jobData.cache && cache) jobData.cache = cache;

--- a/src/job.ts
+++ b/src/job.ts
@@ -363,6 +363,10 @@ export class Job {
         return this.jobData["artifacts"];
     }
 
+    deleteArtifacts () {
+        delete this.jobData["artifacts"];
+    }
+
     get cache (): Cache[] {
         return this.jobData["cache"] || [];
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,6 +59,13 @@ export class Parser {
         const time = process.hrtime();
         await parser.init();
         const warnings = await Validator.run(parser.jobs, parser.stages);
+
+        for (const job of parser.jobs) {
+            if (job.artifacts === null) {
+                job.deleteArtifacts();
+            }
+        }
+
         const parsingTime = process.hrtime(time);
         const pathToExpandedGitLabCi = path.join(argv.cwd, argv.stateDir, "expanded-gitlab-ci.yml");
         fs.mkdirpSync(path.join(argv.cwd, argv.stateDir));

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -146,6 +146,17 @@ export class Validator {
         this.dependencies(jobs, stages);
         this.dependenciesContainment(jobs);
         warnings.push(...this.potentialIllegalJobName(jobs.map(j => j.baseName)));
+        warnings.push(...this.artifacts(jobs));
+        return warnings;
+    }
+
+    private static artifacts (jobs: ReadonlyArray<Job>) {
+        const warnings: string[] = [];
+        for (const job of jobs) {
+            if (job.artifacts === null) {
+                warnings.push(`${job.name}.artifacts is null, ignoring.`);
+            }
+        }
         return warnings;
     }
 }

--- a/tests/test-cases/schema-validation/.gitlab-ci-issue-1277.yml
+++ b/tests/test-cases/schema-validation/.gitlab-ci-issue-1277.yml
@@ -1,0 +1,15 @@
+---
+default:
+  cache:
+    key: 'my-key'
+    paths:
+      - my-file
+
+.some-shared-yaml:
+  if: "$CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH"
+
+my-job:
+  script: 'echo test'
+  artifacts:
+  rules:
+    - !reference [.some-shared-yaml]


### PR DESCRIPTION
Fix: #1277 

Do not extend hidden jobs with `default` so that this validates like on GitLab
![image](https://github.com/firecow/gitlab-ci-local/assets/9151470/72e777b3-6aac-4f58-8002-b4b651335a45)

Showing a warning in this case since GitLab allows running it but shows an error in the pipeline editor:
![image](https://github.com/firecow/gitlab-ci-local/assets/9151470/d4325602-ba9c-456a-9083-141d470f09e9)
