### PR TITLE
Fix `allow_failure` when combined with `rules`

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -194,7 +194,7 @@ export class Job {
 
         // Set {when, allowFailure} based on rules result
         if (this.rules) {
-            const ruleResult = Utils.getRulesResult({cwd, rules: this.rules, variables: this._variables}, this.gitData, this.when);
+            const ruleResult = Utils.getRulesResult({cwd, rules: this.rules, variables: this._variables}, this.gitData, this.when, this.allowFailure);
             this.when = ruleResult.when;
             this.allowFailure = ruleResult.allowFailure;
             this._variables = {...globalVariables, ...jobVariables, ...ruleResult.variables, ...matrixVariables, ...predefinedVariables, ...envMatchedVariables, ...argvVariables};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,11 +180,11 @@ export class Utils {
         return envMatchedVariables;
     }
 
-    static getRulesResult (opt: RuleResultOpt, gitData: GitData, jobWhen: string = "on_success"): {when: string; allowFailure: boolean; variables?: {[name: string]: string}} {
+    static getRulesResult (opt: RuleResultOpt, gitData: GitData, jobWhen: string = "on_success", jobAllowFailure: boolean | {exit_codes: number | number[]} = false): {when: string; allowFailure: boolean | {exit_codes: number | number[]}; variables?: {[name: string]: string}} {
         let when = "never";
 
         // optional manual jobs allowFailure defaults to true https://docs.gitlab.com/ee/ci/jobs/job_control.html#types-of-manual-jobs
-        let allowFailure = jobWhen === "manual";
+        let allowFailure = jobWhen === "manual" ? true : jobAllowFailure;
         let ruleVariable: {[name: string]: string} | undefined;
 
         for (const rule of opt.rules) {

--- a/tests/test-cases/script-failures/.gitlab-ci.yml
+++ b/tests/test-cases/script-failures/.gitlab-ci.yml
@@ -62,9 +62,18 @@ exit_code[number[]] not allowed:
 
 rules:allow_failure precedence:
   image: nginx:alpine
-  allow_failure: false
+  allow_failure:
+    exit_codes: 137
   rules:
     - if: $CI_DEFAULT_BRANCH == "main"
-      allow_failure: true
+      allow_failure: false
   script:
-    - exit 1
+    - exit 137
+
+rules:without allow_failure:
+  allow_failure:
+    exit_codes: 137
+  rules:
+    - when: always
+  script:
+    - exit 137

--- a/tests/test-cases/script-failures/integration.script-failures.test.ts
+++ b/tests/test-cases/script-failures/integration.script-failures.test.ts
@@ -141,6 +141,18 @@ test("script-failures <rules:allow_failure precedence>", async () => {
     }, writeStreams);
 
     expect(writeStreams.stdoutLines.join("\n")).toContain(
-        chalk`{black.bgYellowBright  WARN } {blueBright rules:allow_failure precedence}`,
+        chalk`{black.bgRed  FAIL } {blueBright rules:allow_failure precedence}`,
+    );
+});
+
+test("script-failures <rules:without allow_failure>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/script-failures",
+        job: ["rules:without allow_failure"],
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toContain(
+        chalk`{black.bgYellowBright  WARN } {blueBright rules:without allow_failure}`,
     );
 });


### PR DESCRIPTION
Currently `allow_failure` gets overwritten if there are no `allow_failure` keys in the `rules` themselves. That is

```yaml
rules:without allow_failure:
  allow_failure:
    exit_codes: 137
  rules:
    - when: always
  script:
    - exit 137
```

Incorrectly sets `allow_failure` to `false`, even though no setting is set on the `rules`.