### PR TITLE
fix: should not crash when cache:key:files files don't exist

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -385,8 +385,7 @@ export class Job {
             }
             return `${cwd}/${path}`;
         });
-
-        return "md-" + await Utils.checksumFiles(files);
+        return "md-" + await Utils.checksumFiles(cwd, files);
     }
 
     get beforeScripts (): string[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {GitData, GitSchema} from "./git-data";
 import globby from "globby";
 import micromatch from "micromatch";
 import axios from "axios";
+import path from "path";
 
 type RuleResultOpt = {
     cwd: string;
@@ -261,11 +262,12 @@ export class Utils {
         return {hrdeltatime: process.hrtime(time)};
     }
 
-    static async checksumFiles (files: string[]): Promise<string> {
+    static async checksumFiles (cwd: string, files: string[]): Promise<string> {
         const promises: Promise<string>[] = [];
 
         files.forEach((file) => {
             promises.push(new Promise((resolve, reject) => {
+                if (! fs.pathExistsSync(file)) resolve(path.relative(cwd, file)); // must use relative path here, so that checksum can be deterministic when running the unit tests
                 checksum.file(file, (err, hash) => {
                     if (err) {
                         return reject(err);

--- a/tests/test-cases/cache-key-files/.gitlab-ci.yml
+++ b/tests/test-cases/cache-key-files/.gitlab-ci.yml
@@ -32,3 +32,15 @@ cache-key-file referencing $CI_PROJECT_DIR:
       - fakepackage.json
   script:
     - echo 1
+
+cache-key-file file dont exist:
+  stage: test
+  image: bash
+  cache:
+    key:
+      files:
+        - no-such-file
+    paths:
+      - /tmp
+  script:
+    - echo 1

--- a/tests/test-cases/cache-key-files/integration.key-files.test.ts
+++ b/tests/test-cases/cache-key-files/integration.key-files.test.ts
@@ -35,3 +35,16 @@ test("cache-key-files <cache-key-file referencing $CI_PROJECT_DIR>", async () =>
 
     expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
 });
+
+test("cache-key-files <cache-key-file file dont exist>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/cache-key-files",
+        job: ["cache-key-file file dont exist"],
+    }, writeStreams);
+
+    const expected = [
+        chalk`{blueBright cache-key-file file dont exist} {magentaBright exported cache /tmp 'md-18bbe9d7603e540e28418cf4a072938ac477a2c1'}`,
+    ];
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
+});


### PR DESCRIPTION
fixes #1288