### PR TITLE
fix: Allow repeated include inputs interpolation

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -308,7 +308,7 @@ export class Parser {
 
             const interpolatedConfigurations = JSON.stringify(uninterpolatedConfigurations)
                 .replace(
-                    /(?<firstChar>.)(?<secondChar>.)\$\[\[\s*inputs.(?<interpolationKey>[\w-]+)\s*\|?\s*(?<interpolationFunctions>.*?)\s*\]\](?<lastChar>.)/g // https://regexr.com/81c16
+                    /(?<firstChar>.)?(?<secondChar>.)?\$\[\[\s*inputs.(?<interpolationKey>[\w-]+)\s*\|?\s*(?<interpolationFunctions>.*?)\s*\]\](?<lastChar>[^$])?/g // https://regexr.com/81c16
                     , (_: string, firstChar: string, secondChar: string, interpolationKey: string, interpolationFunctions: string, lastChar: string) => {
                         const configFilePath = path.relative(process.cwd(), filePath);
                         const context = {
@@ -318,6 +318,9 @@ export class Parser {
                             configFilePath,
                             ...ctx,
                         };
+                        firstChar ??= "";
+                        secondChar ??= "";
+                        lastChar ??= "";
 
                         const {inputValue, inputType} = parseIncludeInputs(context);
                         const firstTwoChar = firstChar + secondChar;

--- a/tests/test-cases/include-inputs/input-templates/interpolation-repeat/.gitlab-ci-input-template.yml
+++ b/tests/test-cases/include-inputs/input-templates/interpolation-repeat/.gitlab-ci-input-template.yml
@@ -1,0 +1,8 @@
+---
+spec:
+  inputs:
+    name:
+---
+job $[[ inputs.name ]] $[[ inputs.name ]]:
+  script:
+    - echo $[[ inputs.name ]]$[[ inputs.name ]]

--- a/tests/test-cases/include-inputs/input-templates/interpolation-repeat/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/interpolation-repeat/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+---
+include:
+  - local: "/.gitlab-ci-input-template.yml"
+    inputs:
+      name: foo
+stages:
+  - test

--- a/tests/test-cases/include-inputs/integration.include-inputs.test.ts
+++ b/tests/test-cases/include-inputs/integration.include-inputs.test.ts
@@ -135,6 +135,25 @@ scan-website:
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
 
+test("include-inputs interpolation repeated", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/include-inputs/input-templates/interpolation-repeat",
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - test
+  - .post
+job foo foo:
+  script:
+    - echo foofoo`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});
+
 test("include-inputs inputs validation for array", async () => {
     try {
         const writeStreams = new WriteStreamsMock();


### PR DESCRIPTION
A template like

```yml
---
spec:
  inputs:
    name:
---
job $[[ inputs.name ]] $[[ inputs.name ]]:
  script:
    - echo $[[ inputs.name ]]$[[ inputs.name ]]
```

currently ends up looking like

```yaml
job name $[[ inputs.name ]]:
  script:
    - echo name$[[ inputs.name ]]
```

after substitution.

The fix is to make the regex parsing the `$[[ ]]` part more permissive.