### PR TITLE
Expand variables in `rules:changes`

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -64,6 +64,15 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
     hour12: false,
 });
 
+export type JobRule = {
+    if?: string;
+    when?: string;
+    changes?: string[] | {paths: string[]};
+    exists?: string[];
+    allow_failure?: boolean;
+    variables?: {[name: string]: string};
+};
+
 export class Job {
 
     static readonly illegalJobNames = new Set([
@@ -78,14 +87,7 @@ export class Job {
     readonly dependencies: string[] | null;
     readonly environment?: {name: string; url: string | null; deployment_tier: string | null; action: string | null};
     readonly jobId: number;
-    readonly rules?: {
-        if?: string;
-        when?: string;
-        changes?: string[] | {paths: string[]};
-        exists?: string[];
-        allow_failure?: boolean;
-        variables?: {[name: string]: string};
-    }[];
+    readonly rules?: JobRule[];
 
     readonly allowFailure: boolean | {
         exit_codes: number | number[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import {Job} from "./job";
+import {Job, JobRule} from "./job";
 import * as fs from "fs-extra";
 import checksum from "checksum";
 import base64url from "base64url";
@@ -13,14 +13,7 @@ import axios from "axios";
 
 type RuleResultOpt = {
     cwd: string;
-    rules: {
-        if?: string;
-        when?: string;
-        changes?: string[] | {paths: string[]};
-        exists?: string[];
-        allow_failure?: boolean;
-        variables?: {[name: string]: string};
-    }[];
+    rules: JobRule[];
     variables: {[key: string]: string};
 };
 

--- a/tests/test-cases/rules-changes/.gitlab-ci-rules:changes:paths.yml
+++ b/tests/test-cases/rules-changes/.gitlab-ci-rules:changes:paths.yml
@@ -7,3 +7,16 @@ alpine:
           - "foo"
   script:
     - echo "Job is running"
+
+matrix:
+  image: alpine
+  parallel:
+    matrix:
+      - FILE:
+          - foo
+  rules:
+    - changes:
+        paths:
+          - "${FILE}"
+  script:
+    - echo "Job is running"

--- a/tests/test-cases/rules-changes/.gitlab-ci.yml
+++ b/tests/test-cases/rules-changes/.gitlab-ci.yml
@@ -6,3 +6,15 @@ alpine:
         - "foo"
   script:
     - echo "Job is running"
+
+matrix:
+  image: alpine
+  parallel:
+    matrix:
+      - FILE:
+          - foo
+  rules:
+    - changes:
+        - "${FILE}"
+  script:
+    - echo "Job is running"

--- a/tests/test-cases/rules-changes/integration.rules-changes.test.ts
+++ b/tests/test-cases/rules-changes/integration.rules-changes.test.ts
@@ -18,9 +18,10 @@ test("rules:changes (has changes))", async () => {
         cwd: "tests/test-cases/rules-changes",
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines.join("\n")).toContain(
-        chalk`{blueBright alpine} {greenBright >} Job is running\n`
-    );
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining([
+        chalk`{blueBright alpine       } {greenBright >} Job is running`,
+        chalk`{blueBright matrix: [foo]} {greenBright >} Job is running`,
+    ]));
 });
 
 test("rules:changes:paths (has changes)", async () => {
@@ -34,9 +35,10 @@ test("rules:changes:paths (has changes)", async () => {
         file: ".gitlab-ci-rules:changes:paths.yml",
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines.join("\n")).toContain(
-        chalk`{blueBright alpine} {greenBright >} Job is running\n`
-    );
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining([
+        chalk`{blueBright alpine       } {greenBright >} Job is running`,
+        chalk`{blueBright matrix: [foo]} {greenBright >} Job is running`,
+    ]));
 });
 
 test("rules:changes (no changes)", async () => {
@@ -49,9 +51,10 @@ test("rules:changes (no changes)", async () => {
         cwd: "tests/test-cases/rules-changes",
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines.join("\n")).not.toContain(
-        chalk`{blueBright alpine} {greenBright >} Job is running\n`
-    );
+    expect(writeStreams.stdoutLines).not.toEqual(expect.arrayContaining([
+        chalk`{blueBright alpine       } {greenBright >} Job is running`,
+        chalk`{blueBright matrix: [foo]} {greenBright >} Job is running`,
+    ]));
 });
 
 test("rules:changes:paths (no changes)", async () => {
@@ -65,7 +68,8 @@ test("rules:changes:paths (no changes)", async () => {
         file: ".gitlab-ci-rules:changes:paths.yml",
     }, writeStreams);
 
-    expect(writeStreams.stdoutLines.join("\n")).not.toContain(
-        chalk`{blueBright alpine} {greenBright >} Job is running\n`
-    );
+    expect(writeStreams.stdoutLines).not.toEqual(expect.arrayContaining([
+        chalk`{blueBright alpine       } {greenBright >} Job is running`,
+        chalk`{blueBright matrix: [foo]} {greenBright >} Job is running`,
+    ]));
 });


### PR DESCRIPTION
This enables common `parallel:matrix` configurations like

```yaml
matrix:
  image: alpine
  parallel:
    matrix:
      - SUBDIR:
          - foo
          - bar
  rules:
    - changes:
        paths:
          - "${SUBDIR}/**/*"
  script:
    - echo "Job is running"
```