### PR TITLE
Fix `umask=false` for images without a shell entrypoint

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -470,7 +470,7 @@ export class Job {
             let chownOpt = "0:0";
             let chmodOpt = "a+rw";
             if (expanded["FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR"] === "true") {
-                const {stdout} = await Utils.spawn(["docker", "run", "--rm", imageName, "sh", "-c", "echo \"$(id -u):$(id -g)\""]);
+                const {stdout} = await Utils.spawn(["docker", "run", "--rm", "--entrypoint", "sh", imageName, "-c", "echo \"$(id -u):$(id -g)\""]);
                 chownOpt = stdout;
                 if (chownOpt == "0:0") {
                     chmodOpt = "g-w";

--- a/tests/test-cases/umask/.gitlab-ci.yml
+++ b/tests/test-cases/umask/.gitlab-ci.yml
@@ -11,3 +11,11 @@ alpine-root:
   script:
     - stat -c "%a %n %u %g" one.txt
     - stat -c "%a %n %u %g" script.sh
+
+kaniko-root:
+  image:
+    name: gcr.io/kaniko-project/executor:v1.23.0-debug
+    entrypoint: [""]
+  script:
+    - stat -c "%a %n %u %g" one.txt
+    - stat -c "%a %n %u %g" script.sh

--- a/tests/test-cases/umask/integration.umask.test.ts
+++ b/tests/test-cases/umask/integration.umask.test.ts
@@ -69,3 +69,33 @@ test.concurrent("umask <alpine-root> --no-umask", async () => {
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdOut));
 });
+
+test.concurrent("umask <kaniko-root> --umask", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/umask/",
+        umask: true,
+        job: ["kaniko-root"],
+    }, writeStreams);
+
+    const expectedStdOut = [
+        chalk`{blueBright kaniko-root} {greenBright >} 666 one.txt 0 0`,
+        chalk`{blueBright kaniko-root} {greenBright >} 777 script.sh 0 0`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdOut));
+});
+
+test.concurrent("umask <kaniko-root> --no-umask", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/umask/",
+        umask: false,
+        job: ["kaniko-root"],
+    }, writeStreams);
+
+    const expectedStdOut = [
+        chalk`{blueBright kaniko-root} {greenBright >} 644 one.txt 0 0`,
+        chalk`{blueBright kaniko-root} {greenBright >} 755 script.sh 0 0`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdOut));
+});


### PR DESCRIPTION
While checking https://github.com/firecow/gitlab-ci-local/issues/1297 I got an error with (essentially) the following CI file

```yaml
---
build:
  image:
    name: gcr.io/kaniko-project/executor:v1.23.0-debug
    entrypoint: [""]
  script:
    - ls
```

failed for me with

```console
$ gitlab-ci-local --umask=false
Using fallback git commit data
Unable to retrieve default remote branch, falling back to `main`.
Using fallback git remote data
parsing and downloads finished in 49 ms.
json schema validated in 206 ms
build starting gcr.io/kaniko-project/executor:v1.23.0-debug (test)
Error: Command failed with exit code 1: docker run --rm gcr.io/kaniko-project/executor:v1.23.0-debug sh -c echo "$(id -u):$(id -g)"
Error: unknown command "sh" for "executor"
Run 'executor --help' for usage.
    at makeError (/nix/store/c89rzb02w6k156nzfxdi3rkmlngg4ma4-gitlab-ci-local-4.52.1/lib/node_modules/gitlab-ci-local/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/nix/store/c89rzb02w6k156nzfxdi3rkmlngg4ma4-gitlab-ci-local-4.52.1/lib/node_modules/gitlab-ci-local/node_modules/execa/index.js:118:26)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Job.start (/nix/store/c89rzb02w6k156nzfxdi3rkmlngg4ma4-gitlab-ci-local-4.52.1/lib/node_modules/gitlab-ci-local/src/job.ts:494:34)
    at /nix/store/c89rzb02w6k156nzfxdi3rkmlngg4ma4-gitlab-ci-local-4.52.1/lib/node_modules/gitlab-ci-local/node_modules/p-map/index.js:57:22
```

The fix is to explicitly set the entrypoint to `sh` when spawning the image to check the UID and GID of the container, so that the  UID and GID of containers that have their entrypoint set to something other than a shell can still be retrieved.