### PR TITLE
fix: Enable `services` for podman executable

### DIFF
--- a/tests/test-cases/network-arg/integration.network-arg.test.ts
+++ b/tests/test-cases/network-arg/integration.network-arg.test.ts
@@ -3,13 +3,15 @@ import {handler} from "../../../src/handler";
 import chalk from "chalk";
 import {initSpawnSpy, initBashSpy} from "../../mocks/utils.mock";
 import {WhenStatics} from "../../mocks/when-statics";
+import assert from "assert";
+import {AssertionError} from "assert";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
 });
 
 
-test("network-host", async () => {
+test("network-host <test-job>", async () => {
     const bashSpy = initBashSpy([]);
 
     const writeStreams = new WriteStreamsMock();
@@ -27,7 +29,21 @@ test("network-host", async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test("network-none", async () => {
+test("network-host <service-job>", async () => {
+    try {
+        const writeStreams = new WriteStreamsMock();
+        await handler({
+            cwd: "tests/test-cases/network-arg",
+            job: ["service-job"],
+            network: ["host"],
+        }, writeStreams);
+    } catch (e) {
+        assert(e instanceof AssertionError, "e is not instanceof AssertionError");
+        expect(e.message).toBe(chalk`Cannot add service network alias with network mode 'host'`);
+    }
+});
+
+test("network-none <test-job>", async () => {
     const bashSpy = initBashSpy([]);
 
     const writeStreams = new WriteStreamsMock();
@@ -45,7 +61,21 @@ test("network-none", async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
 
-test("network-custom", async () => {
+test("network-none <service-job>", async () => {
+    try {
+        const writeStreams = new WriteStreamsMock();
+        await handler({
+            cwd: "tests/test-cases/network-arg",
+            job: ["service-job"],
+            network: ["none"],
+        }, writeStreams);
+    } catch (e) {
+        assert(e instanceof AssertionError, "e is not instanceof AssertionError");
+        expect(e.message).toBe(chalk`Cannot add service network alias with network mode 'none'`);
+    }
+});
+
+test("network-custom <test-job>", async () => {
     const bashSpy = initBashSpy([]);
     const networkSpy = initSpawnSpy([{
         cmdArgs: expect.arrayContaining(["docker", "network", "connect"]),
@@ -65,9 +95,7 @@ test("network-custom", async () => {
     expect(networkSpy).toHaveBeenCalledWith(expect.arrayContaining(["docker", "network", "connect", "custom-network2"]));
 });
 
-test("network-custom-with-service", async () => {
-    const bashSpy = initBashSpy([]);
-
+test("network-custom <service-job>", async () => {
     const networkSpy = initSpawnSpy([{
         cmdArgs: expect.arrayContaining(["docker", "network", "connect"]),
         returnValue: {stdout: "", stderr: "", exitCode: 0},
@@ -78,10 +106,9 @@ test("network-custom-with-service", async () => {
     await handler({
         cwd: "tests/test-cases/network-arg",
         job: ["service-job"],
-        network: ["host", "custom-network1", "custom-network2"],
+        network: ["custom-network1", "custom-network2"],
     }, writeStreams);
 
-    expect(bashSpy).toHaveBeenCalledWith(expect.stringMatching(/--network host/), expect.any(String));
     expect(networkSpy).toHaveBeenCalledWith(expect.arrayContaining(["docker", "network", "connect", "custom-network1"]));
     expect(networkSpy).toHaveBeenCalledWith(expect.arrayContaining(["docker", "network", "connect", "custom-network2"]));
 });


### PR DESCRIPTION
See the discussion in #1300 for more details. Basically, we want to add the service network on container creation instead of afterwards with `podman network connect`, because of the default network mode when using podman.

Since we cannot mix `--network={host,none}` with a user defined network, we cannot use services with `--network={host,none}` mode, so instead of letting the docker/podman command fail, throw a more user friendly `AssertionError.`

Closes #1300 .