### PR TITLE
fix: Do not escape backslashes during rules:if evaluation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -203,7 +203,7 @@ export class Utils {
         // Expand all variables
         evalStr = this.expandTextWith(evalStr, {
             unescape: JSON.stringify("$"),
-            variable: (name) => JSON.stringify(envs[name] ?? null),
+            variable: (name) => JSON.stringify(envs[name] ?? null).replaceAll("\\\\", "\\"),
         });
 
         // Convert =~ to match function

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -238,6 +238,12 @@ test("Complex parentheses junctions regex fail - case insensitive", () => {
     expect(val).toBe(false);
 });
 
+test("Regex with escape characters from variable", () => {
+    const ruleIf = "$TAG =~ $TAG_REGEX";
+    const val = Utils.evaluateRuleIf(ruleIf, {TAG: "prefix/1.0.0", TAG_REGEX: "/^prefix\\/.+/"});
+    expect(val).toBe(true);
+});
+
 test("https://github.com/firecow/gitlab-ci-local/issues/350", () => {
     let rules, rulesResult, variables;
     rules = [


### PR DESCRIPTION
Because the variables in the `rules:if` evaluation are interpolated using `JSON.stringify`, any `\` characters are escaped to `\\`, which makes e.g. regexes that are expanded from variables invalid. The solution is to unescape the `JSON.stringify` output again.

Before the test case

```javascript
const ruleIf = "$TAG =~ $TAG_REGEX";
const val = Utils.evaluateRuleIf(ruleIf, {TAG: "prefix/1.0.0", TAG_REGEX: "/^prefix\\/.+/"});
```

would expand to `"prefix/1.0.0".match(/^prefix\\/.+/) != null`.

Now it expands to `"prefix/1.0.0".match(/^prefix\/.+/) != null`