### PR TITLE
Fix some flaky tests

### DIFF
--- a/examples/docker-in-docker-build-with-local-registry/.gitlab-ci.yml
+++ b/examples/docker-in-docker-build-with-local-registry/.gitlab-ci.yml
@@ -6,7 +6,7 @@ alpine-image:
       command:
         - --insecure-registry=gitlab-ci-local-registry:5000
   needs: []
-  image: docker:latest
+  image: docker:cli
   stage: build
   script:
     - docker pull $CI_REGISTRY_IMAGE:latest || true

--- a/examples/docker-in-docker-build/.gitlab-ci.yml
+++ b/examples/docker-in-docker-build/.gitlab-ci.yml
@@ -4,7 +4,7 @@ alpine-image:
   services:
     - docker:dind
   needs: []
-  image: docker:stable
+  image: docker:cli
   stage: build
   script:
     - printenv

--- a/examples/docker-swarm-php/.gitlab-ci.yml
+++ b/examples/docker-swarm-php/.gitlab-ci.yml
@@ -17,7 +17,7 @@ composer-install:
 # @Description Build/Push PHP image
 build-php:
   needs: [composer-install]
-  image: docker:stable
+  image: docker:cli
   stage: build
   artifacts:
     reports:

--- a/tests/test-cases/artifacts-reports-dotenv/.gitignore
+++ b/tests/test-cases/artifacts-reports-dotenv/.gitignore
@@ -1,1 +1,2 @@
 /build.env
+multi*.env

--- a/tests/test-cases/dind-no-tls/.gitlab-ci.yml
+++ b/tests/test-cases/dind-no-tls/.gitlab-ci.yml
@@ -1,8 +1,9 @@
 ---
 test-job:
-  image: docker.io/library/docker:stable
+  image: docker.io/library/docker:cli
   services:
-    - name: docker.io/library/docker:stable-dind
+    # Pinned to 27-dind in case non-TLS DIND is removed at some point in the future.
+    - name: docker.io/library/docker:27-dind
       alias: docker
   variables:
     DOCKER_HOST: tcp://docker:2375

--- a/tests/test-cases/dind-no-tls/integration.dind-no-tls.test.ts
+++ b/tests/test-cases/dind-no-tls/integration.dind-no-tls.test.ts
@@ -25,7 +25,7 @@ test("dind-no-tls <test-job> --needs", async () => {
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expectedStdout));
 
     const expectedStderr = [
-        chalk`{blueBright test-job} {redBright >} WARNING: API is accessible on http://0.0.0.0:2375 without encryption.`,
+        chalk`{blueBright test-job} {redBright >} [DEPRECATION NOTICE]: API is accessible on http://0.0.0.0:2375 without encryption.`,
     ];
     expect(writeStreams.stderrLines).toEqual(expect.arrayContaining(expectedStderr));
 });

--- a/tests/test-cases/dind-tls/.gitlab-ci.yml
+++ b/tests/test-cases/dind-tls/.gitlab-ci.yml
@@ -4,7 +4,7 @@ test-job:
     - name: docker.io/library/docker:dind
       alias: docker
   needs: []
-  image: docker.io/library/docker:stable
+  image: docker.io/library/docker:cli
   stage: build
   script:
     - docker pull -q alpine 1> /dev/null


### PR DESCRIPTION
The `dind-no-tls` test fails for me locally because I do not have `iptables`. The fix is to update the `dind` image that is used (more recent versions pick up `nftables`). While I was at it, I also updated the other `docker` references to use `cli` instead of `stable` (the stable tag has not been updated in 4 years).

I'm not sure if this is a quirk of my global configuration, but for the artifacts tests the tests generate `.env` files that are then picked up by git as untracked, so I have added them to the `.gitignore`.