### PR TITLE
fix: Allow multi-line variable values via command line

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -122,7 +122,7 @@ export class Argv {
         const variables: {[key: string]: string} = {};
         const pairs = typeof val == "string" ? val.split(" ") : val;
         (pairs ?? []).forEach((variablePair: string) => {
-            const exec = /(?<key>\w*?)(=)(?<value>.*)/.exec(variablePair);
+            const exec = /(?<key>\w*?)(=)(?<value>(.|\n|\r)*)/.exec(variablePair);
             if (exec?.groups?.key) {
                 variables[exec.groups.key] = exec?.groups?.value;
             }

--- a/tests/test-cases/cli-option-variables/.gitlab-ci.yml
+++ b/tests/test-cases/cli-option-variables/.gitlab-ci.yml
@@ -3,3 +3,4 @@ test-job:
   script:
     - echo ${CLI_VAR}
     - echo ${CLI_VAR_DOT}
+    - echo "${CLI_MULTILINE}"

--- a/tests/test-cases/cli-option-variables/integration.cli-option-variables.test.ts
+++ b/tests/test-cases/cli-option-variables/integration.cli-option-variables.test.ts
@@ -13,12 +13,15 @@ test("cli-option-variables <test-job> --variable \"CLI_VAR=hello world\"", async
     await handler({
         cwd: "tests/test-cases/cli-option-variables",
         job: ["test-job"],
-        variable: ["CLI_VAR=hello world", "CLI_VAR_DOT=dotdot"],
+        variable: ["CLI_VAR=hello world", "CLI_VAR_DOT=dotdot", `CLI_MULTILINE=This is a multi
+line string`],
     }, writeStreams);
 
     const expected = [
         chalk`{blueBright test-job} {greenBright >} hello world`,
         chalk`{blueBright test-job} {greenBright >} dotdot`,
+        chalk`{blueBright test-job} {greenBright >} This is a multi`,
+        chalk`{blueBright test-job} {greenBright >} line string`
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });


### PR DESCRIPTION
When passing variables via command line via --variable, and the variable had multi-line content, only the first line was passed onto the container.

Example:

```bash
gitlab-ci-local --variable MULTILINE="This is
a multi line
variable value"
```

In this case, only "This is" was passed to the CI job.