### PR TITLE
chore(schema): Update schema to 379d3cbbce2c5db13840919a8f3c14bab5f9bca5

### DIFF
--- a/src/schema/schema.json
+++ b/src/schema/schema.json
@@ -256,9 +256,13 @@
         },
         "reports": {
           "type": "object",
-          "markdownDescription": "Reports will be uploaded as artifacts, and often displayed in the Gitlab UI, such as in Merge Requests. [Learn More](https://docs.gitlab.com/ee/ci/yaml/#artifactsreports).",
+          "markdownDescription": "Reports will be uploaded as artifacts, and often displayed in the Gitlab UI, such as in merge requests. [Learn More](https://docs.gitlab.com/ee/ci/yaml/#artifactsreports).",
           "additionalProperties": false,
           "properties": {
+            "annotations": {
+              "type": "string",
+              "description": "Path to JSON file with annotations report."
+            },
             "junit": {
               "description": "Path for file(s) that should be parsed as JUnit XML result",
               "oneOf": [
@@ -290,7 +294,8 @@
                 "coverage_format": {
                   "description": "Code coverage format used by the test framework.",
                   "enum": [
-                    "cobertura"
+                    "cobertura",
+                    "jacoco"
                   ]
                 },
                 "path": {
@@ -812,6 +817,15 @@
               ],
               "additionalProperties": false
             },
+            "akeyless": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
             "file": {
               "type": "boolean",
               "default": true,
@@ -836,6 +850,11 @@
             {
               "required": [
                 "gcp_secret_manager"
+              ]
+            },
+            {
+              "required": [
+                "akeyless"
               ]
             }
           ],


### PR DESCRIPTION
See <https://gitlab.com/gitlab-org/gitlab/-/merge_requests/155478>.

Fixes #1307.

Follow up to #1309, which added an easy way to update the schema, but did not actually contain the upstream fix which adds the `annotations` keyword to the schema.