### PR TITLE
fix: handle edge cases of jobs:when where the value `never` is considered invalid

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -134,6 +134,9 @@ export class Parser {
 
         // Check job variables for invalid hash of key value pairs, and cast numbers to strings
         Utils.forEachRealJob(gitlabData, (jobName, jobData) => {
+            assert(jobData.when !== "never",
+                chalk`This GitLab CI configuration is invalid: jobs:${jobName} when:never can only be used in a rules section or workflow:rules`
+            );
             for (const [key, _value] of Object.entries(jobData.variables || {})) {
                 let value = _value;
                 if (value === null) value = ""; // variable's values are nullable

--- a/tests/test-cases/when/.gitlab-ci.yml
+++ b/tests/test-cases/when/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+---
+test-job:
+  stage: deploy
+  when: never
+  script:
+    - echo "test"

--- a/tests/test-cases/when/integration.when.test.ts
+++ b/tests/test-cases/when/integration.when.test.ts
@@ -1,0 +1,25 @@
+import {WriteStreamsMock} from "../../../src/write-streams";
+import {handler} from "../../../src/handler";
+import {initSpawnSpy} from "../../mocks/utils.mock";
+import {WhenStatics} from "../../mocks/when-statics";
+import {AssertionError} from "assert";
+import {assert} from "console";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("when", async () => {
+    try {
+        const writeStreams = new WriteStreamsMock();
+        await handler({
+            cwd: "tests/test-cases/when",
+        }, writeStreams);
+    } catch (e: any) {
+        assert(e instanceof AssertionError, "e is not instanceof AssertionError");
+        expect(e.message).toContain("This GitLab CI configuration is invalid: jobs:test-job when:never can only be used in a rules section or workflow:rules");
+        return;
+    }
+
+    throw new Error("Error is expected but not thrown/caught");
+});


### PR DESCRIPTION
fixes #1328

https://docs.gitlab.com/ee/ci/yaml/#when
![image](https://github.com/user-attachments/assets/19f8de0c-6838-42af-9ee0-6e9d067dbd83)


# Expected behavior after merging:
![image](https://github.com/user-attachments/assets/19895f69-1f44-4c80-9de5-3df0eb8aa2a6)
