### PR TITLE
test: improper teardown in jest

### DIFF
--- a/tests/test-cases/gitlab-runner-emulation/integration.emulate-runner.test.ts
+++ b/tests/test-cases/gitlab-runner-emulation/integration.emulate-runner.test.ts
@@ -2,17 +2,27 @@ import {WriteStreamsMock} from "../../../src/write-streams";
 import {handler} from "../../../src/handler";
 import {initBashSpy, initSpawnSpy} from "../../mocks/utils.mock";
 import {WhenStatics} from "../../mocks/when-statics";
+import {cleanupJobResources, Job} from "../../../src/job";
 import {
     GitlabRunnerCPUsPresetValue,
     GitlabRunnerMemoryPresetValue,
     GitlabRunnerPresetValues,
 } from "../../../src/gitlab-preset";
 
+let jobs: Job[] = [];
 beforeAll(() => {
     initSpawnSpy([...WhenStatics.all, {
         cmdArgs: ["docker", "cp", expect.any(String), expect.any(String)],
         returnValue: {stdout: "Ok"},
     }]);
+});
+
+beforeEach(async () => {
+    jobs = [];
+});
+
+afterEach(async () => {
+    await cleanupJobResources(jobs);
 });
 
 test("--container-emulate some_unexisting_runner", async () => {
@@ -21,7 +31,7 @@ test("--container-emulate some_unexisting_runner", async () => {
         await handler({
             cwd: "tests/test-cases/container-executable",
             containerEmulate: "some_unexisting_runner",
-        }, writeStreams);
+        }, writeStreams, jobs);
 
         expect(true).toBe(false);
     } catch (e: unknown) {

--- a/tests/test-cases/network-arg/integration.network-arg.test.ts
+++ b/tests/test-cases/network-arg/integration.network-arg.test.ts
@@ -1,15 +1,24 @@
 import {WriteStreamsMock} from "../../../src/write-streams";
 import {handler} from "../../../src/handler";
+import {Job, cleanupJobResources} from "../../../src/job";
 import chalk from "chalk";
 import {initSpawnSpy, initBashSpy} from "../../mocks/utils.mock";
 import {WhenStatics} from "../../mocks/when-statics";
 import assert from "assert";
 import {AssertionError} from "assert";
 
+let jobs: Job[] = [];
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
 });
 
+beforeEach(async () => {
+    jobs = [];
+});
+
+afterEach(async () => {
+    await cleanupJobResources(jobs);
+});
 
 test("network-host <test-job>", async () => {
     const bashSpy = initBashSpy([]);
@@ -36,7 +45,7 @@ test("network-host <service-job>", async () => {
             cwd: "tests/test-cases/network-arg",
             job: ["service-job"],
             network: ["host"],
-        }, writeStreams);
+        }, writeStreams, jobs);
     } catch (e) {
         assert(e instanceof AssertionError, "e is not instanceof AssertionError");
         expect(e.message).toBe(chalk`Cannot add service network alias with network mode 'host'`);
@@ -68,7 +77,7 @@ test("network-none <service-job>", async () => {
             cwd: "tests/test-cases/network-arg",
             job: ["service-job"],
             network: ["none"],
-        }, writeStreams);
+        }, writeStreams, jobs);
     } catch (e) {
         assert(e instanceof AssertionError, "e is not instanceof AssertionError");
         expect(e.message).toBe(chalk`Cannot add service network alias with network mode 'none'`);


### PR DESCRIPTION
When the `handler` throws error in the test suites, `cleanupJobResources` is not called, resulting in dangling resources. This should fix the `openHandle` warning when running the tests 

- initially had another idea which is to wrap the handler with a try/finally block
to https://github.com/firecow/gitlab-ci-local/blob/master/src/handler.ts#L24, but it's messy since we're catching the errors in `src/index.ts` so for now went with this, which should be less disruptive
