### PR TITLE
Fixes undefined vars becoming null and erroring in conditions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,7 +218,7 @@ export class Utils {
                 default:
                     throw operator;
             }
-            return `.match(${rhs}${flags})${remainingTokens} ${_operator} null`;
+            return `.match(${rhs}${flags})${remainingTokens} ${_operator} null `;
         });
 
         // Scenario when RHS is surrounded by double-quotes
@@ -252,6 +252,8 @@ Refer to https://docs.gitlab.com/ee/ci/jobs/job_rules.html#unexpected-behavior-f
         // Convert all null.match functions to false
         evalStr = evalStr.replace(/null.match\(.+?\)\s*!=\s*null/g, "false");
         evalStr = evalStr.replace(/null.match\(.+?\)\s*==\s*null/g, "false");
+
+        evalStr = evalStr.trim();
 
         let res;
         try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,7 +199,7 @@ export class Utils {
         // Expand all variables
         evalStr = this.expandTextWith(evalStr, {
             unescape: JSON.stringify("$"),
-            variable: (name) => JSON.stringify(envs[name] ?? null).replaceAll("\\\\", "\\"),
+            variable: (name) => JSON.stringify(envs[name] ?? "").replaceAll("\\\\", "\\"),
         });
         const expandedEvalStr = evalStr;
 
@@ -248,10 +248,6 @@ Refer to https://docs.gitlab.com/ee/ci/jobs/job_rules.html#unexpected-behavior-f
             });
             return `.match(new RegExp(${_rhs})) ${_operator} null`;
         });
-
-        // Convert all null.match functions to false
-        evalStr = evalStr.replace(/null.match\(.+?\) != null/g, "false");
-        evalStr = evalStr.replace(/null.match\(.+?\) == null/g, "false");
 
         let res;
         try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,7 +199,7 @@ export class Utils {
         // Expand all variables
         evalStr = this.expandTextWith(evalStr, {
             unescape: JSON.stringify("$"),
-            variable: (name) => JSON.stringify(envs[name] ?? "").replaceAll("\\\\", "\\"),
+            variable: (name) => JSON.stringify(envs[name] ?? null).replaceAll("\\\\", "\\"),
         });
         const expandedEvalStr = evalStr;
 
@@ -248,6 +248,10 @@ Refer to https://docs.gitlab.com/ee/ci/jobs/job_rules.html#unexpected-behavior-f
             });
             return `.match(new RegExp(${_rhs})) ${_operator} null`;
         });
+
+        // Convert all null.match functions to false
+        evalStr = evalStr.replace(/null.match\(.+?\)\s*!=\s*null/g, "false");
+        evalStr = evalStr.replace(/null.match\(.+?\)\s*==\s*null/g, "false");
 
         let res;
         try {

--- a/tests/rules-regex.test.ts
+++ b/tests/rules-regex.test.ts
@@ -74,7 +74,7 @@ const tests = [
     },
     {
         rule: '$CI_COMMIT_BRANCH && $GITLAB_FEATURES =~ /\bdependency_scanning\b/ && $CI_GITLAB_FIPS_MODE == "true"',
-        jsExpression: 'null && false&& null == "true"',
+        jsExpression: 'null && false && null == "true"',
         evalResult: false,
     },
 ];

--- a/tests/rules-regex.test.ts
+++ b/tests/rules-regex.test.ts
@@ -74,7 +74,7 @@ const tests = [
     },
     {
         rule: '$CI_COMMIT_BRANCH && $GITLAB_FEATURES =~ /\bdependency_scanning\b/ && $CI_GITLAB_FIPS_MODE == "true"',
-        jsExpression: 'null && false && null == "true"',
+        jsExpression: 'null && false&& null == "true"',
         evalResult: false,
     },
 ];

--- a/tests/rules-regex.test.ts
+++ b/tests/rules-regex.test.ts
@@ -72,6 +72,11 @@ const tests = [
         jsExpression: '"23".match(/1234/) != null',
         evalResult: false,
     },
+    {
+        rule: '$CI_COMMIT_BRANCH && $GITLAB_FEATURES =~ /\bdependency_scanning\b/ && $CI_GITLAB_FIPS_MODE == "true"',
+        jsExpression: 'null && false&& null == "true"',
+        evalResult: false,
+    },
 ];
 /* eslint-enable @typescript-eslint/quotes */
 


### PR DESCRIPTION
When running the following

```
> gitlab-ci-local@4.53.0 start
> ts-node --log-error src/index.ts --cwd ../some-dir --list-json
```

The following error occurs

```
Error attempting to evaluate the following rules:
  rules:
    - if: '"main" && null =~ /\bdependency_scanning\b/ && null == "true"'
as
```javascript
"main" && null.match(/\bdependency_scanning\b/)  != null&& null == "true"
```

```
TypeError: Cannot read properties of null (reading 'match')
    at eval (eval at evaluateRuleIf (gitlab-ci-local/src/utils.ts:258:19), <anonymous>:1:20)
    at Function.evaluateRuleIf (gitlab-ci-local/src/utils.ts:258:19)
    at Function.getRulesResult (gitlab-ci-local/src/utils.ts:181:24)
    at new Job (gitlab-ci-local/src/job.ts:217:38)
    at gitlab-ci-local/src/parser.ts:179:29
    at Function.forEachRealJob (gitlab-ci-local/src/utils.ts:54:13)
    at Parser.init (gitlab-ci-local/src/parser.ts:165:15)
    at async Function.create (gitlab-ci-local/src/parser.ts:60:9)
    at async handler (gitlab-ci-local/src/handler.ts:63:18)
    at async Object.handler (gitlab-ci-local/src/index.ts:37:21)
```


I suspect this happens on a yml that contains
```
include:
  - template: Security/SAST.gitlab-ci.yml
  - template: Jobs/Dependency-Scanning.gitlab-ci.yml
```

which expands to the following:

```
gemnasium-maven-dependency_scanning:
  stage: test
  script:
    - /analyzer run
  artifacts:
    access: developer
    reports:
      dependency_scanning: gl-dependency-scanning-report.json
      cyclonedx: '**/gl-sbom-*.cdx.json'
    paths:
      - '**/gl-sbom-*.cdx.json'
  dependencies: []
  rules:
    - if: $DEPENDENCY_SCANNING_DISABLED == 'true' || $DEPENDENCY_SCANNING_DISABLED == '1'
      when: never
    - if: $DS_EXCLUDED_ANALYZERS =~ /gemnasium-maven/
      when: never
    - if: $CI_COMMIT_BRANCH && $GITLAB_FEATURES =~ /\bdependency_scanning\b/ && $CI_GITLAB_FIPS_MODE == "true"
      exists:
        - '**/{build.gradle,build.gradle.kts,build.sbt,pom.xml}'
      variables:
        DS_IMAGE_SUFFIX: '-fips'
    - if: $CI_COMMIT_BRANCH && $GITLAB_FEATURES =~ /\bdependency_scanning\b/
      exists:
        - '**/{build.gradle,build.gradle.kts,build.sbt,pom.xml}'
  allow_failure: true
  variables:
    DS_ANALYZER_IMAGE: $SECURE_ANALYZERS_PREFIX/$DS_ANALYZER_NAME:$DS_MAJOR_VERSION
    DS_ANALYZER_NAME: gemnasium-maven
  image:
    name: $DS_ANALYZER_IMAGE$DS_IMAGE_SUFFIX
  cache:
    - *ref_0
  before_script:
    - >-
      if command -v git && [ $OPS_CONSOLE_SHA ]; then (cd services/opsConsole; git fetch --depth 1 origin $OPS_CONSOLE_SHA; git switch --detach
      $OPS_CONSOLE_SHA); fi
    - >-
      if [ $(npm --version) ] && [ "$CI_JOB_NAME" = "${CI_JOB_NAME#gemnasium}" ]; then npm ci --cache .npm --prefer-offline; else echo "container does not use
      NPM"; fi
```

With the problematic line being

```
- if: $CI_COMMIT_BRANCH && $GITLAB_FEATURES =~ /\bdependency_scanning\b/ && $CI_GITLAB_FIPS_MODE == "true"
```

This can be avoided by defining the variable to be empty, however the proposed solution is likely more future proof.