### PR TITLE
fix git remote regex parsing to handle additional characters

### DIFF
--- a/src/git-data.ts
+++ b/src/git-data.ts
@@ -100,7 +100,7 @@ export class GitData {
             }
 
             if (gitRemote.startsWith("http")) {
-                gitRemoteMatch = /(?<schema>https?):\/\/(?:(\w+):([\w-]+)@)?(?<host>[^/:]+):?(?<port>\d+)?\/(?<group>\S+)\/(?<project>\S+)\.git/.exec(gitRemote); // regexr.com/7ve8l
+                gitRemoteMatch = /(?<schema>https?):\/\/(?:([^:]+):([^@]+)@)?(?<host>[^/:]+):?(?<port>\d+)?\/(?<group>\S+)\/(?<project>\S+)\.git/.exec(gitRemote); // regexr.com/7ve8l
                 assert(gitRemoteMatch?.groups != null, "git remote get-url origin didn't provide valid matches");
 
                 let port = "443";

--- a/tests/git-data.test.ts
+++ b/tests/git-data.test.ts
@@ -75,6 +75,16 @@ const tests = [
         },
     },
     {
+        input: "https://username-with-dashes:glpat-qwerty12345@somegitlab.com:8080/vendor/package.git",
+        expected: {
+            schema: "https",
+            port: "8080",
+            host: "somegitlab.com",
+            group: "vendor",
+            project: "package",
+        },
+    },
+    {
         input: "https://example.com:8443/1/2/3package.git",
         expected: {
             schema: "https",


### PR DESCRIPTION
When `gitlab-ci-local` is run from within gitlab ci, the remote url is `https://gitlab-ci-token:[MASKED]@gitlab.com/user/repo.git`

This PR resolves this issue by updating the regex parsing to handle additional characters.