### PR TITLE
remove fetch-includes early return

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -35,11 +35,6 @@ export async function handler (args: any, writeStreams: WriteStreams, jobs: Job[
 
     assert(fs.existsSync(`${cwd}/${file}`), `${path.resolve(cwd)}/${file} could not be found`);
 
-    if (argv.fetchIncludes) {
-        await Parser.create(argv, writeStreams, 0, jobs);
-        return [];
-    }
-
     if (argv.preview) {
         const pipelineIid = await state.getPipelineIid(cwd, stateDir);
         parser = await Parser.create(argv, writeStreams, pipelineIid, jobs, false);


### PR DESCRIPTION
I previously came across an issue where I was getting incorrect output due to cached files.

On realising this, I set the `--fetch-includes` flags, as it was documented that it would always fetch includes even when cached.

However when this flag was enabled, the program returned no output, and short-circuited all other flags.

This is because of the changes seen below, even though this flag value is used elsewhere to determine whether includes should be refetched.

While this is an api breaking change, if I understand the code correctly, it as an acceptable bug fix.

This is because the flag currently doesn't produce any output and only calls `Parser.create`.

However this PR would set it so that the flag does produce the correct output (which if I understand correctly won't make a difference as the user isn't checking for output) and all other code paths call `Parser.create` anyway.

If this change is not acceptable, the creation of a new flag would be required, along with changes to the rest of the code that uses `fetchIncludes` so that it performs as expected.