### PR TITLE
refactor: pull docker image earlier

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -476,6 +476,8 @@ export class Job {
         }
 
         if (imageName) {
+            await this.pullImage(writeStreams, imageName);
+
             const buildVolumeName = this.buildVolumeName;
             const tmpVolumeName = this.tmpVolumeName;
             const fileVariablesDir = this.fileVariablesDir;
@@ -694,8 +696,6 @@ export class Job {
         this.refreshLongRunningSilentTimeout(writeStreams);
 
         if (imageName && !this._containerId) {
-            await this.pullImage(writeStreams, imageName);
-
             let dockerCmd = `${this.argv.containerExecutable} create --interactive ${this.generateInjectSSHAgentOptions()} `;
             if (this.argv.privileged) {
                 dockerCmd += "--privileged ";


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c4ecf5f0-0fe1-4aae-acd3-c29d52ee9324)
some cases when `docker run ...` is ran before the image is pulled