### PR TITLE
Added --default-image option to be used with --shell-executor-no-image=false

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "depcheck": "1.x.x",
         "esbuild": "^0.24.0",
         "eslint": "8.x.x",
-        "jest": "^29.7.0",
+        "jest": "29.x.x",
         "jest-when": "3.x.x",
         "nodemon": "^3.1.1",
         "ts-jest": "29.x.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "depcheck": "1.x.x",
         "esbuild": "^0.24.0",
         "eslint": "8.x.x",
-        "jest": "29.x.x",
+        "jest": "^29.7.0",
         "jest-when": "3.x.x",
         "nodemon": "^3.1.1",
         "ts-jest": "29.x.x",

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -49,11 +49,11 @@ export class Argv {
             writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --shell-isolation does not work with --no-shell-executor-no-image\n`);
         }
 
-        if (argv.defaultImage && argv.shellIsolation) {
+        if (argv.defaultImageExplicitlySet && argv.shellIsolation) {
             writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --default-image does not work with --shell-isolation=true\n`);
         }
 
-        if (argv.defaultImage && argv.shellExecutorNoImage) {
+        if (argv.defaultImageExplicitlySet && argv.shellExecutorNoImage) {
             writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --default-image does not work with --shell-executor-no-image=true\n`);
         }
 
@@ -284,6 +284,10 @@ export class Argv {
 
     get defaultImage (): string {
         return this.map.get("defaultImage") ?? "docker.io/ruby:3.1";
+    }
+
+    get defaultImageExplicitlySet (): boolean {
+        return this.map.get("defaultImage") ?? false;
     }
 
     get maximumIncludes (): number {

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -48,6 +48,15 @@ export class Argv {
         if (!argv.shellExecutorNoImage && argv.shellIsolation) {
             writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --shell-isolation does not work with --no-shell-executor-no-image\n`);
         }
+
+        if (argv.defaultImage && argv.shellIsolation) {
+            writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --default-image does not work with --shell-isolation=true\n`);
+        }
+
+        if (argv.defaultImage && argv.shellExecutorNoImage) {
+            writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --default-image does not work with --shell-executor-no-image=true\n`);
+        }
+
         return argv;
     }
 
@@ -271,6 +280,10 @@ export class Argv {
     get shellExecutorNoImage (): boolean {
         // TODO: default to false in 5.x.x
         return this.map.get("shellExecutorNoImage") ?? true;
+    }
+
+    get defaultImage (): string {
+        return this.map.get("defaultImage") ?? "docker.io/ruby:3.1";
     }
 
     get maximumIncludes (): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,11 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             description: "Whether to use shell executor when no image is specified.",
             requiresArg: false,
         })
+        .option("default-image", {
+            type: "string",
+            description: "When using --shell-executor-no-image=false which image to be used for the container. Defaults to docker.io/ruby:3.1 if not set.",
+            requiresArg: false,
+        })
         .option("mount-cache", {
             type: "boolean",
             description: "Enable docker mount based caching",

--- a/src/job.ts
+++ b/src/job.ts
@@ -911,7 +911,7 @@ export class Job {
                 return null;
             } else {
                 // https://docs.gitlab.com/ee/ci/runners/hosted_runners/linux.html#container-images
-                return "docker.io/ruby:3.1";
+                return this.argv.defaultImage;
             }
         }
         const expanded = Utils.expandVariables(vars);

--- a/tests/test-cases/shell-executor-no-image/.gitlab-ci.yml
+++ b/tests/test-cases/shell-executor-no-image/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+test-job:
+  stage: test
+  script:
+    - echo "Heya from default-image"

--- a/tests/test-cases/shell-executor-no-image/integration.shell-executor-no-image.test.ts
+++ b/tests/test-cases/shell-executor-no-image/integration.shell-executor-no-image.test.ts
@@ -1,0 +1,45 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+
+test("shell-executor-no-image false default-image alpine", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        pullPolicy: "if-not-present",
+        cwd: "tests/test-cases/shell-executor-no-image/",
+        shellExecutorNoImage: false,
+        defaultImage: "alpine:latest",
+        job: ["test-job"],
+        noColor: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/test-job starting alpine:latest \(test\)/);
+});
+
+test("shell-executor-no-image false default-image null", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        pullPolicy: "if-not-present",
+        cwd: "tests/test-cases/shell-executor-no-image/",
+        shellExecutorNoImage: false,
+        defaultImage: null,
+        job: ["test-job"],
+        noColor: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/test-job starting docker.io\/ruby:3.1 \(test\)/);
+});
+
+test("shell-executor-no-image true default-image doesnt-matter", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        pullPolicy: "if-not-present",
+        cwd: "tests/test-cases/shell-executor-no-image/",
+        shellExecutorNoImage: true,
+        defaultImage: "doesnt-matter",
+        job: ["test-job"],
+        noColor: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/test-job starting shell \(test\)/);
+    expect(writeStreams.stderrLines.join("\n")).toMatch(/WARN\s\s--default-image does not work with --shell-executor-no-image=true/);
+});


### PR DESCRIPTION
Currently if `--shell-executor-no-image=false` is used the runner defaults to `docker.io/ruby:3.1`.
In case isolation is required, there is no option to run the ci in a custom image.

Added --default-image option. 
If set when `--shell-executor-no-image=false`, the value will be used as a image source for the container.
If not set when `--shell-executor-no-image=false`, the default `docker.io/ruby:3.1` will be used.
If set when `--shell-executor-no-image=true` (or not set), warring message is displayed.
If set when `--shell-isolation`, warring message is displayed.

~Fixed typo (or old option name) in `arvg.ts:49`, from `--no-shell-executor-no-image` to  `--shell-executor-no-image`~

Included 3 tests to validate proper runner image/shell is used.