### PR TITLE
fix: Parsing of rules fails in where there is no whitespace near the parentheses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,7 +218,7 @@ export class Utils {
                 default:
                     throw operator;
             }
-            return `.match(${rhs}${flags})${remainingTokens} ${_operator} null `;
+            return `.match(${rhs}${flags}) ${_operator} null${remainingTokens}`;
         });
 
         // Scenario when RHS is surrounded by double-quotes

--- a/tests/rules-regex.test.ts
+++ b/tests/rules-regex.test.ts
@@ -77,6 +77,16 @@ const tests = [
         jsExpression: 'null && false && null == "true"',
         evalResult: false,
     },
+    {
+        rule: '($CI_MERGE_REQUEST_SOURCE_BRANCH_NAME =~ /^perf_.*$/)',
+        jsExpression: '(false)', // ((null.match(/^perf_.*$/) != null)) => (false)
+        evalResult: false,
+    },
+    {
+        rule: '("qwerty" =~ /^perf_.*$/)',
+        jsExpression: '("qwerty".match(/^perf_.*$/) != null)',
+        evalResult: false,
+    },
 ];
 /* eslint-enable @typescript-eslint/quotes */
 


### PR DESCRIPTION
fixes #1416 