### PR TITLE
Fix list-json rules by only returning rules if defined

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -244,7 +244,7 @@ export class Commander {
                 when: job.when,
                 allow_failure: job.allowFailure,
                 needs: job.needs?.filter(n => !n.project && !n.pipeline),
-                rules: job.rules,
+                rules: job.rules ?? [],
             });
         });
 

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -244,7 +244,7 @@ export class Commander {
                 when: job.when,
                 allow_failure: job.allowFailure,
                 needs: job.needs?.filter(n => !n.project && !n.pipeline),
-                rules: job.rules ?? [],
+                ...job.rules ? {rules: job.rules} : {},
             });
         });
 


### PR DESCRIPTION
list-json was returning `null` in json for rules output when the rules were undefined