### PR TITLE
Fix running error by reverting import with type json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,9 +10,9 @@ import {Argv} from "./argv.js";
 import {AssertionError} from "assert";
 import {Job, cleanupJobResources} from "./job.js";
 import {GitlabRunnerPresetValues} from "./gitlab-preset.js";
-import packageJson from "../package.json";
 
 const jobs: Job[] = [];
+const version = JSON.parse("../package.json")["version"];
 
 process.on("SIGINT", async (_: string, code: number) => {
     await cleanupJobResources(jobs);
@@ -26,7 +26,7 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
     const yparser = yargs(process.argv.slice(2));
     yparser.parserConfiguration({"greedy-arrays": false})
         .showHelpOnFail(false)
-        .version(packageJson["version"])
+        .version(version)
         .wrap(yparser.terminalWidth?.())
         .command({
             handler: async (argv) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {Argv} from "./argv.js";
 import {AssertionError} from "assert";
 import {Job, cleanupJobResources} from "./job.js";
 import {GitlabRunnerPresetValues} from "./gitlab-preset.js";
-import packageJson from "../package.json" with { type: "json" };
+import packageJson from "../package.json";
 
 const jobs: Job[] = [];
 

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,4 +1,4 @@
-import _schema from "./schema.json" with { type: "json" };
+import _schema from "./schema.json";
 
 const schema: any = _schema;
 schema.definitions.job_template.properties.gclInjectSSHAgent = {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,6 +1,4 @@
-import _schema from "./schema.json";
-
-const schema: any = _schema;
+const schema: any = JSON.parse("./schema.json");
 schema.definitions.job_template.properties.gclInjectSSHAgent = {
     "type": "boolean",
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,5 @@
     "inlineSources": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
When running the tool, the following error is returned:
```
npx --yes gitlab-ci-local@latest                                                                                                                                                 
file:///Users/username/.npm/_npx/3f18f2096def1b34/node_modules/gitlab-ci-local/src/index.js:13
import packageJson from "../package.json" with { type: "json" };
                                          ^^^^

SyntaxError: Unexpected token 'with'
    at ESMLoader.moduleStrategy (node:internal/modules/esm/translators:119:18)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:468:14)
    at async link (node:internal/modules/esm/module_job:68:21)

Node.js v18.18.2
```

**Minimal .gitlab-ci.yml illustrating the issue**
```yml
---
job:
  script:
    - echo "Heya"
```

**Expected behavior**
Tool to run

**Host information**
MacOs
gitlab-ci-local 4.55

**Containerd binary**
Are you using docker

**Additional context**
This seems related to #1331 and #1337

My installed typescript version is 5.6.3, so I don't think it's that.

Still trying to figure out why this doesn't work.