### PR TITLE
Fix json import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import chalk from "chalk";
+import {readFileSync} from "fs";
 import yargs from "yargs";
 import {Parser} from "./parser.js";
 import * as state from "./state.js";
@@ -10,9 +11,10 @@ import {Argv} from "./argv.js";
 import {AssertionError} from "assert";
 import {Job, cleanupJobResources} from "./job.js";
 import {GitlabRunnerPresetValues} from "./gitlab-preset.js";
-import packageJson from "../package.json";
 
 const jobs: Job[] = [];
+
+const version = JSON.parse(readFileSync("package.json", "utf8"))["version"];
 
 process.on("SIGINT", async (_: string, code: number) => {
     await cleanupJobResources(jobs);
@@ -26,7 +28,7 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
     const yparser = yargs(process.argv.slice(2));
     yparser.parserConfiguration({"greedy-arrays": false})
         .showHelpOnFail(false)
-        .version(packageJson["version"])
+        .version(version)
         .wrap(yparser.terminalWidth?.())
         .command({
             handler: async (argv) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {Argv} from "./argv.js";
 import {AssertionError} from "assert";
 import {Job, cleanupJobResources} from "./job.js";
 import {GitlabRunnerPresetValues} from "./gitlab-preset.js";
-import packageJson from "../package.json" with { type: "json" };
+import packageJson from "../package.json";
 
 const jobs: Job[] = [];
 

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,4 +1,4 @@
-import _schema from "./schema.json" with { type: "json" };
+import _schema from "./schema.json";
 
 const schema: any = _schema;
 schema.definitions.job_template.properties.gclInjectSSHAgent = {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,6 +1,5 @@
-import _schema from "./schema.json";
-
-const schema: any = _schema;
+import {readFileSync} from "fs";
+const schema: any = JSON.parse(readFileSync("src/schema/schema.json", "utf8"));
 schema.definitions.job_template.properties.gclInjectSSHAgent = {
     "type": "boolean",
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,5 @@
     "inlineSources": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Reopening of #1422 

In Node 18.18, the following error occurs:
```
npx --yes gitlab-ci-local@latest                                                                                                                                                 
file:///Users/username/.npm/_npx/3f18f2096def1b34/node_modules/gitlab-ci-local/src/index.js:13
import packageJson from "../package.json" with { type: "json" };
                                          ^^^^

SyntaxError: Unexpected token 'with'
    at ESMLoader.moduleStrategy (node:internal/modules/esm/translators:119:18)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:468:14)
    at async link (node:internal/modules/esm/module_job:68:21)

Node.js v18.18.2
```

This PR fixes the issue by converting json imports to instead use readfilesync and JSON.parse instead, which makes it more explicit and avoids this error.

This fix allows users who may otherwise not be able to update to Node v18.20 overnight to continue using this tool.

Thanks again!