### PR TITLE
#1426 Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Get rid of all those dev specific shell scripts and make files.
     * [Self Hosted Custom Ports](#self-hosted-custom-ports)
 * [Development](#development)
     * [Scripts](#scripts)
-    * [Package binaries](#package-binaries)
+* [Creating single executable binaries from source](#creating-single-executable-binaries-from-source)
 
 ## Installation
 
@@ -402,19 +402,29 @@ npm run esbuild
 # Run all tests
 npm run test
 
+# Run the program with hot-reloading enabled using the `.gitlab-ci.yml` in the root directory
+npm run dev
+
+# Pass --help flag into the program
+npm run dev -- -- --help # (equivalent of gitlab-ci-local --help)
+
 # Run individual test-case
 npx jest tests/test-cases/cache-paths-not-array
 ```
 
 ![example](./docs/images/example.png)
 
-It's also possible to run individual `.gitlab-ci.yml`, via `node src/index.js --cwd examples/docker-compose-nodejs`
+It's also possible to run individual `.gitlab-ci.yml`, via `npx tsx src/index.ts --cwd examples/docker-compose-nodejs`
 
-### Package binaries
-
+## Creating single executable binaries from source
 ```bash
+npm install
+npm run esbuild
+
+# According to your needs:
 npm run pkg-linux
 npm run pkg-win
 npm run pkg-macos
 npm run pkg-all
+# the binary will be generated in the respective ./bin/<os>/gitlab-ci-local
 ```

--- a/README.md
+++ b/README.md
@@ -396,6 +396,9 @@ You need nodejs 18+
 # Install node_modules
 npm install
 
+# Build
+npm run esbuild
+
 # Run all tests
 npm run test
 

--- a/README.md
+++ b/README.md
@@ -396,9 +396,6 @@ You need nodejs 18+
 # Install node_modules
 npm install
 
-# Build
-npm run esbuild
-
 # Run all tests
 npm run test
 


### PR DESCRIPTION
link to #1426 

~npm run esbuild is mandatory to package 
not sure it has to be there~


---
edits:
(npm run esbuild is is only required for creating the single executable binary)
