### PR TITLE
fix(deps): Debian package needs rsync to run, so depend on it

### DIFF
--- a/publish-deb
+++ b/publish-deb
@@ -20,6 +20,7 @@ Maintainer: Mads Jon Nielsen <madsjon@gmail.com>
 Description: ${DESCRIPTION}
 Homepage: https://github.com/firecow/gitlab-ci-local
 Website: https://github.com/firecow/gitlab-ci-local
+Depends: rsync
 EOF
 
 mkdir -p "bin/gitlab-ci-local_${VERSION}_amd64/usr/local/bin/"


### PR DESCRIPTION
Running gitlab-ci-local will fail on a system that does not have rsync. Add it as a dependency to automatically install it if missing.