### PR TITLE
feat: add --shell-executor option. (#1447).

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -58,6 +58,10 @@ export class Argv {
             writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --default-image does not work with --shell-executor-no-image=true\n`);
         }
 
+        if (argv.defaultImageExplicitlySet && argv.forceShellExecutor) {
+            writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } --default-image does not work with --force-shell-executor=true\n`);
+        }
+
         return argv;
     }
 
@@ -285,6 +289,10 @@ export class Argv {
     get shellExecutorNoImage (): boolean {
         // TODO: default to false in 5.x.x
         return this.map.get("shellExecutorNoImage") ?? true;
+    }
+
+    get forceShellExecutor (): boolean {
+        return this.map.get("forceShellExecutor") ?? false;
     }
 
     get defaultImage (): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,11 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             description: "Enable artifact isolation for shell-executor jobs",
             requiresArg: false,
         })
+        .option("force-shell-executor", {
+            type: "boolean",
+            description: "Forces all jobs to be executed using the shell executor. (Only use this option for trusted job)",
+            requiresArg: false,
+        })
         .option("shell-executor-no-image", {
             type: "boolean",
             description: "Whether to use shell executor when no image is specified.",

--- a/src/job.ts
+++ b/src/job.ts
@@ -991,6 +991,9 @@ export class Job {
     }
 
     private imageName (vars: {[key: string]: string} = {}): string | null {
+        if (this.argv.forceShellExecutor) {
+            return null;
+        }
         const image = this.jobData["image"];
         if (!image) {
             if (this.argv.shellExecutorNoImage) {

--- a/tests/test-cases/force-shell-executor/.gitlab-ci.yml
+++ b/tests/test-cases/force-shell-executor/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+---
+test-job:
+  image: alpine:latest
+  stage: test
+  script:
+    - echo "Heya from default-image"

--- a/tests/test-cases/force-shell-executor/integration.test.ts
+++ b/tests/test-cases/force-shell-executor/integration.test.ts
@@ -1,0 +1,45 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+
+test("force-shell-executor false default-image alpine", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        pullPolicy: "if-not-present",
+        cwd: "tests/test-cases/force-shell-executor/",
+        forceShellExecutor: false,
+        defaultImage: "alpine:latest",
+        job: ["test-job"],
+        noColor: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/test-job starting alpine:latest \(test\)/);
+});
+
+test("force-shell-executor false default-image null but job image alpine", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        pullPolicy: "if-not-present",
+        cwd: "tests/test-cases/force-shell-executor/",
+        forceShellExecutor: false,
+        defaultImage: null,
+        job: ["test-job"],
+        noColor: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/test-job starting alpine:latest \(test\)/);
+});
+
+test("force-shell-executor true default-image doesnt-matter", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        pullPolicy: "if-not-present",
+        cwd: "tests/test-cases/force-shell-executor/",
+        forceShellExecutor: true,
+        defaultImage: "doesnt-matter",
+        job: ["test-job"],
+        noColor: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/test-job starting shell \(test\)/);
+    expect(writeStreams.stderrLines.join("\n")).toMatch(/WARN\s\s--default-image does not work with --force-shell-executor=true/);
+});


### PR DESCRIPTION
--shell-executor option (#1447)
Allows forcing to always use the shell executor even when there are images declared somewhere. Avoids image downloads and updates when you want a speedy pipeline