### PR TITLE
fix: services:entrypoint should support variable expansion and double quotes

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1386,7 +1386,9 @@ export class Job {
 
         if (serviceEntrypoint?.length ?? 0 > 1) {
             serviceEntrypoint?.slice(1).forEach((e) => {
-                dockerCmd += `"${e}" `;
+                dockerCmd += `'${e
+                    .replace(/'/g, "'\"'\"'") // replaces `'` with `'"'"'`
+                }' `;
             });
         }
         (service.command ?? []).forEach((e) => dockerCmd += `"${e.replace(/\$/g, "\\$")}" `);

--- a/tests/test-cases/services/.gitlab-ci-2.yml
+++ b/tests/test-cases/services/.gitlab-ci-2.yml
@@ -1,0 +1,17 @@
+---
+job1:
+  services:
+    - name: nginx:1.27.4-alpine-slim
+      entrypoint:
+        - "sh"
+        - "-c"
+        - |
+          cat > /usr/share/nginx/html/index.html <<EOF
+          should support single quote       [']
+          should support double quote       ["]
+          should support variable expansion [$NGINX_VERSION]
+          EOF
+          /docker-entrypoint.sh nginx -g 'daemon off;'
+  image: busybox
+  script:
+    - wget -qO- nginx

--- a/tests/test-cases/services/integration.test.ts
+++ b/tests/test-cases/services/integration.test.ts
@@ -140,3 +140,19 @@ test.concurrent("services <no-tmp>", async () => {
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });
+
+test("services <no-tmp>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/services",
+        file: ".gitlab-ci-2.yml",
+        noColor: true,
+    }, writeStreams);
+
+    const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("job1 >")).join("\n");
+    expect(filteredStdout).toEqual(`
+job1 > should support single quote       [']
+job1 > should support double quote       ["]
+job1 > should support variable expansion [1.27.4]
+`.trim());
+});


### PR DESCRIPTION
closes #1484 