### PR TITLE
feat: partially ignore json schema validation

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -25,6 +25,7 @@ export class Argv {
     static readonly default = {
         "variablesFile": ".gitlab-ci-local-variables.yml",
         "evaluateRuleChanges": true,
+        "ignoreSchemaPaths": [],
     };
 
     map: Map<string, any> = new Map<string, any>();
@@ -135,6 +136,10 @@ export class Argv {
     get extraHost (): string[] {
         const val = this.map.get("extraHost") ?? [];
         return typeof val == "string" ? val.split(" ") : val;
+    }
+
+    get ignoreSchemaPaths (): string[] {
+        return this.map.get("ignoreSchemaPaths") ?? Argv.default.ignoreSchemaPaths;
     }
 
     get pullPolicy (): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,12 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             description: "Whether to enable json schema validation",
             requiresArg: false,
         })
+        .option("ignore-schema-paths", {
+            type: "array",
+            requiresArg: false,
+            default: Argv.default.ignoreSchemaPaths,
+            description: "The json schema paths that will be ignored",
+        })
         .option("concurrency", {
             type: "number",
             description: "Limit the number of jobs that run simultaneously",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -82,6 +82,7 @@ export class Parser {
             Validator.jsonSchemaValidation({
                 pathToExpandedGitLabCi,
                 gitLabCiConfig: parser.gitlabData,
+                argv,
             });
             if (argv.childPipelineDepth == 0) writeStreams.stderr(chalk`{grey json schema validated in ${prettyHrtime(process.hrtime(time))}}\n`);
         }

--- a/src/schema-error.ts
+++ b/src/schema-error.ts
@@ -7,6 +7,7 @@ import pointer from "jsonpointer";
 export interface ValidationError {
     message: string;
     path: string;
+    schemaPath: string;
 }
 
 const QUOTES_REGEX = /"/g;
@@ -78,6 +79,7 @@ export const betterAjvErrors = ({
     return definedErrors.map((error) => {
         const path = basePath ? pointerToDotNotation(basePath + error.instancePath) : pointerToDotNotation(error.instancePath).substring(1);
         const prop = getLastSegment(error.instancePath);
+        const schemaPath = error.schemaPath;
         const propertyMessage = prop ? `property '${prop}'` : path;
         const defaultMessage = `${propertyMessage} ${(cleanAjvMessage(error.message as string))}`;
 
@@ -89,6 +91,7 @@ export const betterAjvErrors = ({
                 validationError = {
                     message: `'${additionalProp}' property is not expected to be here`,
                     path,
+                    schemaPath,
                 };
                 break;
             }
@@ -99,6 +102,7 @@ export const betterAjvErrors = ({
                 validationError = {
                     message: `'${prop}' property must be one of [${allowedValues.join(", ")}] (found ${value})`,
                     path,
+                    schemaPath,
                 };
                 break;
             }
@@ -108,6 +112,7 @@ export const betterAjvErrors = ({
                 validationError = {
                     message: `'${prop}' property type must be ${type}`,
                     path,
+                    schemaPath,
                 };
                 break;
             }
@@ -115,6 +120,7 @@ export const betterAjvErrors = ({
                 validationError = {
                     message: `${path} must have required property '${error.params.missingProperty}'`,
                     path,
+                    schemaPath,
                 };
                 break;
             }
@@ -122,11 +128,12 @@ export const betterAjvErrors = ({
                 return {
                     message: `'${prop}' property must be equal to the allowed value`,
                     path,
+                    schemaPath,
                 };
             }
 
             default:
-                validationError = {message: defaultMessage, path};
+                validationError = {message: defaultMessage, path, schemaPath};
         }
 
         // Remove empty properties
@@ -140,4 +147,3 @@ export const betterAjvErrors = ({
         return validationError;
     });
 };
-

--- a/tests/test-cases/schema-validation-ignore/.gitlab-ci-1.yml
+++ b/tests/test-cases/schema-validation-ignore/.gitlab-ci-1.yml
@@ -1,0 +1,6 @@
+---
+job:
+  image: busybox:latest
+  script:
+    - echo "hello world"
+  tags: []

--- a/tests/test-cases/schema-validation-ignore/.gitlab-ci-2.yml
+++ b/tests/test-cases/schema-validation-ignore/.gitlab-ci-2.yml
@@ -1,0 +1,9 @@
+---
+job:
+  image: busybox:latest
+  script:
+    - echo "hello world"
+  tags: []
+  artifacts:
+    reports:
+      junit: []

--- a/tests/test-cases/schema-validation-ignore/integration.test.ts
+++ b/tests/test-cases/schema-validation-ignore/integration.test.ts
@@ -1,0 +1,51 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import assert, {AssertionError} from "assert";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("should be able to ignore 1 schemaPath", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        file: ".gitlab-ci-1.yml",
+        cwd: "tests/test-cases/schema-validation-ignore",
+        ignoreSchemaPaths: ["#/definitions/tags/minItems"],
+    }, writeStreams);
+});
+
+test("should be able to ignore 2 schemaPath", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        file: ".gitlab-ci-2.yml",
+        cwd: "tests/test-cases/schema-validation-ignore",
+        ignoreSchemaPaths: [
+            "#/definitions/tags/minItems",
+            "#/properties/reports/properties/junit/oneOf/0/type",
+        ],
+    }, writeStreams);
+});
+
+test("should be still fail for schemaPath that's not ignored", async () => {
+    try {
+        const writeStreams = new WriteStreamsMock();
+        await handler({
+            file: ".gitlab-ci-2.yml",
+            cwd: "tests/test-cases/schema-validation-ignore",
+            noColor: true,
+            ignoreSchemaPaths: [
+                "#/properties/reports/properties/junit/oneOf/0/type",
+            ],
+        }, writeStreams);
+        expect(true).toBe(false);
+    } catch (e: any) {
+        const expected = `Invalid .gitlab-ci.yml configuration!
+\t• property 'tags' must not have fewer than 1 items at job.tags [#/definitions/tags/minItems]
+`;
+        assert(e instanceof AssertionError, "e is not instanceof AssertionError");
+        expect(e.message).toContain(expected);
+    }
+});

--- a/tests/test-cases/schema-validation/integration.test.ts
+++ b/tests/test-cases/schema-validation/integration.test.ts
@@ -69,10 +69,10 @@ test("schema validation 4 errors", async () => {
     } catch (e: any) {
         const expected = `
 Invalid .gitlab-ci.yml configuration!
-\t• 'variables' property type must be object at error1.variables
-\t• 'variables' property type must be object at error2.variables
-\t• 'variables' property type must be object at error3.variables
-\t• 'variables' property type must be object at error4.variables
+\t• 'variables' property type must be object at error1.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error2.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error3.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error4.variables [#/definitions/jobVariables/type]
 
 `;
         assert(e instanceof AssertionError, "e is not instanceof AssertionError");
@@ -91,11 +91,11 @@ test("schema validation 5 errors", async () => {
         expect(true).toBe(false);
     } catch (e: any) {
         const expected = `Invalid .gitlab-ci.yml configuration!
-\t• 'variables' property type must be object at error1.variables
-\t• 'variables' property type must be object at error2.variables
-\t• 'variables' property type must be object at error3.variables
-\t• 'variables' property type must be object at error4.variables
-\t• 'variables' property type must be object at error5.variables
+\t• 'variables' property type must be object at error1.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error2.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error3.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error4.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error5.variables [#/definitions/jobVariables/type]
 
 For further troubleshooting, consider either of the following:`;
         assert(e instanceof AssertionError, "e is not instanceof AssertionError");
@@ -114,11 +114,11 @@ test("schema validation 6 errors", async () => {
         expect(true).toBe(false);
     } catch (e: any) {
         const expected = `Invalid .gitlab-ci.yml configuration!
-\t• 'variables' property type must be object at error1.variables
-\t• 'variables' property type must be object at error2.variables
-\t• 'variables' property type must be object at error3.variables
-\t• 'variables' property type must be object at error4.variables
-\t• 'variables' property type must be object at error5.variables
+\t• 'variables' property type must be object at error1.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error2.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error3.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error4.variables [#/definitions/jobVariables/type]
+\t• 'variables' property type must be object at error5.variables [#/definitions/jobVariables/type]
 \t... and 1 more
 
 `;


### PR DESCRIPTION
This should be useful for the following scenarios:
- gitlab-ci-local json schema is outdated
- json schema fails but gitlab.com pipeline still accepts it

closes #1503 