### PR TITLE
Update schema.ts

### DIFF
--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1354,6 +1354,9 @@ export const schema = {
             "description": "Splits up a single job into multiple that run in parallel. Provides `CI_NODE_INDEX` and `CI_NODE_TOTAL` environment variables to the jobs.",
             "oneOf": [
                 {
+                    "type": "null",
+                },
+                {
                     "type": "integer",
                     "description": "Creates N instances of the job that run in parallel.",
                     "default": 0,


### PR DESCRIPTION
Allowing null in parallel's schema.

According to https://docs.gitlab.com/ci/yaml/yaml_optimization/#exclude-a-key-from-extends , the way to overwrite a field from a base job that is extended is to set the value to null for that key. So this change probably should be made to every item that doesn't have have a required none null value.

In my use case here, is we have a template job that defines a parallel matrix with variables, and then another job that extends on it. However the child job is a single job that doesn't have a matrix.

Work around would be to create a dummy matrix with a single cardinality in it.
