### PR TITLE
fix: Fix inputs parsing when ctx.inputs is undefined.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -409,7 +409,7 @@ function parseIncludeInputs (ctx: any): {inputValue: any; inputType: InputType} 
 
 function getInputValue (ctx: any) {
     const {inputs, interpolationKey, configFilePath, inputsSpecification} = ctx;
-    const inputValue = inputs[interpolationKey] ??
+    const inputValue = inputs?.[interpolationKey] ??
         inputsSpecification.spec.inputs[interpolationKey]?.default;
     assert(inputValue !== undefined, chalk`This GitLab CI configuration is invalid: \`{blueBright ${configFilePath}}\`: \`{blueBright ${interpolationKey}}\` input: required value has not been provided.`);
     return inputValue;

--- a/tests/test-cases/basic-inputs/input-templates/default-no-inputs/.gitlab-ci.yml
+++ b/tests/test-cases/basic-inputs/input-templates/default-no-inputs/.gitlab-ci.yml
@@ -1,0 +1,26 @@
+---
+spec:
+  inputs:
+    default_input_string:
+      type: string
+      default: string
+    default_input_number:
+      default: 1
+      type: number
+    default_input_boolean:
+      default: true
+      type: boolean
+    default_input_array:
+      type: array
+      default:
+        - alice
+        - bob
+---
+stages:
+  - test
+scan-website:
+  script:
+    - echo $[[ inputs.default_input_string ]]
+    - echo $[[ inputs.default_input_number ]]
+    - echo $[[ inputs.default_input_boolean ]]
+    - $[[ inputs.default_input_array ]]

--- a/tests/test-cases/basic-inputs/integration.test.ts
+++ b/tests/test-cases/basic-inputs/integration.test.ts
@@ -1,0 +1,33 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import assert, {AssertionError} from "assert";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import chalk from "chalk";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("basic-inputs defaults no inputs", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/basic-inputs/input-templates/default-no-inputs",
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - test
+  - .post
+scan-website:
+  script:
+    - echo string
+    - echo 1
+    - echo true
+    - alice
+    - bob`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});

--- a/tests/test-cases/basic-inputs/integration.test.ts
+++ b/tests/test-cases/basic-inputs/integration.test.ts
@@ -1,9 +1,7 @@
 import {WriteStreamsMock} from "../../../src/write-streams.js";
 import {handler} from "../../../src/handler.js";
-import assert, {AssertionError} from "assert";
 import {initSpawnSpy} from "../../mocks/utils.mock.js";
 import {WhenStatics} from "../../mocks/when-statics.js";
-import chalk from "chalk";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);


### PR DESCRIPTION
A tiny fix for parsing inputs. It's for the case when `spec.inputs` are specified in main `.gitlab-ci.yml` with defaults and no inputs provided for the job.

Example:
```
---
spec:
  inputs:
    foo:
      type: string
      default: bar
---
job:
  script:
    - echo $[[ inputs.foo ]]
```