### PR TITLE
feat: implement cache:key:prefix and some enhancement to make gcl cache work more similar to gitlab.com

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -328,6 +328,25 @@ export class Utils {
         });
     }
 
+    static isSubpath (lhs: string, rhs: string, cwd: string = process.cwd()) {
+        let absLhs = "";
+        if (path.isAbsolute(lhs)) {
+            absLhs = lhs;
+        } else {
+            absLhs = path.resolve(cwd, lhs);
+        }
+
+        let absRhs = "";
+        if (path.isAbsolute(rhs)) {
+            absRhs = rhs;
+        } else {
+            absRhs = path.resolve(cwd, rhs);
+        }
+
+        const relative = path.relative(absRhs, absLhs);
+        return !relative.startsWith("..");
+    }
+
     static async rsyncTrackedFiles (cwd: string, stateDir: string, target: string): Promise<{hrdeltatime: [number, number]}> {
         const time = process.hrtime();
         await fs.mkdirp(`${cwd}/${stateDir}/builds/${target}`);

--- a/tests/test-cases/cache-docker/.gitlab-ci.yml
+++ b/tests/test-cases/cache-docker/.gitlab-ci.yml
@@ -4,19 +4,58 @@ variables:
 
 produce-cache:
   stage: build
-  image: docker.io/library/alpine
+  image: busybox
   cache:
     key: $VALUE
-    paths: [.cache]
-  script: mkdir -p .cache && touch .cache/file1
+    paths:
+      - .cache
+      - .cache/
+      - .cache/*
+      - .cache/**
+      - .cache2/*/bar
+      - .cache2/**/bar
+      - .cache3
+      - /tmp
+  script:
+    - |
+      # creating 4 files/folder that should match .cache
+      mkdir -p .cache
+      touch .cache/file1
+      touch .cache/file2
+      touch .cache/.hiddenfile
+
+    - |
+      # creating 4 files/folder that should match .cache2/*/bar
+      mkdir -p .cache2/foo/bar
+      touch .cache2/foo/bar/file1
+      touch .cache2/foo/bar/file2
+      touch .cache2/foo/bar/.hiddenfile
+
+    - |
+      # creating files in .cache2 which should not match .cache2/*.bar
+      touch .cache2/a
+      touch .cache2/b
+      mkdir -p .cache2/foo/bazz
+      touch .cache2/foo/bazz/a
 
 consume-cache:
   stage: test
-  image: docker.io/library/alpine
+  image: busybox
   needs: [produce-cache]
   dependencies: [produce-cache]  # testing the absence of artifacts
   cache:
     key: maven
     paths: [.cache]
     policy: pull
-  script: if [ ! -f .cache/file1 ]; then exit 1; fi
+  script:
+    - test -f .cache/file1
+    - test -f .cache/file2
+    - test -f .cache/.hiddenfile
+
+    - test -f .cache2/foo/bar/file1
+    - test -f .cache2/foo/bar/file2
+    - test -f .cache2/foo/bar/.hiddenfile
+
+    - "! test -f .cache2/a"
+    - "! test -f .cache2/b"
+    - "! test -f .cache2/foo/bazz/a"

--- a/tests/test-cases/cache-docker/integration.test.ts
+++ b/tests/test-cases/cache-docker/integration.test.ts
@@ -3,18 +3,51 @@ import {handler} from "../../../src/handler.js";
 import fs from "fs-extra";
 import {initSpawnSpy} from "../../mocks/utils.mock.js";
 import {WhenStatics} from "../../mocks/when-statics.js";
+import {basename} from "node:path/posix";
+import {dirname} from "node:path";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
 });
 
-test.concurrent("cache-docker <consume-cache> --needs", async () => {
-    await fs.rm("tests/test-cases/cache-docker/.gitlab-ci-local/cache/", {recursive: true, force: true});
+const name = basename(dirname(import.meta.url));
+const cwd = `tests/test-cases/${name}`;
+
+describe(name, () => {
     const writeStreams = new WriteStreamsMock();
-    await handler({
-        cwd: "tests/test-cases/cache-docker",
-        job: ["consume-cache"],
-        needs: true,
-    }, writeStreams);
-    expect(writeStreams.stdoutLines.join("\n")).toEqual(expect.stringMatching(/exported cache .cache 'maven'/));
+    beforeAll(async () => {
+        await fs.rm(`${cwd}/.gitlab-ci-local/cache/`, {recursive: true, force: true}); // to ensure that the cache from previous runs gets deleted
+
+        await handler({
+            cwd,
+            noColor: true,
+            file: ".gitlab-ci.yml",
+        }, writeStreams);
+    });
+
+    it("should show export cache message", () => {
+        expect(writeStreams.stdoutLines.join("\n")).toContain("produce-cache cache created in '.gitlab-ci-local/cache/maven'");
+    });
+
+    it("should show the correct number of files that's exported", () => {
+        expect(writeStreams.stdoutLines.join("\n")).toContain(".cache: found 4 artifact files and directories");
+        expect(writeStreams.stdoutLines.join("\n")).toContain(".cache/: found 4 artifact files and directories");
+        expect(writeStreams.stdoutLines.join("\n")).toContain(".cache/*: found 3 artifact files and directories");
+        // NOTE: gitlab.com shows .cache/**: found 7 matching artifact files and directories
+        //       i can't make any sense of it, i think it's probably a bug?
+        expect(writeStreams.stdoutLines.join("\n")).toContain(".cache/**: found 3 artifact files and directories");
+        expect(writeStreams.stdoutLines.join("\n")).toContain(".cache2/*/bar: found 4 artifact files and directories");
+        expect(writeStreams.stdoutLines.join("\n")).toContain(".cache2/**/bar: found 4 artifact files and directories");
+        expect(writeStreams.stdoutLines.join("\n")).toContain("WARNING: .cache3: no matching files. Ensure that the artifact path is relative to the working directory");
+        expect(writeStreams.stdoutLines.join("\n")).toContain("WARNING: processPath: artifact path is not a subpath of project directory: /tmp");
+    });
+
+    it("should export cache to local fs", () => {
+        expect(fs.existsSync(`${cwd}/.gitlab-ci-local/cache/maven`)).toBe(true);
+    });
+
+    it("should be pull the cache with the expected content", () => {
+        // The assertions are done via the consume-cache job's script
+        expect(writeStreams.stdoutLines.join("\n")).toContain("PASS  consume-cache");
+    });
 });

--- a/tests/test-cases/cache-key-files/integration.test.ts
+++ b/tests/test-cases/cache-key-files/integration.test.ts
@@ -3,13 +3,12 @@ import {handler} from "../../../src/handler.js";
 import fs from "fs-extra";
 import {initSpawnSpy} from "../../mocks/utils.mock.js";
 import {WhenStatics} from "../../mocks/when-statics.js";
-import chalk from "chalk";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
 });
 
-test.concurrent("cache-key-files <consume-cache> --shell-isolation --needs", async () => {
+test("cache-key-files <consume-cache> --shell-isolation --needs", async () => {
     await fs.rm("tests/test-cases/cache-key-files/.gitlab-ci-local/cache/", {recursive: true, force: true});
     const writeStreams = new WriteStreamsMock();
     await handler({
@@ -27,13 +26,12 @@ test("cache-key-files <cache-key-file referencing $CI_PROJECT_DIR>", async () =>
     await handler({
         cwd: "tests/test-cases/cache-key-files",
         job: ["cache-key-file referencing $CI_PROJECT_DIR"],
+        noColor: true,
     }, writeStreams);
 
-    const expected = [
-        chalk`{blueBright cache-key-file referencing $CI_PROJECT_DIR} {magentaBright exported cache fakepackage.json 'md-8aaa60c7b3009df8ce6973111af131bbcde5636e'}`,
-    ];
+    const expected = "cache-key-file referencing $CI_PROJECT_DIR cache created in '.gitlab-ci-local/cache/0_/builds/gcl/test-project/fakepackage-8aaa60c7b3009df8ce6973111af131bbcde5636e'";
 
-    expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected);
 });
 
 test("cache-key-files <cache-key-file file dont exist>", async () => {
@@ -41,10 +39,9 @@ test("cache-key-files <cache-key-file file dont exist>", async () => {
     await handler({
         cwd: "tests/test-cases/cache-key-files",
         job: ["cache-key-file file dont exist"],
+        noColor: true,
     }, writeStreams);
 
-    const expected = [
-        chalk`{blueBright cache-key-file file dont exist} {magentaBright exported cache /tmp 'md-18bbe9d7603e540e28418cf4a072938ac477a2c1'}`,
-    ];
-    expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
+    const expected = "cache-key-file file dont exist cache created in '.gitlab-ci-local/cache/0_no-such-file-18bbe9d7603e540e28418cf4a072938ac477a2c1'";
+    expect(writeStreams.stdoutLines.join("\n")).toContain(expected);
 });

--- a/tests/test-cases/cache-key-prefix/.gitlab-ci-1.yml
+++ b/tests/test-cases/cache-key-prefix/.gitlab-ci-1.yml
@@ -1,0 +1,26 @@
+---
+development-cache:
+  image: busybox
+  script:
+    - mkdir -p cached
+    - echo "development" > cached/value.txt
+  cache:
+    paths:
+      - cached/
+    key:
+      prefix: development
+      files:
+        - Dockerfile
+
+production-cache:
+  image: busybox
+  script:
+    - mkdir -p cached
+    - echo "production" > cached/value.txt
+  cache:
+    paths:
+      - cached/
+    key:
+      prefix: production
+      files:
+        - Dockerfile

--- a/tests/test-cases/cache-key-prefix/.gitlab-ci-2.yml
+++ b/tests/test-cases/cache-key-prefix/.gitlab-ci-2.yml
@@ -1,0 +1,12 @@
+---
+rspec:
+  image: busybox
+  script:
+    - echo "This rspec job uses a cache."
+  cache:
+    key:
+      files:
+        - Gemfile.lock
+      prefix: $CI_JOB_NAME
+    paths:
+      - vendor/ruby

--- a/tests/test-cases/cache-key-prefix/integration.test.ts
+++ b/tests/test-cases/cache-key-prefix/integration.test.ts
@@ -1,0 +1,50 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import {basename} from "node:path/posix";
+import {dirname} from "node:path";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+const name = basename(dirname(import.meta.url));
+const cwd = `tests/test-cases/${name}`;
+
+describe(name, () => {
+    it("should produce prepand a string to the cache keys", async () => {
+        const writeStreams = new WriteStreamsMock();
+        await handler({
+            cwd,
+            noColor: true,
+            file: ".gitlab-ci-1.yml",
+        }, writeStreams);
+
+        const expected = [
+            "cached/: found 2 artifact files and directories",
+            "production-cache  cache created in '.gitlab-ci-local/cache/0_production-6651ddff6eb82c840ced7c1dddee15c6e1913dd4'",
+            "development-cache cache created in '.gitlab-ci-local/cache/0_development-6651ddff6eb82c840ced7c1dddee15c6e1913dd4'",
+        ];
+
+        expected.forEach((e) => {
+            expect(writeStreams.stdoutLines.join("\n")).toContain(e);
+        });
+    });
+});
+
+describe(name, () => {
+    const writeStreams = new WriteStreamsMock();
+
+    beforeAll(async () => {
+        await handler({
+            cwd,
+            noColor: true,
+            file: ".gitlab-ci-2.yml",
+        }, writeStreams);
+    });
+
+    it("should support variable expansion", () => {
+        expect(writeStreams.stdoutLines.join("\n")).toContain("rspec cache created in '.gitlab-ci-local/cache/0_rspec-21fb5836b499a2be648386aac055d2e069160d6c'");
+    });
+});

--- a/tests/test-cases/cache-shell-fail/integration.test.ts
+++ b/tests/test-cases/cache-shell-fail/integration.test.ts
@@ -2,7 +2,6 @@ import {WriteStreamsMock} from "../../../src/write-streams.js";
 import {handler} from "../../../src/handler.js";
 import {initSpawnSpy} from "../../mocks/utils.mock.js";
 import {WhenStatics} from "../../mocks/when-statics.js";
-import chalk from "chalk";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
@@ -15,10 +14,11 @@ test.concurrent("cache-shell-fail <consume-cache> --shell-isolation --needs", as
         job: ["consume-cache"],
         needs: true,
         shellIsolation: true,
+        noColor: true,
     }, writeStreams);
 
     const expected = [
-        chalk`{blueBright produce-cache} {yellow !! no cache was copied for cache/**/* !!}`,
+        "WARNING: cache/**/*: no matching files. Ensure that the artifact path is relative to the working directory",
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -182,3 +182,57 @@ describe("evaluateRuleChanges", () => {
         });
     });
 });
+
+describe("isSubPath where process.cwd() have been mocked to return /home/user/gitlab-ci-local", () => {
+    beforeAll(() => {
+        const spy = import.meta.jest.spyOn(process, "cwd");
+        spy.mockReturnValue("/home/user/gitlab-ci-local");
+    });
+
+    const tests: {
+        input: [string, string, string?];
+        expected: boolean;
+    }[] = [
+        {
+            input: ["/tmp", "foo"],
+            expected: false,
+        },
+        {
+            input: ["../bar", "foo"],
+            expected: false,
+        },
+        {
+            input: ["../gitlab-ci-local", "."],
+            expected: true,
+        },
+        {
+            input: ["../gitlab-ci-local", "/home/user/gitlab-ci-local"],
+            expected: true,
+        },
+        {
+            input: ["../gitlab-ci-local", "/gitlab-ci-local"],
+            expected: false,
+        },
+        {
+            input: ["../////gitlab-ci-local", "."],
+            expected: true,
+        },
+        {
+            input: ["cache/*/foo", "cache"],
+            expected: true,
+        },
+        {
+            input: ["cache", "cache/*/foo"],
+            expected: false,
+        },
+        {
+            input: ["key-files", "/home/user/gitlab-ci-local", "/home/user/gitlab-ci-local"],
+            expected: true,
+        },
+    ];
+    tests.forEach(({input, expected}) => {
+        test(`isSubpath("${input[0]}", "${input[1]}") => ${expected}`, () => {
+            expect(Utils.isSubpath(...input)).toBe(expected);
+        });
+    });
+});


### PR DESCRIPTION
closes #1478

sorry for the big PR i kind of mangled a few stuff into it ...

implements the following enhancement:
- https://docs.gitlab.com/ci/yaml/#cachekeyprefix 

![image](https://github.com/user-attachments/assets/216d10aa-0270-4671-b391-be38e22bceac)

- info/warning log on number of matched cache
 
![image](https://github.com/user-attachments/assets/89cfffb5-bc10-4d82-bfe5-8f74be4ece59)

- optimize copying of cache to only run once for all path instead of running the cp command for each path
  
![image](https://github.com/user-attachments/assets/73399403-1ea2-469a-97e2-ac56a1a0db40)
