### PR TITLE
fix: extending job with referenced variables should merge and not overwrite

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -40,7 +40,12 @@ export function jobExtends (gitlabData: any) {
 export function reference (gitlabData: any, recurseData: any) {
     for (const [key, value] of Object.entries<any>(recurseData || {})) {
         if (value?.referenceData) {
-            recurseData[key] = getSubDataByReference(gitlabData, value.referenceData);
+            if (Object.keys(value).length > 1) {
+                recurseData[key] = {...getSubDataByReference(gitlabData, value.referenceData), ...recurseData[key]};
+                delete recurseData[key].referenceData;
+            } else {
+                recurseData[key] = getSubDataByReference(gitlabData, value.referenceData);
+            }
         } else if (typeof value === "object") {
             reference(gitlabData, value);
         }

--- a/tests/test-cases/reference/.gitlab-ci-1.yml
+++ b/tests/test-cases/reference/.gitlab-ci-1.yml
@@ -1,0 +1,15 @@
+---
+.somevariables:
+  variables:
+    HESTHEST: ponypony
+
+
+.something:
+  variables: !reference [.somevariables, variables]
+
+test-job:
+  extends: [.something]
+  variables:
+    NICENESS: byrdalos
+  script:
+    - echo ${NICENESS}

--- a/tests/test-cases/reference/.gitlab-ci-2.yml
+++ b/tests/test-cases/reference/.gitlab-ci-2.yml
@@ -1,0 +1,15 @@
+---
+.somevariables:
+  variables:
+    NICENESS: reference
+
+
+.something:
+  variables: !reference [.somevariables, variables]
+
+test-job:
+  extends: [.something]
+  variables:
+    NICENESS: byrdalos
+  script:
+    - echo ${NICENESS}

--- a/tests/test-cases/reference/integration.test.ts
+++ b/tests/test-cases/reference/integration.test.ts
@@ -152,3 +152,56 @@ test("should not support 11 level deep", async () => {
     }
     throw new Error("Error is expected but not thrown/caught");
 });
+
+it("should merge values", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        preview: true,
+        file: ".gitlab-ci-1.yml",
+        cwd: "tests/test-cases/reference",
+    }, writeStreams);
+
+    const expected = `
+---
+stages:
+  - .pre
+  - build
+  - test
+  - deploy
+  - .post
+test-job:
+  variables:
+    HESTHEST: ponypony
+    NICENESS: byrdalos
+  script:
+    - echo \${NICENESS}
+`;
+
+    expect(writeStreams.stdoutLines.join("\n")).toEqual(expected.trim());
+});
+
+it("should have a lower precedence than a local scope", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        preview: true,
+        file: ".gitlab-ci-2.yml",
+        cwd: "tests/test-cases/reference",
+    }, writeStreams);
+
+    const expected = `
+---
+stages:
+  - .pre
+  - build
+  - test
+  - deploy
+  - .post
+test-job:
+  variables:
+    NICENESS: byrdalos
+  script:
+    - echo \${NICENESS}
+`;
+
+    expect(writeStreams.stdoutLines.join("\n")).toEqual(expected.trim());
+});


### PR DESCRIPTION
closes #1562