### PR TITLE
Implement support for podmans userns option

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -207,6 +207,10 @@ export class Argv {
         return this.map.get("umask") ?? true;
     }
 
+    get userns (): string | undefined {
+        return this.map.get("userns");
+    }
+
     get privileged (): boolean {
         return this.map.get("privileged") ?? false;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,11 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             description: "Sets docker user to 0:0",
             requiresArg: false,
         })
+        .option("userns", {
+            type: "string",
+            description: "Set docker executor userns option",
+            requiresArg: false,
+        })
         .option("privileged", {
             type: "boolean",
             description: "Set docker executor to privileged mode",

--- a/src/job.ts
+++ b/src/job.ts
@@ -843,6 +843,10 @@ export class Job {
                 dockerCmd += "--user 0:0 ";
             }
 
+            if (this.argv.userns != undefined) {
+                dockerCmd += `--userns=${this.argv.userns} `;
+            }
+
             if (this.argv.containerMacAddress) {
                 dockerCmd += `--mac-address "${this.argv.containerMacAddress}" `;
             }
@@ -1395,6 +1399,10 @@ export class Job {
 
         if (this.argv.umask) {
             dockerCmd += "--user 0:0 ";
+        }
+
+        if (this.argv.userns != undefined) {
+            dockerCmd += `--userns=${this.argv.userns} `;
         }
 
         if (this.argv.privileged) {


### PR DESCRIPTION
I had problems when running a CI pipeline via gitlab-ci-local on a host that uses podman as container engine. Experimenting with the podman invocation locally (the container init script does some  I found out, that using the `--userns=keep-id` [docs](https://docs.podman.io/en/v4.6.1/markdown/options/userns.container.html) option fixes the problem.

So this adds the flag needed to let gitlab-ci-local with the needed flag in the container executor invocation.