### PR TITLE
fix: cache.key.files containing `*` and `'` should'nt crash

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1216,8 +1216,8 @@ export class Job {
 
             time = process.hrtime();
             let cmd = "shopt -s globstar nullglob dotglob\n";
-            cmd += `mkdir -p ${cachePath}/${cacheName}\n`;
-            cmd += `rsync -Ra ${paths} ${cachePath}/${cacheName}/. || true\n`;
+            cmd += `mkdir -p ${Utils.safeBashString(cachePath + "/" + cacheName)}\n`;
+            cmd += `rsync -Ra ${paths} ${Utils.safeBashString(cachePath + "/" + cacheName + "/.")} || true\n`;
 
             await Mutex.exclusive(cacheName, async () => {
                 await this.copyOut(cmd, stateDir, "cache", []);
@@ -1336,7 +1336,7 @@ export class Job {
         await fs.mkdirp(`${cwd}/${stateDir}/${type}`);
 
         if (this.imageName(this._variables)) {
-            const {stdout: containerId} = await Utils.bash(`${this.argv.containerExecutable} create -i ${dockerCmdExtras.join(" ")} -v ${buildVolumeName}:${this.ciProjectDir} -w ${this.ciProjectDir} ${helperImageName} bash -c "${cmd}"`, cwd);
+            const {stdout: containerId} = await Utils.bash(`${this.argv.containerExecutable} create -i ${dockerCmdExtras.join(" ")} -v ${buildVolumeName}:${this.ciProjectDir} -w ${this.ciProjectDir} ${helperImageName} bash -c "${cmd.replace(/"/g, "\\\"")}"`, cwd);
             this._containersToClean.push(containerId);
             await Utils.spawn([this.argv.containerExecutable, "start", containerId, "--attach"]);
             await Utils.spawn([this.argv.containerExecutable, "cp", `${containerId}:/${type}/.`, `${stateDir}/${type}/.`], cwd);

--- a/tests/test-cases/cache-key-files/.gitlab-ci-1.yml
+++ b/tests/test-cases/cache-key-files/.gitlab-ci-1.yml
@@ -1,0 +1,11 @@
+---
+test:
+  image: bash
+  cache:
+    paths:
+      - fakepackage.json
+    key:
+      files:
+        - fake*
+  script:
+    - echo "Wiiiii"

--- a/tests/test-cases/cache-key-files/.gitlab-ci-2.yml
+++ b/tests/test-cases/cache-key-files/.gitlab-ci-2.yml
@@ -1,0 +1,11 @@
+---
+test:
+  image: bash
+  cache:
+    paths:
+      - fakepackage.json
+    key:
+      files:
+        - fake'
+  script:
+    - echo "Wiiiii"

--- a/tests/test-cases/cache-key-files/integration.test.ts
+++ b/tests/test-cases/cache-key-files/integration.test.ts
@@ -45,3 +45,21 @@ test("cache-key-files <cache-key-file file dont exist>", async () => {
     const expected = "cache-key-file file dont exist cache created in '.gitlab-ci-local/cache/0_no-such-file-18bbe9d7603e540e28418cf4a072938ac477a2c1'";
     expect(writeStreams.stdoutLines.join("\n")).toContain(expected);
 });
+
+test("cache-key-files file containing `*` should not crash", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/cache-key-files",
+        file: ".gitlab-ci-1.yml",
+        noColor: true,
+    }, writeStreams);
+});
+
+test("cache-key-files file containing `'` should not crash", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/cache-key-files",
+        file: ".gitlab-ci-2.yml",
+        noColor: true,
+    }, writeStreams);
+});


### PR DESCRIPTION
closes #1574 