### PR TITLE
Trivial: Cast dockerCmd string replace to string.

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -907,7 +907,7 @@ export class Job {
 
             for (const [key, val] of Object.entries(expanded)) {
                 // Replacing `'` with `'\''` to correctly handle single quotes(if `val` contains `'`) in shell commands
-                dockerCmd += `  -e '${key}=${val.replace(/'/g, "'\\''")}' \\\n`;
+                dockerCmd += `  -e '${key}=${val.toString().replace(/'/g, "'\\''")}' \\\n`;
             }
 
             if (this.imageEntrypoint) {
@@ -1437,7 +1437,7 @@ export class Job {
 
         for (const [key, val] of Object.entries(expanded)) {
             // Replacing `'` with `'\''` to correctly handle single quotes(if `val` contains `'`) in shell commands
-            dockerCmd += `  -e '${key}=${val.replace(/'/g, "'\\''")}' \\\n`;
+            dockerCmd += `  -e '${key}=${val.toString().replace(/'/g, "'\\''")}' \\\n`;
         }
 
         const serviceEntrypoint = service.entrypoint;


### PR DESCRIPTION
Issue: with one of my gitlab pipelines, our usage of service directives over parallel executors was causing nodejs errors to be raised when trying to replace dockerCmd strings that for some reason were not strings.

Solution: Force casting the values to be string representations in all cases fixed the issue I was having and is a safer call to make.