### PR TITLE
fix(git-data): pass cwd to git diff subprocess for out-of-source runs

### DIFF
--- a/src/git-data.ts
+++ b/src/git-data.ts
@@ -80,8 +80,8 @@ export class GitData {
         }
     }
 
-    static changedFiles (defaultBranch: string) {
-        return Utils.syncSpawn(["git", "diff", "--name-only", defaultBranch]).stdout.split("\n");
+    static changedFiles (defaultBranch: string, cwd: string) {
+        return Utils.syncSpawn(["git", "diff", "--name-only", defaultBranch], cwd).stdout.split("\n");
     }
 
     private async initRemoteData (cwd: string, writeStreams: WriteStreams): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,7 +199,7 @@ export class Utils {
         for (const rule of opt.rules) {
             if (!Utils.evaluateRuleIf(rule.if, opt.variables)) continue;
             if (!Utils.evaluateRuleExist(opt.cwd, rule.exists)) continue;
-            if (evaluateRuleChanges && !Utils.evaluateRuleChanges(gitData.branches.default, rule.changes)) continue;
+            if (evaluateRuleChanges && !Utils.evaluateRuleChanges(gitData.branches.default, rule.changes, opt.cwd)) continue;
 
             when = rule.when ? rule.when : jobWhen;
             allowFailure = rule.allow_failure ?? allowFailure;
@@ -337,7 +337,7 @@ export class Utils {
         return false;
     }
 
-    static evaluateRuleChanges (defaultBranch: string, ruleChanges: string[] | {paths: string[]} | undefined): boolean {
+    static evaluateRuleChanges (defaultBranch: string, ruleChanges: string[] | {paths: string[]} | undefined, cwd: string): boolean {
         if (ruleChanges === undefined) return true;
 
         // Normalize rules:changes:paths to rules:changes
@@ -346,7 +346,7 @@ export class Utils {
         // NOTE: https://docs.gitlab.com/ee/ci/yaml/#ruleschanges
         //   Glob patterns are interpreted with Ruby's [File.fnmatch](https://docs.ruby-lang.org/en/master/File.html#method-c-fnmatch)
         //   with the flags File::FNM_PATHNAME | File::FNM_DOTMATCH | File::FNM_EXTGLOB.
-        return micromatch.some(GitData.changedFiles(`origin/${defaultBranch}`), ruleChanges, {
+        return micromatch.some(GitData.changedFiles(`origin/${defaultBranch}`, cwd), ruleChanges, {
             nonegate: true,
             noextglob: true,
             posix: false,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -178,7 +178,7 @@ describe("evaluateRuleChanges", () => {
         test.concurrent(`${t.description} \t\t [input: ${t.input} pattern: ${t.pattern} hasChanges: ${t.hasChanges}]`, () => {
             const spy = import.meta.jest.spyOn(GitData, "changedFiles");
             spy.mockReturnValue(t.input);
-            expect(Utils.evaluateRuleChanges("origin/master", t.pattern)).toBe(t.hasChanges);
+            expect(Utils.evaluateRuleChanges("origin/master", t.pattern, ".")).toBe(t.hasChanges);
         });
     });
 });


### PR DESCRIPTION
Running gitlab-ci-local for a different worktree (eg `gitlab-ci-local --cwd=../project-b`) would throw an error because the `changedFiles` function executes the git diff subprocess in the current cwd.

This commit fixes it by passing the correct cwd to the subprocess.