### PR TITLE
fix: Attempt to cut down start up time for downloaded files

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -158,9 +158,16 @@ export class ParserIncludes {
                         break;
                     } else {
                         const localFileName = `${cwd}/${stateDir}/includes/${gitData.remote.host}/${projectPath}/${ref}/${f}`;
-                        // Check remotely only if the file does not exist locally
-                        if (!fs.existsSync(localFileName) && !(await Utils.remoteFileExist(cwd, f, ref, domain, projectPath, gitData.remote.schema, gitData.remote.port))) {
+                        const fileExists = fs.existsSync(localFileName);
+                        // If the file already has been downloaded, skip it
+                        if (fileExists) {
                             continue;
+                        }
+
+                        // Check remotely only if the file does not exist locally
+                        const remoteFileExists = await Utils.remoteFileExist(cwd, f, ref, domain, projectPath, gitData.remote.schema, gitData.remote.port);
+                        if (!remoteFileExists) { 
+                            continue
                         }
 
                         const fileDoc = {


### PR DESCRIPTION
In debugging the startup times for gitlab-ci-local, I noticed that remote includes were being downloaded everytime despite being already downloaded. Afaict this stops the downloads from happening, though I don't have confidence that the changes will work as expected. 