### PR TITLE
fix: expand variable when parsing cache path

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1224,7 +1224,8 @@ export class Job {
             });
             endTime = process.hrtime(time);
 
-            for (const _path of c.paths) {
+            for (const __path of c.paths) {
+                const _path = Utils.expandText(__path, expanded);
                 if (!Utils.isSubpath(_path, this.argv.cwd, this.argv.cwd)) {
                     writeStreams.stdout(chalk`{yellow WARNING: processPath: artifact path is not a subpath of project directory: ${_path}}\n`);
                     continue;

--- a/tests/test-cases/cache-directives/integration.test.ts
+++ b/tests/test-cases/cache-directives/integration.test.ts
@@ -14,8 +14,10 @@ test.concurrent("cache-directives <test-job> --shell-isolation --needs", async (
     await handler({
         cwd: "tests/test-cases/cache-directives",
         job: ["test-job"],
+        noColor: true,
         shellIsolation: true,
     }, writeStreams);
 
     await expect(fs.pathExists("tests/test-cases/cache-directives/.gitlab-ci-local/cache/default/cache/file1.txt")).resolves.toBe(true);
+    expect(writeStreams.stdoutLines.join("\n")).toContain("cache/**.txt: found 1 artifact files and directories");
 });


### PR DESCRIPTION
should'nt be showing the folllowing warning
<img width="1910" height="486" alt="image" src="https://github.com/user-attachments/assets/57f89dff-0198-47dc-bd21-4eabc66e012a" />