### PR TITLE
modify the used image wait-for-it #1552

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -322,6 +322,10 @@ export class Argv {
         return this.map.get("defaultImage") ?? "docker.io/ruby:3.1";
     }
 
+    get waitImage (): string {
+        return this.map.get("waitImage") ?? "docker.io/sumina46/wait-for-it:latest";
+    }
+
     get helperImage (): string {
         return this.map.get("helperImage") ?? "docker.io/firecow/gitlab-ci-local-util:latest";
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,11 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             description: "When using --shell-executor-no-image=false which image to be used for the container. Defaults to docker.io/ruby:3.1 if not set.",
             requiresArg: false,
         })
+        .option("wait-image", {
+            type: "string",
+            description: "Which image to be used for the wait container. Defaults to docker.io/sumina46/wait-for-it:latest if not set.",
+            requiresArg: false,
+        })
         .option("helper-image", {
             type: "string",
             description: "When using --shell-executor-no-image=false which image to be used for the utils container. Defaults to docker.io/firecow/gitlab-ci-local-util:latest if not set.",

--- a/src/job.ts
+++ b/src/job.ts
@@ -1488,7 +1488,6 @@ export class Job {
         const serviceAlias = service.alias;
         const serviceName = service.name;
         const waitImageName = this.argv.waitImage;
-        
 
         const {stdout} = await Utils.spawn([this.argv.containerExecutable, "image", "inspect", serviceName]);
         const imageInspect = JSON.parse(stdout);
@@ -1513,7 +1512,7 @@ export class Job {
                 if (!port.endsWith("/tcp")) return;
                 const portNum = parseInt(port.replace("/tcp", ""));
                 const containerName = `gcl-wait-for-it-${this.jobId}-${serviceIndex}-${portNum}`;
-                const spawnCmd = [this.argv.containerExecutable, "run", "--rm", `--name=${containerName}`, "--network", `${this._serviceNetworkId}`,`${waitImageName}`, `${uniqueAlias}:${portNum}`, "-t", "30"];
+                const spawnCmd = [this.argv.containerExecutable, "run", "--rm", `--name=${containerName}`, "--network", `${this._serviceNetworkId}`, `${waitImageName}`, `${uniqueAlias}:${portNum}`, "-t", "30"];
                 this._containersToClean.push(containerName);
                 return Utils.spawn(spawnCmd);
             }));

--- a/src/job.ts
+++ b/src/job.ts
@@ -1487,6 +1487,8 @@ export class Job {
     private async serviceHealthCheck (writeStreams: WriteStreams, service: Service, serviceIndex: number, serviceContainerLogFile: string) {
         const serviceAlias = service.alias;
         const serviceName = service.name;
+        const waitImageName = this.argv.waitImage;
+        
 
         const {stdout} = await Utils.spawn([this.argv.containerExecutable, "image", "inspect", serviceName]);
         const imageInspect = JSON.parse(stdout);
@@ -1511,7 +1513,7 @@ export class Job {
                 if (!port.endsWith("/tcp")) return;
                 const portNum = parseInt(port.replace("/tcp", ""));
                 const containerName = `gcl-wait-for-it-${this.jobId}-${serviceIndex}-${portNum}`;
-                const spawnCmd = [this.argv.containerExecutable, "run", "--rm", `--name=${containerName}`, "--network", `${this._serviceNetworkId}`, "docker.io/sumina46/wait-for-it", `${uniqueAlias}:${portNum}`, "-t", "30"];
+                const spawnCmd = [this.argv.containerExecutable, "run", "--rm", `--name=${containerName}`, "--network", `${this._serviceNetworkId}`,`${waitImageName}`, `${uniqueAlias}:${portNum}`, "-t", "30"];
                 this._containersToClean.push(containerName);
                 return Utils.spawn(spawnCmd);
             }));


### PR DESCRIPTION
New param "wait-image" to be able to use a alternative image  
Default is the previously hard-coded one : docker.io/sumina46/wait-for-it:latest
closes #1552