### PR TITLE
add optionto set the docker 'device' command line argument

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -215,6 +215,12 @@ export class Argv {
         return this.map.get("privileged") ?? false;
     }
 
+    get device (): string | null {
+        const device = this.map.get("device");
+        if (!device) return null;
+        return device;
+    }
+
     get ulimit (): string | null {
         const ulimit = this.map.get("ulimit");
         if (!ulimit) return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,11 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             description: "Set docker executor to privileged mode",
             requiresArg: false,
         })
+        .option("device", {
+            type: "string",
+            description: "Set docker executor device option",
+            requiresArg: false,
+        })
         .option("ulimit", {
             type: "number",
             description: "Set docker executor ulimit",

--- a/src/job.ts
+++ b/src/job.ts
@@ -837,6 +837,10 @@ export class Job {
                 dockerCmd += "--privileged ";
             }
 
+            if (this.argv.device) {
+                dockerCmd += `--device=${this.argv.device} `;
+            }
+
             if (this.argv.ulimit !== null) {
                 dockerCmd += `--ulimit nofile=${this.argv.ulimit} `;
             }
@@ -1412,6 +1416,10 @@ export class Job {
 
         if (this.argv.privileged) {
             dockerCmd += "--privileged ";
+        }
+
+        if (this.argv.device) {
+            dockerCmd += `--device=${this.argv.device} `;
         }
 
         if (this.argv.ulimit !== null) {


### PR DESCRIPTION
Not sure how to make a test for this. 

Devices like /dev/null are already present in the docker container. So you need a *new* device present on the machine to share with docker.

You could do something like this https://stackoverflow.com/questions/23135589/create-dev-fakedevice-supporting-read-write-and-ioctl to make a new character device but you would need root to install it.

Would docker in docker help here?