### PR TITLE
Fix flaky extra-host test

### DIFF
--- a/tests/test-cases/extra-host/.gitlab-ci.yml
+++ b/tests/test-cases/extra-host/.gitlab-ci.yml
@@ -1,13 +1,13 @@
 ---
 test-job:
-  image: docker.io/curlimages/curl:7.69.1
+  image: docker.io/alpine:3.21
   script:
-    - curl -I http://fake-google.com
+    - getent hosts fake-google.com
 
 service-job:
-  image: docker.io/curlimages/curl:7.69.1
+  image: docker.io/alpine:3.21
   services:
-    - name: docker.io/alpine:latest
+    - name: docker.io/alpine:3.21
       entrypoint: ["/bin/sh", "-c"]
       command: ["getent hosts fake-google.com"]
   script:

--- a/tests/test-cases/extra-host/integration.test.ts
+++ b/tests/test-cases/extra-host/integration.test.ts
@@ -1,6 +1,5 @@
 import {WriteStreamsMock} from "../../../src/write-streams.js";
 import {handler} from "../../../src/handler.js";
-import chalk from "chalk-template";
 import {initSpawnSpy} from "../../mocks/utils.mock.js";
 import {WhenStatics} from "../../mocks/when-statics.js";
 import fs from "fs-extra";
@@ -17,14 +16,11 @@ test("extra-host <test-job>", async () => {
         extraHost: ["fake-google.com:142.250.185.206"],
     }, writeStreams);
 
-    const expected = [
-        chalk`{blueBright test-job} {greenBright >} HTTP/1.1 404 Not Found`,
-    ];
-    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/142\.250\.185\.206/);
 });
 
 test("extra-host <service-job>", async () => {
-    await fs.promises.rm("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log", {force: true});
+    await fs.promises.rm("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:3.21-0.log", {force: true});
 
     const writeStreams = new WriteStreamsMock();
     await handler({
@@ -34,6 +30,6 @@ test("extra-host <service-job>", async () => {
     }, writeStreams);
 
     expect(writeStreams.stdoutLines.join("\n")).toMatch(/true/);
-    expect(await fs.pathExists("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log")).toEqual(true);
-    expect(await fs.readFile("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:latest-0.log", "utf-8")).toMatch(/142.250.185.206/);
+    expect(await fs.pathExists("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:3.21-0.log")).toEqual(true);
+    expect(await fs.readFile("tests/test-cases/extra-host/.gitlab-ci-local/services-output/service-job/docker.io/alpine:3.21-0.log", "utf-8")).toMatch(/142.250.185.206/);
 });


### PR DESCRIPTION
- Replace `curl -I` against a stale Google IP with `getent hosts`
- No external network dependency needed, only verifies DNS resolution
- Switch from `curlimages/curl` to `alpine:3.21`