### PR TITLE
Fix flaky services and dependency-proxy tests

### DIFF
--- a/tests/test-cases/dependency-proxy/integration.test.ts
+++ b/tests/test-cases/dependency-proxy/integration.test.ts
@@ -36,6 +36,16 @@ describe("dependency-proxy", () => {
         });
 
         test("docker", async () => {
+
+            initSpawnSpyReject([
+                {
+                    cmdArgs: "docker login gitlab.com:443".split(" "),
+                    rejection: {
+                        stderr: "Cannot perform an interactive login from a non TTY device",
+                    },
+                },
+            ]);
+
             try {
                 const writeStreams = new WriteStreamsMock();
                 await handler({

--- a/tests/test-cases/services/integration.test.ts
+++ b/tests/test-cases/services/integration.test.ts
@@ -81,7 +81,7 @@ test.concurrent("services <multiport-job>", async () => {
         chalk`{black.bgGreenBright  PASS } {blueBright multiport-job}`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
-});
+}, 120000);
 
 test.concurrent("services <alias-job>", async () => {
     const writeStreams = new WriteStreamsMock();


### PR DESCRIPTION
## Summary
- Mock `docker login` rejection in dependency-proxy docker test instead of relying on actual Docker, which produces different error messages depending on the environment
- Increase timeout for `multiport-job` test from 60s to 120s since Docker multi-port service startup can exceed 60s in CI

## Test plan
- [x] CI passes on this PR
- [x] Verify the two previously flaky tests now pass consistently