### PR TITLE
Fix rclone R2 config and simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
-    inputs:
-      dry-run:
-        description: 'Dry run (npm --dry-run, draft release, skip R2 upload)'
-        type: boolean
-        default: true
 
 env:
   PKG_CACHE_PATH: .pkg
-  DRY_RUN: ${{ inputs.dry-run || false }}
 
 jobs:
   release:
@@ -25,6 +19,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set version from tag
+        if: github.ref_type == 'tag'
         run: |
           sed -i "s/0.0.0/${GITHUB_REF_NAME}/g" package.json src/index.ts
 
@@ -48,18 +43,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y rclone
 
       - name: Download existing ppa from R2
-        run: |
-          rclone copy r2:${R2_BUCKET}/ ppa/ \
-            --s3-provider=Cloudflare \
-            --s3-access-key-id="${R2_ACCESS_KEY_ID}" \
-            --s3-secret-access-key="${R2_SECRET_ACCESS_KEY}" \
-            --s3-endpoint="${R2_ENDPOINT}" \
-            --s3-no-check-bucket
+        run: rclone copy r2:${R2_BUCKET}/ ppa/
         env:
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          RCLONE_CONFIG_R2_NO_CHECK_BUCKET: true
 
       - name: Import GPG key and preset passphrase
         run: |
@@ -78,26 +70,23 @@ jobs:
         run: ./publish-deb
 
       - name: Publish to npm
-        run: npm publish --provenance ${{ env.DRY_RUN == 'true' && '--dry-run' || '' }}
+        if: github.ref_type == 'tag'
+        run: npm publish --provenance
 
       - name: Create GitHub Release
-        run: >
-          gh release create "${GITHUB_REF_NAME}" bin/*.gz --generate-notes
-          ${{ env.DRY_RUN == 'true' && '--draft' || '' }}
+        if: github.ref_type == 'tag'
+        run: gh release create "${GITHUB_REF_NAME}" bin/*.gz --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload ppa to Cloudflare R2
-        if: env.DRY_RUN != 'true'
-        run: |
-          rclone copy ppa/ r2:${R2_BUCKET}/ \
-            --s3-provider=Cloudflare \
-            --s3-access-key-id="${R2_ACCESS_KEY_ID}" \
-            --s3-secret-access-key="${R2_SECRET_ACCESS_KEY}" \
-            --s3-endpoint="${R2_ENDPOINT}" \
-            --s3-no-check-bucket
+        if: github.ref_type == 'tag'
+        run: rclone copy ppa/ r2:${R2_BUCKET}/
         env:
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          RCLONE_CONFIG_R2_NO_CHECK_BUCKET: true


### PR DESCRIPTION
## Summary
- Use `RCLONE_CONFIG_R2_*` env vars for R2 access
- Skip publish/release/upload steps on `workflow_dispatch` via `github.ref_type == 'tag'`
- Remove `continue-on-error` from R2 download

## Test plan
- [x] `workflow_dispatch` dry-run passes
- [x] R2 download works with correct credentials
- [x] Tag a real release and verify full pipeline