### PR TITLE
Add --shm-size CLI option for Docker executor 

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -237,6 +237,10 @@ export class Argv {
         return ulimit;
     }
 
+    get shmSize (): string | undefined {
+        return this.map.get("shmSize");
+    }
+
     get needs (): boolean {
         return this.map.get("needs") ?? false;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,6 +232,11 @@ process.on("SIGUSR2", async () => await cleanupJobResources(jobs));
             description: "Set docker executor ulimit",
             requiresArg: false,
         })
+        .option("shm-size", {
+            type: "string",
+            description: "Set docker executor shared memory size, docker default is 64m (e.g., '256m', '1g')",
+            requiresArg: false,
+        })
         .option("network", {
             type: "array",
             description: "Add networks to docker executor",

--- a/src/job.ts
+++ b/src/job.ts
@@ -942,6 +942,10 @@ If you know what you're doing and would like to suppress this warning, use one o
                 dockerCmd += `--userns=${this.argv.userns} `;
             }
 
+            if (this.argv.shmSize != undefined) {
+                dockerCmd += `--shm-size=${this.argv.shmSize} `;
+            }
+
             if (this.argv.containerMacAddress) {
                 dockerCmd += `--mac-address "${this.argv.containerMacAddress}" `;
             }
@@ -1549,6 +1553,10 @@ If you know what you're doing and would like to suppress this warning, use one o
 
         if (this.argv.ulimit !== null) {
             dockerCmd += `--ulimit nofile=${this.argv.ulimit} `;
+        }
+
+        if (this.argv.shmSize != undefined) {
+            dockerCmd += `--shm-size=${this.argv.shmSize} `;
         }
 
         for (const volume of this.argv.volume) {

--- a/tests/test-cases/shm-size/.gitlab-ci.yml
+++ b/tests/test-cases/shm-size/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+---
+test-job:
+  image: docker.io/alpine
+  script:
+    - echo hello
+
+service-job:
+  image: docker.io/alpine
+  services: [docker.io/redis]
+  script:
+    - echo hello

--- a/tests/test-cases/shm-size/integration.test.ts
+++ b/tests/test-cases/shm-size/integration.test.ts
@@ -1,0 +1,61 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {Job, cleanupJobResources} from "../../../src/job.js";
+import {initSpawnSpy, initBashSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+let jobs: Job[] = [];
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+beforeEach(async () => {
+    jobs = [];
+});
+
+afterEach(async () => {
+    await cleanupJobResources(jobs);
+});
+
+test("shm-size <test-job> --shm-size=256m", async () => {
+    const bashSpy = initBashSpy([]);
+
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/shm-size",
+        job: ["test-job"],
+        shmSize: "256m",
+    }, writeStreams);
+
+    expect(bashSpy).toHaveBeenCalledWith(expect.stringMatching(/--shm-size=256m/), expect.any(String));
+});
+
+test("shm-size <test-job> without --shm-size", async () => {
+    const bashSpy = initBashSpy([]);
+    const callsBefore = bashSpy.mock.calls.length;
+
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/shm-size",
+        job: ["test-job"],
+    }, writeStreams);
+
+    const newCalls = bashSpy.mock.calls.slice(callsBefore).map((c: any[]) => c[0]);
+    const shmCalls = newCalls.filter((cmd: string) => cmd.includes("--shm-size"));
+    expect(shmCalls.length).toBe(0);
+});
+
+test("shm-size <service-job> --shm-size=1g", async () => {
+    const bashSpy = initBashSpy([]);
+
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/shm-size",
+        job: ["service-job"],
+        shmSize: "1g",
+    }, writeStreams, jobs);
+
+    const bashCalls = bashSpy.mock.calls.map((c: any[]) => c[0]);
+    const shmCalls = bashCalls.filter((cmd: string) => cmd.includes("--shm-size=1g"));
+    expect(shmCalls.length).toBeGreaterThanOrEqual(2);
+});


### PR DESCRIPTION
# Summary                                                                                                             
                                                                                                                  
- Adds --shm-size CLI option that passes through to Docker's --shm-size flag                                        
- Applies to both job containers and service containers
- Follows existing patterns for Docker options (--ulimit, --privileged, --device)

Closes #1738

# Changes

- src/index.ts - yargs CLI option definition
- src/argv.ts - shmSize getter
- src/job.ts - flag insertion for main and service container docker commands
- tests/test-cases/shm-size/ - integration tests

# Usage

gitlab-ci-local my-job --shm-size 512m

# Tests

- --shm-size=VALUE appears in docker create command when option is set
- --shm-size does not appear when option is omitted
- Service containers also receive the flag
