### PR TITLE
Sign release binaries with GPG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Sign release binaries
         run: |
           for f in bin/*.gz; do
-            gpg --default-key "madsjon@gmail.com" --detach-sign --armor "$f"
+            gpg --batch --default-key "madsjon@gmail.com" --detach-sign --armor "$f"
           done
 
       - name: Build .deb and sign


### PR DESCRIPTION
## Summary
- GPG-sign all `.gz` release binaries (detached armor signatures)
- Upload `.asc` signature files alongside binaries in GitHub releases

Uses the existing GPG key already configured for Debian package signing.

Closes #1463

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sign all .gz release binaries with GPG and publish detached .asc signatures in GitHub Releases so users can verify downloads. Uses the existing Debian package signing key and runs GPG in batch mode for CI, closing #1463.

<sup>Written for commit 695898e2cf46425cd848f90ced7fe2bba88d11c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

