### PR TITLE
Use standard naming for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,19 +32,19 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - run: bun run build:linux-amd64
-      - run: gzip -c bin/linux-amd64/gitlab-ci-local > bin/linux-amd64.gz
+      - run: tar czf bin/gitlab-ci-local-linux-amd64.tar.gz -C bin/linux-amd64 gitlab-ci-local
 
       - run: bun run build:linux-arm64
-      - run: gzip -c bin/linux-arm64/gitlab-ci-local > bin/linux-arm64.gz
+      - run: tar czf bin/gitlab-ci-local-linux-arm64.tar.gz -C bin/linux-arm64 gitlab-ci-local
 
       - run: bun run build:win
-      - run: gzip -c bin/win/gitlab-ci-local.exe > bin/win.gz
+      - run: (cd bin/win && zip ../gitlab-ci-local-windows-amd64.zip gitlab-ci-local.exe)
 
       - run: bun run build:macos-x64
-      - run: gzip -c bin/macos-x64/gitlab-ci-local > bin/macos-x64.gz
+      - run: tar czf bin/gitlab-ci-local-darwin-amd64.tar.gz -C bin/macos-x64 gitlab-ci-local
 
       - run: bun run build:macos-arm64
-      - run: gzip -c bin/macos-arm64/gitlab-ci-local > bin/macos-arm64.gz
+      - run: tar czf bin/gitlab-ci-local-darwin-arm64.tar.gz -C bin/macos-arm64 gitlab-ci-local
 
       - name: Install rclone
         run: sudo apt-get update && sudo apt-get install -y rclone
@@ -73,9 +73,9 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Sign release binaries
+      - name: Sign release archives
         run: |
-          for f in bin/*.gz; do
+          for f in bin/gitlab-ci-local-*; do
             gpg --batch --default-key "madsjon@gmail.com" --detach-sign --armor "$f"
           done
 
@@ -91,8 +91,8 @@ jobs:
       - name: Create GitHub Release
         if: github.ref_type == 'tag'
         run: |
-          gh release create "${GITHUB_REF_NAME}" bin/*.gz bin/*.gz.asc --generate-notes ||
-          gh release upload "${GITHUB_REF_NAME}" bin/*.gz bin/*.gz.asc --clobber
+          gh release create "${GITHUB_REF_NAME}" bin/gitlab-ci-local-* --generate-notes ||
+          gh release upload "${GITHUB_REF_NAME}" bin/gitlab-ci-local-* --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,6 @@ CLI tool to run GitLab CI pipelines locally. Written in TypeScript, built with B
 
 ## Release artifacts
 
-- GitHub releases: `linux-amd64.gz`, `linux-arm64.gz`, `macos-x64.gz`, `macos-arm64.gz`, `win.gz`
+- GitHub releases: `gitlab-ci-local-{os}-{arch}.tar.gz` (linux/darwin) and `.zip` (windows), plus `.asc` signatures
 - Debian PPA: amd64 and arm64 `.deb` packages, hosted on Cloudflare R2
 - npm: `dist/index.js` bundle targeting Node.js

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ brew install gitlab-ci-local
 Download and put binary in `C:\Program Files\Git\mingw64\bin`
 
 ```bash
-curl -L https://github.com/firecow/gitlab-ci-local/releases/latest/download/win.gz | gunzip -c > /c/Program\ Files/Git/mingw64/bin/gitlab-ci-local.exe
+curl -L https://github.com/firecow/gitlab-ci-local/releases/latest/download/gitlab-ci-local-windows-amd64.zip -o gcl.zip && unzip -o gcl.zip -d /c/Program\ Files/Git/mingw64/bin && rm gcl.zip
 ```
 
 Executing `gitlab-ci-local` with `--variable MSYS_NO_PATHCONV=1` can be useful in certain situations


### PR DESCRIPTION
## Summary
- Rename release archives from `{os}.gz` to `gitlab-ci-local-{os}-{arch}.tar.gz` (`.zip` for Windows)
- OS/arch follows Go/Docker convention: `linux`, `darwin`, `windows`, `amd64`, `arm64`
- Enables auto-detection by tools like [ubi](https://github.com/houseabsolute/ubi) and [mise](https://mise.jdx.dev/dev-tools/backends/github.html)

Closes #1637

## Test plan
- [x] Push tag on fork and verify archive names in the GitHub release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized release artifact names to gitlab-ci-local-{os}-{arch}.tar.gz (Linux/macOS) and .zip (Windows). Updated the release workflow and docs to use OS/arch names (linux, darwin, windows; amd64, arm64) for better tooling compatibility.

- **Refactors**
  - Adopted gitlab-ci-local-{os}-{arch}.{ext} naming using Go/Docker OS/arch values.
  - Switched from gzipped binaries to tar.gz/zip archives; signing/upload globs now target gitlab-ci-local-*.
  - Updated README and CLAUDE.md, including the Windows install command.

- **Migration**
  - Update any scripts to use the new filenames (e.g., gitlab-ci-local-linux-amd64.tar.gz, gitlab-ci-local-windows-amd64.zip).
  - Tools like ubi and mise can auto-detect the correct asset without changes.

<sup>Written for commit 5d8ce7e463c965030bd7a3a55330296687a62604. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

