### PR TITLE
Fix environment schema constraints rejecting valid CI variables

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,6 +5,10 @@ import schema from "./schema.json";
 delete schema.definitions.include_item.oneOf[0].pattern; // include shorthand rejects glob wildcards
 // @ts-expect-error ts-expect-error
 delete schema.definitions.cache_item.properties.key.oneOf[0].pattern; // cache key rejects paths with /
+// @ts-expect-error ts-expect-error
+delete schema.definitions.job_template.properties.environment.oneOf[1].properties.name.minLength; // environment name rejects unexpanded variables
+// @ts-expect-error ts-expect-error
+delete schema.definitions.job_template.properties.environment.oneOf[1].properties.url.pattern; // environment url rejects variables with underscores
 
 // @ts-expect-error ts-expect-error
 schema.definitions.job_template.properties.gclInjectSSHAgent = {


### PR DESCRIPTION
## Summary
- Strip `environment.name` `minLength: 1` — rejects empty strings from unexpanded variables like `$PIPELINE_ENVIRONMENT`
- Strip `environment.url` pattern `^(https?://.+|\$[A-Za-z]+)` — rejects common CI variables with underscores like `$CI_ENVIRONMENT_URL`

Ref: #1441

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed environment schema to accept CI variables in environment.name and environment.url, preventing false validation failures. Resolves #1441.

- **Bug Fixes**
  - Removed minLength from environment.name to allow empty strings from unexpanded vars (e.g., $PIPELINE_ENVIRONMENT).
  - Removed URL pattern from environment.url to allow underscores in CI vars (e.g., $CI_ENVIRONMENT_URL).

<sup>Written for commit fb138e3b091dcf1ef34316fb5d579dd34dd71a18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

