### PR TITLE
fix: docker cp fails on read-only directories

### DIFF
--- a/tests/test-cases/artifacts-docker-readonly-permissions/.gitignore
+++ b/tests/test-cases/artifacts-docker-readonly-permissions/.gitignore
@@ -1,0 +1,1 @@
+/readonly-dir/

--- a/tests/test-cases/artifacts-docker-readonly-permissions/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-docker-readonly-permissions/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+---
+produce-artifacts:
+  stage: build
+  image: busybox
+  script:
+    - mkdir -p readonly-dir/subdir
+    - echo "hello" > readonly-dir/subdir/file.txt
+    - chmod -R a-w readonly-dir
+  artifacts:
+    paths:
+      - readonly-dir

--- a/tests/test-cases/artifacts-docker-readonly-permissions/integration.test.ts
+++ b/tests/test-cases/artifacts-docker-readonly-permissions/integration.test.ts
@@ -1,0 +1,31 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import fs from "fs-extra";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import {basename} from "node:path/posix";
+import {dirname} from "node:path";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+const name = basename(dirname(import.meta.url));
+const cwd = `tests/test-cases/${name}`;
+
+describe(name, () => {
+    const writeStreams = new WriteStreamsMock();
+    beforeAll(async () => {
+        await fs.rm(`${cwd}/.gitlab-ci-local/`, {recursive: true, force: true});
+
+        await handler({
+            cwd,
+            noColor: true,
+            file: ".gitlab-ci.yml",
+        }, writeStreams);
+    });
+
+    it("should successfully export artifacts with read-only directories", () => {
+        expect(writeStreams.stdoutLines.join("\n")).toContain("produce-artifacts exported artifacts");
+    });
+});

--- a/tests/test-cases/cache-docker-readonly-permissions/.gitlab-ci.yml
+++ b/tests/test-cases/cache-docker-readonly-permissions/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+---
+produce-cache:
+  stage: build
+  image: busybox
+  cache:
+    paths:
+      - .readonly-cache
+  script:
+    - mkdir -p .readonly-cache/subdir
+    - echo "hello" > .readonly-cache/subdir/file.txt
+    - chmod -R a-w .readonly-cache

--- a/tests/test-cases/cache-docker-readonly-permissions/integration.test.ts
+++ b/tests/test-cases/cache-docker-readonly-permissions/integration.test.ts
@@ -1,0 +1,31 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import fs from "fs-extra";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import {basename} from "node:path/posix";
+import {dirname} from "node:path";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+const name = basename(dirname(import.meta.url));
+const cwd = `tests/test-cases/${name}`;
+
+describe(name, () => {
+    const writeStreams = new WriteStreamsMock();
+    beforeAll(async () => {
+        await fs.rm(`${cwd}/.gitlab-ci-local/cache/`, {recursive: true, force: true});
+
+        await handler({
+            cwd,
+            noColor: true,
+            file: ".gitlab-ci.yml",
+        }, writeStreams);
+    });
+
+    it("should successfully export cache with read-only directories", () => {
+        expect(writeStreams.stdoutLines.join("\n")).toContain("produce-cache cache created in '.gitlab-ci-local/cache/default'");
+    });
+});


### PR DESCRIPTION
- `docker cp` preserves file permissions from inside the container. When cached files or artifacts contain read-only directories (e.g. Go modules), `docker cp` fails with `permission denied`.
- Adds `chmod -R u+w` inside the helper container before `docker cp` runs.

Fixes #1170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented docker cp from failing on read-only directories by making them writable inside the helper container before copy-out. This ensures caches and artifacts with read-only content (e.g., Go modules) export successfully.

- **Bug Fixes**
  - Append `chmod -R u+w /{type} 2>/dev/null || true` to the helper container command before docker cp, ensuring /cache or /artifacts are writable.
  - Added integration tests for read-only cache and artifacts; existing docker cache/artifacts tests still pass.

<sup>Written for commit 1a41e725c960ff1420bf177f1f100167e26637d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

