### PR TITLE
Fix race condition in state.yml read-modify-write

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -74,10 +74,9 @@ export async function handler (args: any, writeStreams: WriteStreams, jobs: Job[
         }
         generateGitIgnore(cwd, stateDir);
         const time = process.hrtime();
-        if (argv.needs || argv.onlyNeeds) {
-            await state.incrementPipelineIid(cwd, stateDir);
-        }
-        const pipelineIid = await state.getPipelineIid(cwd, stateDir);
+        const pipelineIid = (argv.needs || argv.onlyNeeds)
+            ? await state.incrementPipelineIid(cwd, stateDir)
+            : await state.getPipelineIid(cwd, stateDir);
         parser = await Parser.create(argv, writeStreams, pipelineIid, jobs);
         await Utils.rsyncTrackedFiles(cwd, stateDir, ".docker");
         await Commander.runJobs(argv, parser, writeStreams);
@@ -101,8 +100,7 @@ export async function handler (args: any, writeStreams: WriteStreams, jobs: Job[
         }
         generateGitIgnore(cwd, stateDir);
         const time = process.hrtime();
-        await state.incrementPipelineIid(cwd, stateDir);
-        const pipelineIid = await state.getPipelineIid(cwd, stateDir);
+        const pipelineIid = await state.incrementPipelineIid(cwd, stateDir);
         parser = await Parser.create(argv, writeStreams, pipelineIid, jobs);
         await Utils.rsyncTrackedFiles(cwd, stateDir, ".docker");
         await Commander.runPipeline(argv, parser, writeStreams);

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,5 +1,6 @@
 import fs from "fs-extra";
 import * as yaml from "js-yaml";
+import path from "path";
 
 const loadStateYML = async (stateFile: string): Promise<any> => {
     if (!fs.existsSync(stateFile)) {
@@ -9,6 +10,52 @@ const loadStateYML = async (stateFile: string): Promise<any> => {
     return yaml.load(stateFileContent) || {};
 };
 
+const withFileLock = async <T>(lockPath: string, fn: () => Promise<T>): Promise<T> => {
+    const maxWaitMs = 30_000;
+    const start = Date.now();
+
+    fs.ensureDirSync(path.dirname(lockPath));
+
+    while (true) {
+        try {
+            fs.mkdirSync(lockPath);
+            break;
+        } catch (error: any) {
+            if (error.code !== "EEXIST") {
+                throw error;
+            }
+
+            // Check for stale lock
+            try {
+                const stat = fs.statSync(lockPath);
+                if (Date.now() - stat.mtimeMs > maxWaitMs) {
+                    fs.rmdirSync(lockPath);
+                    continue;
+                }
+            } catch {
+                continue;
+            }
+
+            if (Date.now() - start > maxWaitMs) {
+                throw new Error(`Timed out waiting for lock: ${lockPath}`);
+            }
+
+            const jitter = Math.random() * 50 + 10;
+            await new Promise((resolve) => setTimeout(resolve, jitter));
+        }
+    }
+
+    try {
+        return await fn();
+    } finally {
+        try {
+            fs.rmdirSync(lockPath);
+        } catch {
+            // Lock dir already removed (e.g. stale-lock cleanup by another process)
+        }
+    }
+};
+
 const getPipelineIid = async (cwd: string, stateDir: string) => {
     const stateFile = `${cwd}/${stateDir}/state.yml`;
     const ymlData = await loadStateYML(stateFile);
@@ -16,12 +63,21 @@ const getPipelineIid = async (cwd: string, stateDir: string) => {
     return ymlData["pipelineIid"] ? ymlData["pipelineIid"] : 0;
 };
 
-const incrementPipelineIid = async (cwd: string, stateDir: string) => {
+const incrementPipelineIid = async (cwd: string, stateDir: string): Promise<number> => {
     const stateFile = `${cwd}/${stateDir}/state.yml`;
-    const ymlData = await loadStateYML(stateFile);
+    const lockPath = `${cwd}/${stateDir}/state.yml.lock`;
 
-    ymlData["pipelineIid"] = ymlData["pipelineIid"] != null ? ymlData["pipelineIid"] + 1 : 0;
-    await fs.outputFile(stateFile, `---\n${yaml.dump(ymlData)}`);
+    return withFileLock(lockPath, async () => {
+        const ymlData = await loadStateYML(stateFile);
+        ymlData["pipelineIid"] = ymlData["pipelineIid"] != null ? ymlData["pipelineIid"] + 1 : 0;
+        const newIid = ymlData["pipelineIid"];
+
+        const tmpFile = path.join(path.dirname(stateFile), `.state.yml.tmp.${process.pid}`);
+        fs.outputFileSync(tmpFile, `---\n${yaml.dump(ymlData)}`);
+        fs.renameSync(tmpFile, stateFile);
+
+        return newIid;
+    });
 };
 
 export {getPipelineIid, incrementPipelineIid};

--- a/tests/test-cases/pipeline-iid/.gitlab-ci.yml
+++ b/tests/test-cases/pipeline-iid/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+test-job:
+  stage: test
+  script:
+    - echo "CI_PIPELINE_IID=$CI_PIPELINE_IID"

--- a/tests/test-cases/pipeline-iid/integration.test.ts
+++ b/tests/test-cases/pipeline-iid/integration.test.ts
@@ -1,0 +1,79 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import * as state from "../../../src/state.js";
+import fs from "fs-extra";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("pipeline-iid increments", async () => {
+    const cwd = "tests/test-cases/pipeline-iid";
+    const stateDir = ".gitlab-ci-local";
+
+    await fs.remove(`${cwd}/${stateDir}/state.yml`);
+    await fs.remove(`${cwd}/${stateDir}/state.yml.lock`);
+
+    const iid0 = await state.incrementPipelineIid(cwd, stateDir);
+    expect(iid0).toBe(0);
+
+    const iid1 = await state.incrementPipelineIid(cwd, stateDir);
+    expect(iid1).toBe(1);
+
+    const iid2 = await state.incrementPipelineIid(cwd, stateDir);
+    expect(iid2).toBe(2);
+
+    const readBack = await state.getPipelineIid(cwd, stateDir);
+    expect(readBack).toBe(2);
+
+    await fs.remove(`${cwd}/${stateDir}/state.yml`);
+    await fs.remove(`${cwd}/${stateDir}/state.yml.lock`);
+});
+
+test("pipeline-iid concurrent increments produce unique values", async () => {
+    const cwd = "tests/test-cases/pipeline-iid";
+    const stateDir = ".gitlab-ci-local";
+
+    await fs.remove(`${cwd}/${stateDir}/state.yml`);
+    await fs.remove(`${cwd}/${stateDir}/state.yml.lock`);
+
+    const concurrency = 20;
+    const results = await Promise.all(
+        Array.from({length: concurrency}, () => state.incrementPipelineIid(cwd, stateDir))
+    );
+
+    const unique = new Set(results);
+    expect(unique.size).toBe(concurrency);
+
+    const sorted = [...results].sort((a, b) => a - b);
+    expect(sorted).toEqual(Array.from({length: concurrency}, (_, i) => i));
+
+    const finalIid = await state.getPipelineIid(cwd, stateDir);
+    expect(finalIid).toBe(concurrency - 1);
+
+    await fs.remove(`${cwd}/${stateDir}/state.yml`);
+    await fs.remove(`${cwd}/${stateDir}/state.yml.lock`);
+});
+
+test("pipeline-iid <test-job>", async () => {
+    const cwd = "tests/test-cases/pipeline-iid";
+    const stateDir = ".gitlab-ci-local";
+
+    await fs.remove(`${cwd}/${stateDir}/state.yml`);
+    await fs.remove(`${cwd}/${stateDir}/state.yml.lock`);
+
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd,
+        job: ["test-job"],
+        needs: true,
+    }, writeStreams);
+
+    const found = writeStreams.stdoutLines.filter((l) => l.includes("CI_PIPELINE_IID=0"));
+    expect(found.length).toBe(1);
+
+    await fs.remove(`${cwd}/${stateDir}/state.yml`);
+    await fs.remove(`${cwd}/${stateDir}/state.yml.lock`);
+});


### PR DESCRIPTION
## Summary
- Add cross-process file locking to `incrementPipelineIid` using `mkdir` as an atomic mutex
- Write state via temp file + `rename` to prevent partial reads
- Return new IID directly from `incrementPipelineIid`, eliminating the race window between increment and read in `handler.ts`

## Test plan
- [x] New `pipeline-iid` test case: sequential increments, 20 concurrent increments (no duplicates), handler integration
- [x] Existing tests pass (`plain`, `preview`, `needs-sequence`, `list-case`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition when updating state.yml so pipeline IIDs are unique and sequential under concurrency. Writes are now atomic and the handler uses the returned IID directly to remove the read-after-increment window.

- **Bug Fixes**
  - Serialize concurrent increments with a mkdir-based file lock and stale-lock cleanup.
  - Write state atomically via temp file + rename to prevent partial reads.
  - Return the new IID from incrementPipelineIid and update handler to use it.
  - Add tests for sequential and 20 concurrent increments, plus handler integration; existing cases still pass.

<sup>Written for commit c422c215725bc4b005c1c6cc02ead0b3118c0976. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

