### PR TITLE
Route parser warnings through WriteStreams instead of console.log

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1703,14 +1703,14 @@ If you know what you're doing and would like to suppress this warning, use one o
                 }
 
                 for (const file of files) {
-                    const content = await Parser.loadYaml(file, {});
+                    const content = await Parser.loadYaml(file, {}, true, this.writeStreams);
                     contents = {
                         ...contents,
                         ...content,
                     };
                 }
             } else if (include["artifact"]) {
-                const content = await Parser.loadYaml(`${cwd}/${stateDir}/artifacts/${include["job"]}/${include["artifact"]}`, {});
+                const content = await Parser.loadYaml(`${cwd}/${stateDir}/artifacts/${include["job"]}/${include["artifact"]}`, {}, true, this.writeStreams);
                 contents = {
                     ...contents,
                     ...content,

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -116,7 +116,7 @@ export class ParserIncludes {
                     throw new AssertionError({message: `Local include file cannot be found ${value["local"]}`});
                 }
                 for (const localFile of files) {
-                    const content = await Parser.loadYaml(localFile, {inputs: value.inputs ?? {}}, expandVariables);
+                    const content = await Parser.loadYaml(localFile, {inputs: value.inputs ?? {}}, expandVariables, writeStreams);
                     includeDatas = includeDatas.concat(await this.init(content, opts));
                 }
             } else if (value["project"]) {
@@ -124,7 +124,7 @@ export class ParserIncludes {
                     const fileDoc = await Parser.loadYaml(
                         `${cwd}/${stateDir}/includes/${gitData.remote.host}/${value["project"]}/${value["ref"] || "HEAD"}/${fileValue}`
                         , {inputs: value.inputs || {}}
-                        , expandVariables);
+                        , expandVariables, writeStreams);
                     // Expand local includes inside a "project"-like include
                     fileDoc["include"] = this.expandInnerLocalIncludes(fileDoc["include"], value["project"], value["ref"], opts);
                     includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
@@ -148,7 +148,7 @@ export class ParserIncludes {
                 assert(file !== null, `This GitLab CI configuration is invalid: component: \`${value["component"]}\`. One of the files [${files}] must exist in \`${component.domain}` +
                                     (component.port ? `:${component.port}` : "") + `/${component.projectPath}\``);
 
-                const fileDoc = await Parser.loadYaml(file, {inputs: value.inputs || {}}, expandVariables);
+                const fileDoc = await Parser.loadYaml(file, {inputs: value.inputs || {}}, expandVariables, writeStreams);
                 // Expand local includes inside to a "project"-like include
                 fileDoc["include"] = this.expandInnerLocalIncludes(fileDoc["include"], component.projectPath, component.ref, opts);
                 includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
@@ -156,13 +156,13 @@ export class ParserIncludes {
                 const {project, ref, file, domain} = this.covertTemplateToProjectFile(value["template"]);
                 const fsUrl = Utils.fsUrl(`https://${domain}/${project}/-/raw/${ref}/${file}`);
                 const fileDoc = await Parser.loadYaml(
-                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: value.inputs || {}}, expandVariables,
+                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: value.inputs || {}}, expandVariables, writeStreams,
                 );
                 includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
             } else if (value["remote"]) {
                 const fsUrl = Utils.fsUrl(value["remote"]);
                 const fileDoc = await Parser.loadYaml(
-                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: value.inputs || {}}, expandVariables,
+                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: value.inputs || {}}, expandVariables, writeStreams,
                 );
                 includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
             } else {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -105,12 +105,12 @@ export class Parser {
         const expanded = Utils.expandVariables(variables);
 
         let yamlDataList: any[] = [{stages: [".pre", "build", "test", "deploy", ".post"]}];
-        const gitlabCiData = await Parser.loadYaml(`${cwd}/${file}`, {}, this.expandVariables);
+        const gitlabCiData = await Parser.loadYaml(`${cwd}/${file}`, {}, this.expandVariables, writeStreams);
 
         yamlDataList = yamlDataList.concat(await ParserIncludes.init(gitlabCiData, {argv, cwd, stateDir, writeStreams, gitData, fetchIncludes, variables: expanded, expandVariables: this.expandVariables, maximumIncludes: argv.maximumIncludes}));
         ParserIncludes.resetCount();
 
-        const gitlabCiLocalData = await Parser.loadYaml(`${cwd}/.gitlab-ci-local.yml`, {}, this.expandVariables);
+        const gitlabCiLocalData = await Parser.loadYaml(`${cwd}/.gitlab-ci-local.yml`, {}, this.expandVariables, writeStreams);
         yamlDataList = yamlDataList.concat(await ParserIncludes.init(gitlabCiLocalData, {argv, cwd, stateDir, writeStreams, gitData, fetchIncludes, variables: expanded, expandVariables: this.expandVariables, maximumIncludes: argv.maximumIncludes}));
         ParserIncludes.resetCount();
 
@@ -228,7 +228,7 @@ export class Parser {
         });
     }
 
-    static async loadYaml (filePath: string, ctx: any = {}, expandVariables: boolean = true): Promise<any> {
+    static async loadYaml (filePath: string, ctx: any = {}, expandVariables: boolean = true, writeStreams?: WriteStreams): Promise<any> {
         const ymlPath = `${filePath}`;
         if (!fs.existsSync(ymlPath)) {
             return {};
@@ -290,7 +290,7 @@ export class Parser {
             fileData = yaml.loadAll(fileSplitClone.join("\n"), null, {schema}) as any[];
         } catch (e: any) {
             if (e instanceof yaml.YAMLException && e.reason === "duplicated mapping key") {
-                console.log(chalk`{black.bgYellowBright  WARN } duplicated mapping key detected! Values will be overwritten!`);
+                writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } duplicated mapping key detected! Values will be overwritten!\n`);
                 fileData = yaml.loadAll(fileSplitClone.join("\n"), null, {schema, json: true}) as any[];
             } else {
                 throw e;
@@ -313,6 +313,7 @@ export class Parser {
                             interpolationFunctions,
                             inputsSpecification,
                             configFilePath,
+                            writeStreams,
                             ...ctx,
                         };
                         firstChar ??= "";
@@ -365,7 +366,7 @@ function validateInterpolationKey (ctx: any) {
 function validateInterpolationFunctions (ctx: any) {
     const {interpolationFunctions, configFilePath} = ctx;
     if (interpolationFunctions != "") {
-        console.log(chalk`{black.bgYellowBright  WARN } interpolation functions is currently not supported via gitlab-ci-local. Functions will just be a no-op.`);
+        ctx.writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } interpolation functions is currently not supported via gitlab-ci-local. Functions will just be a no-op.\n`);
     }
     assert(interpolationFunctions.split("|").length <= MAX_FUNCTIONS, chalk`This GitLab CI configuration is invalid: \`{blueBright ${configFilePath}}\`: too many functions in interpolation block.`);
 }
@@ -390,7 +391,7 @@ function validateInput (ctx: any) {
 
     const regex = inputsSpecification.spec.inputs[interpolationKey]?.regex;
     if (regex) {
-        console.log(chalk`{black.bgYellowBright  WARN } spec:inputs:regex is currently not supported via gitlab-ci-local. This will just be a no-op.`);
+        ctx.writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } spec:inputs:regex is currently not supported via gitlab-ci-local. This will just be a no-op.\n`);
     }
 }
 

--- a/tests/test-cases/duplicated-keys/integration.test.ts
+++ b/tests/test-cases/duplicated-keys/integration.test.ts
@@ -25,6 +25,7 @@ test("duplicated-keys <duplicated-keys>", async () => {
 
 
     expect(writeStreams.stdoutLines.join("\n")).toContain(expected.join("\n"));
+    expect(writeStreams.stderrLines.join("\n")).toContain("duplicated mapping key detected");
 });
 
 test("duplicated-keys <duplicated-keys variables overwritten>", async () => {

--- a/tests/test-cases/include-inputs/integration.test.ts
+++ b/tests/test-cases/include-inputs/integration.test.ts
@@ -322,8 +322,8 @@ test("include-inputs options validation", async () => {
 });
 
 test("include-inputs too many functions in interpolation block", async () => {
+    const writeStreams = new WriteStreamsMock();
     try {
-        const writeStreams = new WriteStreamsMock();
         await handler({
             cwd: "tests/test-cases/include-inputs/input-templates/too-many-functions-in-interpolation-block",
             preview: true,
@@ -332,6 +332,7 @@ test("include-inputs too many functions in interpolation block", async () => {
         assert(e instanceof AssertionError, "e is not instanceof AssertionError");
         expect(e.message).toContain("This GitLab CI configuration is invalid:");
         expect(e.message).toContain("too many functions in interpolation block.");
+        expect(writeStreams.stderrLines.join("\n")).toContain("interpolation functions is currently not supported");
         return;
     }
 


### PR DESCRIPTION
## Summary
- Three warnings in `parser.ts` used `console.log()` directly, bypassing the `WriteStreams` abstraction
- This caused warnings to leak to stdout during test runs instead of being captured by `WriteStreamsMock`
- Pass `WriteStreams` through `loadYaml` to the affected code paths and use `writeStreams.stderr()` for warning output
- Add test assertions to verify warnings are captured in `stderrLines`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route parser warnings through WriteStreams (stderr) instead of console.log. This stops warning leaks to stdout and makes tests capture warnings reliably.

- **Bug Fixes**
  - Pass writeStreams through Parser.loadYaml and include paths.
  - Send warnings to writeStreams.stderr for duplicated keys, interpolation functions, and spec:inputs:regex.
  - Update tests to assert warnings in stderrLines.

<sup>Written for commit 1b756e25f78b176b53756085f748726802bdcf41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

