### PR TITLE
Add TypeScript type checking to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,16 @@ jobs:
       - run: node dist/index.js --help
       - run: head -1 dist/index.js | grep -q '#!/usr/bin/env node'
 
+  typecheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: oven-sh/setup-bun@v2.1.2
+        with:
+          bun-version: 1.3.10
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+
   eslint:
     runs-on: ubuntu-24.04
     steps:

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,9 +1,7 @@
 import schema from "./schema.json";
 
 // Remove patterns that are too strict for gitlab-ci-local usage
-// @ts-expect-error ts-expect-error
 delete schema.definitions.include_item.oneOf[0].pattern; // include shorthand rejects glob wildcards
-// @ts-expect-error ts-expect-error
 delete schema.definitions.cache_item.properties.key.oneOf[0].pattern; // cache key rejects paths with /
 // @ts-expect-error ts-expect-error
 delete schema.definitions.job_template.properties.environment.oneOf[1].properties.name.minLength; // environment name rejects unexpanded variables

--- a/tests/test-cases/predefined-variables/integration.test.ts
+++ b/tests/test-cases/predefined-variables/integration.test.ts
@@ -103,7 +103,7 @@ beforeAll(() => {
             if (args.length === 0) {
                 super(_mockDate.getTime());
             } else {
-                super(...args);
+                super(...(args as [number]));
             }
         }
     } as any;


### PR DESCRIPTION
## Summary
- Add `typecheck` job (`tsc --noEmit`) to the build workflow
- Remove two unused `@ts-expect-error` directives in `src/schema.ts`
- Fix spread argument type error in `tests/test-cases/predefined-variables/integration.test.ts`

## Test plan
- [ ] Verify new `typecheck` CI job passes
- [ ] Verify existing CI jobs still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TypeScript typecheck job to CI to block type errors before merge.

- **New Features**
  - Add typecheck job (bun run typecheck -> tsc --noEmit) in the build workflow.

- **Bug Fixes**
  - Remove two unused @ts-expect-error directives in src/schema.ts and fix a spread argument type in predefined-variables/integration.test.ts.

<sup>Written for commit c5f60564c7ab685d0b361a4b790a40465963464c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

