### PR TITLE
fix: flaky log-padding test assertions

### DIFF
--- a/tests/test-cases/log-padding/integration.test.ts
+++ b/tests/test-cases/log-padding/integration.test.ts
@@ -19,10 +19,10 @@ async function verifyLogs ({maxJobNamePadding, expectedJobNamePadding, stateDir}
     }, writeStreams);
 
     expect(writeStreams.stdoutLines.join("\n")).toContain(
-        chalk`{blueBright short-name${" ".repeat(expectedJobNamePadding)}} {greenBright >} short-name\n`,
+        chalk`{blueBright short-name${" ".repeat(expectedJobNamePadding)}} {greenBright >} short-name`,
     );
     expect(writeStreams.stdoutLines.join("\n")).toContain(
-        chalk`{blueBright my-job-with-a-very-long-long-long-long-name} {greenBright >} long-name\n`,
+        chalk`{blueBright my-job-with-a-very-long-long-long-long-name} {greenBright >} long-name`,
     );
 }
 
@@ -52,7 +52,7 @@ test.concurrent("logs - log padding should only take needs and targeted jobs int
     }, writeStreams);
 
     expect(writeStreams.stdoutLines.join("\n")).toContain(
-        chalk`{blueBright short-name with needs         } {greenBright >} short-name with needs\n`,
+        chalk`{blueBright short-name with needs         } {greenBright >} short-name with needs`,
     );
 });
 
@@ -66,6 +66,6 @@ test.concurrent("logs - log padding should only take targeted jobs into account"
     }, writeStreams);
 
     expect(writeStreams.stdoutLines.join("\n")).toContain(
-        chalk`{blueBright short-name} {greenBright >} short-name\n`,
+        chalk`{blueBright short-name} {greenBright >} short-name`,
     );
 });


### PR DESCRIPTION
## Summary
- Remove trailing `\n` from `toContain` expected strings in log-padding tests

`stdoutLines.join("\n")` only places `\n` between lines, not after the last one. When child process event ordering causes the `>` output line to be the last entry in `stdoutLines`, the trailing `\n` in the expected string has nothing to match against and the assertion fails.

This was introduced in #1790 when the tests were converted to `test.concurrent` — the non-deterministic output ordering from concurrent child processes made the `>` line sometimes land as the last line.

Verified locally: 0/10 failures after fix (was 5/10 before).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky log-padding tests by removing the trailing newline from expected strings. stdoutLines.join('\n') doesn’t add a final newline, so assertions failed when the '>' line was last under test.concurrent.

<sup>Written for commit ad99c2d217faa573ba166b6ffa315cce3348b49a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

