### PR TITLE
fix: disable Bun automatic .env loading

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[env]
+dotenv = false


### PR DESCRIPTION
## Summary
- Bun runtime auto-loads `.env` from `process.cwd()` into `process.env` at startup, unlike Node.js
- This was introduced unintentionally when the project was converted from Node.js to Bun
- The leaked variables propagate into shell executor jobs via the `compgen -v` / `e_opts` mechanism, causing tools like `envsubst` to see unexpected values
- Fix: add `bunfig.toml` with `[env] dotenv = false` to disable the auto-loading

## Test plan
- [x] All project-variables-file tests pass (7/7)
- [x] Full test suite passes (only 2 unrelated docker cache timeouts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Bun’s automatic .env loading to prevent project-local variables from leaking into job environments and tools like envsubst. Adds bunfig.toml with [env] dotenv = false so Bun no longer populates process.env from process.cwd().

<sup>Written for commit 1d5633d54d9f9e4b2f70b2985b6481354b3c25bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

