### PR TITLE
Fix home variables overriding pipeline YAML variables

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -10,7 +10,7 @@ import assert, {AssertionError} from "assert";
 import {Mutex} from "./mutex.js";
 import {Argv} from "./argv.js";
 import execa from "execa";
-import {CICDVariable} from "./variables-from-files.js";
+import {VariablesFromFilesResult} from "./variables-from-files.js";
 import {GitlabRunnerCPUsPresetValue, GitlabRunnerMemoryPresetValue, GitlabRunnerPresetValues} from "./gitlab-preset.js";
 import {handler} from "./handler.js";
 import * as yaml from "js-yaml";
@@ -31,7 +31,7 @@ interface JobOptions {
     pipelineIid: number;
     gitData: GitData;
     globalVariables: {[name: string]: string};
-    variablesFromFiles: {[name: string]: CICDVariable};
+    variablesFromFiles: VariablesFromFilesResult;
     predefinedVariables: {[name: string]: any};
     matrixVariables: {[key: string]: string} | null;
     nodeIndex: number | null;
@@ -166,9 +166,9 @@ export class Job {
         this.environment = typeof jobData.environment === "string" ? {name: jobData.environment} : (jobData.environment ? {...jobData.environment} : jobData.environment);
 
         const matrixVariables = opt.matrixVariables ?? {};
-        const fileVariables = Utils.findEnvMatchedVariables(variablesFromFiles, this.fileVariablesDir);
+        const fileVars = Utils.resolveVariablesFromFiles(variablesFromFiles, this.fileVariablesDir);
         const predefinedVariables = this._predefinedVariables(opt);
-        this._variables = {...predefinedVariables, ...this.globalVariables, ...jobVariables, ...matrixVariables, ...fileVariables, ...argvVariables};
+        this._variables = {...predefinedVariables, ...fileVars.homeAndRemote, ...this.globalVariables, ...jobVariables, ...matrixVariables, ...fileVars.projectLocal, ...argvVariables};
 
         if (this.rules && expandVariables) {
             const expanded = Utils.expandVariables(this._variables);
@@ -223,9 +223,9 @@ export class Job {
             }
             this.environment.url = Utils.expandText(this.environment.url, expanded);
         }
-        const envMatchedVariables = Utils.findEnvMatchedVariables(variablesFromFiles, this.fileVariablesDir, this.environment);
+        const envMatchedFileVars = Utils.resolveVariablesFromFiles(variablesFromFiles, this.fileVariablesDir, this.environment);
 
-        const userDefinedVariables = {...this.globalVariables, ...jobVariables, ...matrixVariables, ...ruleVariables, ...envMatchedVariables, ...argvVariables};
+        const userDefinedVariables = {...envMatchedFileVars.homeAndRemote, ...this.globalVariables, ...jobVariables, ...matrixVariables, ...ruleVariables, ...envMatchedFileVars.projectLocal, ...argvVariables};
         this.discourageOverridingOfPredefinedVariables(predefinedVariables, userDefinedVariables, argv.ignorePredefinedVars);
 
         // Merge and expand after finding env matched variables

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -99,7 +99,8 @@ export class Parser {
         const fetchIncludes = argv.fetchIncludes;
         const gitData = await GitData.init(cwd, writeStreams);
         const variablesFromFiles = await VariablesFromFiles.init(argv, writeStreams, gitData);
-        const envMatchedVariables = Utils.findEnvMatchedVariables(variablesFromFiles);
+        const resolved = Utils.resolveVariablesFromFiles(variablesFromFiles);
+        const envMatchedVariables = {...resolved.homeAndRemote, ...resolved.projectLocal};
         const predefinedVariables = initPredefinedVariables({gitData, argv, envMatchedVariables});
         const variables = {...predefinedVariables, ...envMatchedVariables, ...argv.variable};
         const expanded = Utils.expandVariables(variables);
@@ -159,7 +160,7 @@ export class Parser {
         // Generate jobs and put them into stages
         Utils.forEachRealJob(gitlabData, (jobName, jobData) => {
             assert(gitData != null, "gitData must be set");
-            assert(variablesFromFiles != null, "homeVariables must be set");
+            assert(variablesFromFiles != null, "variablesFromFiles must be set");
 
             let nodeIndex = 1;
             const parallelMatrixVariablesList = parallel.matrixVariablesList(jobData, jobName);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import checksum from "checksum";
 import base64url from "base64url";
 import execa, {ExecaError} from "execa";
 import assert from "assert";
-import {CICDVariable} from "./variables-from-files.js";
+import {CICDVariable, type VariablesFromFilesResult} from "./variables-from-files.js";
 import {GitData} from "./git-data.js";
 import {globbySync} from "globby";
 import micromatch from "micromatch";
@@ -187,6 +187,13 @@ export class Utils {
             }
         }
         return envMatchedVariables;
+    }
+
+    static resolveVariablesFromFiles (result: VariablesFromFilesResult, fileVariablesDir?: string, environment?: {name: string}) {
+        return {
+            homeAndRemote: this.findEnvMatchedVariables(result.homeAndRemote, fileVariablesDir, environment),
+            projectLocal: this.findEnvMatchedVariables(result.projectLocal, fileVariablesDir, environment),
+        };
     }
 
     static getRulesResult (opt: RuleResultOpt, gitData: GitData, jobWhen: string = "on_success", jobAllowFailure: boolean | {exit_codes: number | number[]} | undefined = undefined): {when: string; allowFailure: boolean | {exit_codes: number | number[]}; variables?: {[name: string]: string}; needs?: Need[]} {

--- a/src/variables-from-files.ts
+++ b/src/variables-from-files.ts
@@ -21,16 +21,22 @@ export interface CICDVariable {
     }[];
 }
 
+export interface VariablesFromFilesResult {
+    homeAndRemote: {[name: string]: CICDVariable};
+    projectLocal: {[name: string]: CICDVariable};
+}
+
 export class VariablesFromFiles {
 
-    static async init (argv: Argv, writeStreams: WriteStreams, gitData: GitData): Promise<{[name: string]: CICDVariable}> {
+    static async init (argv: Argv, writeStreams: WriteStreams, gitData: GitData): Promise<VariablesFromFilesResult> {
         const cwd = argv.cwd;
         const stateDir = argv.stateDir;
         const homeDir = argv.home;
         const remoteVariables = argv.remoteVariables;
         const autoCompleting = argv.autoCompleting;
         const homeVariablesFile = `${homeDir}/${stateDir}/variables.yml`;
-        const variables: {[name: string]: CICDVariable} = {};
+        const homeAndRemote: {[name: string]: CICDVariable} = {};
+        const projectLocal: {[name: string]: CICDVariable} = {};
         let remoteFileData: any = {};
         let homeFileData: any = {};
 
@@ -67,36 +73,36 @@ export class VariablesFromFiles {
             }
             return v;
         };
-        const addToVariables = async (key: string, val: any, scopePriority: number, isDotEnv = false) => {
+        const addToVariables = async (target: {[name: string]: CICDVariable}, key: string, val: any, scopePriority: number, isDotEnv = false) => {
             const {type, values} = unpack(val);
             for (const [matcher, content] of Object.entries(values)) {
                 assert(typeof content == "string", `${key}.${matcher} content must be text or multiline text`);
                 if (isDotEnv || type === "variable" || (type === null && !/^[/~]/.exec(content))) {
                     const regexp = matcher === "*" ? /.*/g : new RegExp(`^${matcher.replace(/\*/g, ".*")}$`, "g");
-                    variables[key] = variables[key] ?? {type: "variable", environments: []};
-                    variables[key].environments.push({content, regexp, regexpPriority: matcher.length, scopePriority});
+                    target[key] = target[key] ?? {type: "variable", environments: []};
+                    target[key].environments.push({content, regexp, regexpPriority: matcher.length, scopePriority});
                 } else if (type === null && /^[/~]/.exec(content)) {
                     const fileSource = content.replace(/^~\/(.*)/, `${homeDir}/$1`);
                     const regexp = matcher === "*" ? /.*/g : new RegExp(`^${matcher.replace(/\*/g, ".*")}$`, "g");
-                    variables[key] = variables[key] ?? {type: "file", environments: []};
+                    target[key] = target[key] ?? {type: "file", environments: []};
                     if (fs.existsSync(fileSource)) {
-                        variables[key].environments.push({content, regexp, regexpPriority: matcher.length, scopePriority, fileSource});
+                        target[key].environments.push({content, regexp, regexpPriority: matcher.length, scopePriority, fileSource});
                     } else {
-                        variables[key].environments.push({content: `warn: ${key} is pointing to invalid path\n`, regexp, regexpPriority: matcher.length, scopePriority});
+                        target[key].environments.push({content: `warn: ${key} is pointing to invalid path\n`, regexp, regexpPriority: matcher.length, scopePriority});
                     }
                 } else if (type === "file") {
                     const regexp = matcher === "*" ? /.*/g : new RegExp(`^${matcher.replace(/\*/g, ".*")}$`, "g");
-                    variables[key] = variables[key] ?? {type: "file", environments: []};
-                    variables[key].environments.push({content, regexp, regexpPriority: matcher.length, scopePriority});
+                    target[key] = target[key] ?? {type: "file", environments: []};
+                    target[key].environments.push({content, regexp, regexpPriority: matcher.length, scopePriority});
                 } else {
                     assert(false, `${key} was not handled properly`);
                 }
             }
         };
 
-        const addVariableFileToVariables = async (fileData: any, filePriority: number) => {
+        const addVariableFileToVariables = async (target: {[name: string]: CICDVariable}, fileData: any, filePriority: number) => {
             for (const [globalKey, globalEntry] of Object.entries(fileData?.global ?? {})) {
-                await addToVariables(globalKey, globalEntry, 1 + filePriority);
+                await addToVariables(target, globalKey, globalEntry, 1 + filePriority);
             }
 
             const groupUrl = `${gitData.remote.host}/${gitData.remote.group}/`;
@@ -105,7 +111,7 @@ export class VariablesFromFiles {
                 assert(groupEntries != null, "groupEntries cannot be null/undefined");
                 assert(Utils.isObject(groupEntries), "group entries in variable files must be an object");
                 for (const [k, v] of Object.entries(groupEntries)) {
-                    await addToVariables(k, v, 2 + filePriority);
+                    await addToVariables(target, k, v, 2 + filePriority);
                 }
             }
 
@@ -115,13 +121,13 @@ export class VariablesFromFiles {
                 assert(projectEntries != null, "projectEntries cannot be null/undefined");
                 assert(Utils.isObject(projectEntries), "project entries in variable files must be an object");
                 for (const [k, v] of Object.entries(projectEntries)) {
-                    await addToVariables(k, v, 3 + filePriority);
+                    await addToVariables(target, k, v, 3 + filePriority);
                 }
             }
         };
 
-        await addVariableFileToVariables(remoteFileData, 0);
-        await addVariableFileToVariables(homeFileData, 10);
+        await addVariableFileToVariables(homeAndRemote, remoteFileData, 0);
+        await addVariableFileToVariables(homeAndRemote, homeFileData, 10);
 
         const projectVariablesFile = `${argv.cwd}/${argv.variablesFile}`;
         if (fs.existsSync(projectVariablesFile)) {
@@ -144,16 +150,20 @@ export class VariablesFromFiles {
             assert(projectVariablesFileData != null, "projectEntries cannot be null/undefined");
             assert(Utils.isObject(projectVariablesFileData), `${argv.cwd}/.gitlab-ci-local-variables.yml must contain an object`);
             for (const [k, v] of Object.entries(projectVariablesFileData)) {
-                await addToVariables(k, v, 24, isDotEnvFormat);
+                await addToVariables(projectLocal, k, v, 24, isDotEnvFormat);
             }
         }
 
-        for (const varObj of Object.values(variables)) {
-            varObj.environments.sort((a, b) => b.scopePriority - a.scopePriority);
-            varObj.environments.sort((a, b) => b.regexpPriority - a.regexpPriority);
-        }
+        const sortEnvironments = (variables: {[name: string]: CICDVariable}) => {
+            for (const varObj of Object.values(variables)) {
+                varObj.environments.sort((a, b) => b.scopePriority - a.scopePriority);
+                varObj.environments.sort((a, b) => b.regexpPriority - a.regexpPriority);
+            }
+        };
+        sortEnvironments(homeAndRemote);
+        sortEnvironments(projectLocal);
 
-        return variables;
+        return {homeAndRemote, projectLocal};
     }
 
     static normalizeProjectKey (key: string, writeStreams: WriteStreams): string {

--- a/tests/test-cases/variable-order/.gitlab-ci.yml
+++ b/tests/test-cases/variable-order/.gitlab-ci.yml
@@ -22,6 +22,6 @@ test-job:
     - echo "OVERRIDDEN_BY_JOB=${OVERRIDDEN_BY_JOB}"
     - echo "CI_PIPELINE_ID=${CI_PIPELINE_ID}"  # Global overrides predefined
     - echo "CI_JOB_ID=${CI_JOB_ID}"  # Job overrides predefined
-    - echo "HOME_VARIABLE=${HOME_VARIABLE}"  # Home overrides all else
+    - echo "HOME_VARIABLE=${HOME_VARIABLE}"  # Job overrides home
     - echo "PROJECT_VARIABLE=${PROJECT_VARIABLE}"  # Project variables overrides everything
     - echo "PROD_ONLY_VARIABLE=${PROD_ONLY_VARIABLE}"

--- a/tests/test-cases/variable-order/integration.test.ts
+++ b/tests/test-cases/variable-order/integration.test.ts
@@ -23,7 +23,7 @@ test-job > JOB_VARIABLE=job-value
 test-job > OVERRIDDEN_BY_JOB=job-value
 test-job > CI_PIPELINE_ID=pipeline-value
 test-job > CI_JOB_ID=job-value
-test-job > HOME_VARIABLE=home-value
+test-job > HOME_VARIABLE=job-value
 test-job > PROJECT_VARIABLE=project-value
 test-job > PROD_ONLY_VARIABLE=notprod
 `.trim();


### PR DESCRIPTION
## Summary

- Home variables (`~/.gitlab-ci-local/variables.yml`) currently override pipeline YAML job-level variables, which means user convenience defaults can accidentally break CI module behavior
- Split `VariablesFromFiles.init` into two separate dicts: `homeAndRemote` (home + remote file variables) and `projectLocal` (project-local `.gitlab-ci-local-variables.yml`)
- Position them at different points in the variable merge so that home variables act as defaults (overridden by pipeline YAML), while project-local variables remain intentional overrides

**New precedence (lowest → highest):**
`predefined → homeAndRemote → globalYAML → jobYAML → matrix → rules → projectLocal → argv`

## Motivation

When a CI module defines `CODE_HOT_RELOAD: "false"` in its pipeline `variables:` section, a user's `~/.gitlab-ci-local/variables.yml` with `CODE_HOT_RELOAD: "true"` (set for local dev convenience) overrides it, breaking builds. The CI module author set that default for a reason, and home-level convenience variables shouldn't silently override it.

## Test plan

- [x] `variable-order` test updated to reflect new precedence (home variable no longer overrides job variable)
- [x] `project-variables-file` tests pass (project-local variables still override pipeline YAML)
- [x] `custom-home` tests pass (environment-matched home variables still work)
- [x] `remote-variables-file` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variable precedence so home and remote variables act as defaults and no longer override pipeline YAML. Splits variables-from-files into homeAndRemote and projectLocal to preserve intentional project overrides.

- **Bug Fixes**
  - Set new precedence: predefined → homeAndRemote → globalYAML → jobYAML → matrix → rules → projectLocal → argv.
  - Job/Parser now merge home/remote before YAML and keep project-local variables as the last override before argv.

- **Refactors**
  - VariablesFromFiles.init now returns {homeAndRemote, projectLocal}; added Utils.resolveVariablesFromFiles for env/file matching per bucket.
  - Updated types and call sites (job.ts, parser.ts) to use VariablesFromFilesResult.
  - Adjusted tests to reflect new precedence (variable-order).

<sup>Written for commit fd96b07544f3f6f4ceb2c91e122143cb3555520d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

