### PR TITLE
Add `--wait-for-services-timeout` option to CLI

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -350,6 +350,10 @@ export class Argv {
         return this.map.get("waitImage") ?? "docker.io/sumina46/wait-for-it:latest";
     }
 
+    get waitForServicesTimeout (): number {
+        return this.map.get("waitForServicesTimeout") ?? 30;
+    }
+
     get helperImage (): string {
         return this.map.get("helperImage") ?? "docker.io/firecow/gitlab-ci-local-util:latest";
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,11 @@ process.on("SIGUSR2", async () => {
             description: "Which image to be used for the wait container. Defaults to docker.io/sumina46/wait-for-it:latest if not set.",
             requiresArg: false,
         })
+        .option("wait-for-services-timeout", {
+            type: "number",
+            description: "Timeout in seconds for service health checks. Defaults to 30.",
+            requiresArg: false,
+        })
         .option("helper-image", {
             type: "string",
             description: "When using --shell-executor-no-image=false which image to be used for the utils container. Defaults to docker.io/firecow/gitlab-ci-local-util:latest if not set.",

--- a/src/job.ts
+++ b/src/job.ts
@@ -1645,6 +1645,7 @@ If you know what you're doing and would like to suppress this warning, use one o
         const serviceAlias = service.alias;
         const serviceName = service.name;
         const waitImageName = this.argv.waitImage;
+        const waitForServicesTimeout = this.argv.waitForServicesTimeout;
 
         const {stdout} = await Utils.spawn([this.argv.containerExecutable, "image", "inspect", serviceName]);
         const imageInspect = JSON.parse(stdout);
@@ -1669,7 +1670,7 @@ If you know what you're doing and would like to suppress this warning, use one o
                 if (!port.endsWith("/tcp")) return;
                 const portNum = parseInt(port.replace("/tcp", ""));
                 const containerName = `gcl-wait-for-it-${this.jobId}-${serviceIndex}-${portNum}`;
-                const spawnCmd = [this.argv.containerExecutable, "run", "--rm", `--name=${containerName}`, "--network", `${this._serviceNetworkId}`, `${waitImageName}`, `${uniqueAlias}:${portNum}`, "-t", "30"];
+                const spawnCmd = [this.argv.containerExecutable, "run", "--rm", `--name=${containerName}`, "--network", `${this._serviceNetworkId}`, `${waitImageName}`, `${uniqueAlias}:${portNum}`, "-t", `${waitForServicesTimeout}`];
                 this._containersToClean.push(containerName);
                 return Utils.spawn(spawnCmd);
             }));


### PR DESCRIPTION
# Summary

- Adds `--wait-for-services-timeout` CLI option to configure the timeout (in seconds) for service health checks
- Replaces the hardcoded 30-second timeout passed to the `wait-for-it` container
- Mirrors GitLab Runner's `wait_for_services_timeout` configuration option

Closes #1662

# Changes

- `src/index.ts` - yargs CLI option definition
- `src/argv.ts` - `waitForServicesTimeout` getter with default of 30
- `src/job.ts` - use configurable timeout instead of hardcoded `"30"`

# Usage

```
gitlab-ci-local my-job --wait-for-services-timeout 60
```

# Tests

No automated test, but consistent with `--wait-image` flag.

Writing a test for the service health-check flow is beyond my current understanding of the codebase, sorry `¯\_(ツ)_/¯`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a --wait-for-services-timeout CLI flag to configure the service health-check timeout. This replaces the hardcoded 30s and brings parity with GitLab Runner’s wait_for_services_timeout.

- **New Features**
  - --wait-for-services-timeout <seconds> with a default of 30.
  - Timeout is passed to the wait-for-it container when checking service ports.

<sup>Written for commit 7b45f470a84333bb70545a160a96d58e80bca30f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

