### PR TITLE
ci: add Node.js and Bun version matrix to smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,12 @@ jobs:
     strategy:
       matrix:
         node-version: [24, 25]
+        bun-version: [1.2.23, 1.3.10]
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: oven-sh/setup-bun@v2.1.3
         with:
-          bun-version: 1.3.10
+          bun-version: ${{ matrix.bun-version }}
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- Smoke test now runs against Node 24/25 and Bun 1.2/1.3 using a matrix strategy
- Catches compatibility issues with newer runtime versions early