### PR TITLE
fix: prefix rsync paths with ./

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1352,7 +1352,7 @@ If you know what you're doing and would like to suppress this warning, use one o
             for (const path of c.paths) {
                 if (!Utils.isSubpath(path, this.argv.cwd, this.argv.cwd)) continue;
 
-                paths += " " + Utils.expandText(path, expanded).replace(`${expanded.CI_PROJECT_DIR}/`, "");
+                paths += " ./" + Utils.expandText(path, expanded).replace(`${expanded.CI_PROJECT_DIR}/`, "");
             }
 
             time = process.hrtime();
@@ -1425,7 +1425,7 @@ If you know what you're doing and would like to suppress this warning, use one o
         }
         for (const artifactPath of this.artifacts?.paths ?? []) {
             const expandedPath = Utils.expandText(artifactPath, expanded).replace(`${expanded.CI_PROJECT_DIR}/`, "");
-            cpCmd += `${expandedPath} `;
+            cpCmd += `./${expandedPath} `;
         }
         cpCmd += `${artifactsPath}/${safeJobName}/. || true\n`;
         const reportDotenv = Utils.expandText(this.artifacts.reports?.dotenv ?? null, expanded);
@@ -1436,7 +1436,7 @@ If you know what you're doing and would like to suppress this warning, use one o
             reportDotenvs.forEach((reportDotenv) => {
                 cpCmd += `mkdir -p ${artifactsPath}/${safeJobName}/.gitlab-ci-reports/dotenv\n`;
                 cpCmd += `if [ -f ${reportDotenv} ]; then\n`;
-                cpCmd += `  rsync -Ra ${reportDotenv} ${artifactsPath}/${safeJobName}/.gitlab-ci-reports/dotenv/.\n`;
+                cpCmd += `  rsync -Ra ./${reportDotenv} ${artifactsPath}/${safeJobName}/.gitlab-ci-reports/dotenv/.\n`;
                 cpCmd += "fi\n";
             });
         }


### PR DESCRIPTION
to prevent colon-in-filename misinterpretation

Filenames containing colons (e.g. gate:pre-commit.log) are interpreted by rsync as remote host:path, causing it to exec ssh and fails.

May be related to #1686 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefix rsync source paths with ./ so filenames with colons are treated as local files, not host:path. This prevents unintended SSH and fixes artifact/report collection when paths include ':' characters.

<sup>Written for commit 26f01f236311e6e98936ad2aeca82c791ebd9d46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

