### PR TITLE
feat: support spec:inputs for root pipeline via --input and --inputs-file

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -227,13 +227,18 @@ export class Argv {
         const val = this.map.get("input");
         const inputs: {[key: string]: any} = {};
         const pairs = typeof val == "string" ? val.split(" ") : val;
+        const dangerousKeys = new Set(["__proto__", "constructor", "prototype"]);
         (pairs ?? []).forEach((inputPair: string) => {
             // Support component-specific syntax: component:key=value or key=value
-            const exec = /(?:(?<component>[\w-]+):)?(?<key>[\w-]+)(=)(?<value>(.|\n|\r)*)/.exec(inputPair);
+            // Component names may contain word chars, hyphens, and slashes (e.g. templates/deploy)
+            const exec = /(?:(?<component>[\w\-/]+):)?(?<key>[\w-]+)(=)(?<value>(.|\n|\r)*)/.exec(inputPair);
             if (exec?.groups?.key) {
                 const value = exec?.groups?.value;
                 const key = exec.groups.key;
                 const component = exec.groups.component;
+
+                // Guard against prototype pollution
+                if (dangerousKeys.has(key) || dangerousKeys.has(component ?? "")) return;
                 
                 // Try to parse as JSON for arrays/objects/booleans/numbers
                 let parsedValue;

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -60,6 +60,7 @@ export function injectGclVariableEnvVars (argv: {variable?: string[]; [key: stri
 export class Argv {
     static readonly default = {
         "variablesFile": ".gitlab-ci-local-variables.yml",
+        "inputsFile": ".gitlab-ci-local-inputs.yml",
         "evaluateRuleChanges": true,
         "ignoreSchemaPaths": [],
         "ignorePredefinedVars": "",
@@ -165,6 +166,10 @@ export class Argv {
         return this.map.get("variablesFile") ?? Argv.default.variablesFile;
     }
 
+    get inputsFile (): string {
+        return this.map.get("inputsFile") ?? Argv.default.inputsFile;
+    }
+
     get evaluateRuleChanges (): boolean {
         return this.map.get("evaluateRuleChanges") ?? Argv.default.evaluateRuleChanges;
     }
@@ -216,6 +221,39 @@ export class Argv {
             }
         }
         return variables;
+    }
+
+    get input (): {[key: string]: any} {
+        const val = this.map.get("input");
+        const inputs: {[key: string]: any} = {};
+        const pairs = typeof val == "string" ? val.split(" ") : val;
+        (pairs ?? []).forEach((inputPair: string) => {
+            // Support component-specific syntax: component:key=value or key=value
+            const exec = /(?:(?<component>[\w-]+):)?(?<key>[\w-]+)(=)(?<value>(.|\n|\r)*)/.exec(inputPair);
+            if (exec?.groups?.key) {
+                const value = exec?.groups?.value;
+                const key = exec.groups.key;
+                const component = exec.groups.component;
+                
+                // Try to parse as JSON for arrays/objects/booleans/numbers
+                let parsedValue;
+                try {
+                    parsedValue = JSON.parse(value);
+                } catch {
+                    parsedValue = value;
+                }
+                
+                if (component) {
+                    // Component-specific input: store under component namespace
+                    if (!inputs[component]) inputs[component] = {};
+                    inputs[component][key] = parsedValue;
+                } else {
+                    // Global input
+                    inputs[key] = parsedValue;
+                }
+            }
+        });
+        return inputs;
     }
 
     get unsetVariables (): string[] {

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -223,9 +223,10 @@ export class Argv {
         return variables;
     }
 
-    get input (): {[key: string]: any} {
+    get input (): {_global: {[key: string]: any}; _components: {[key: string]: {[key: string]: any}}} {
         const val = this.map.get("input");
-        const inputs: {[key: string]: any} = {};
+        const _global: {[key: string]: any} = {};
+        const _components: {[key: string]: {[key: string]: any}} = {};
         const pairs = typeof val == "string" ? val.split(" ") : val;
         const dangerousKeys = new Set(["__proto__", "constructor", "prototype"]);
         (pairs ?? []).forEach((inputPair: string) => {
@@ -249,16 +250,14 @@ export class Argv {
                 }
 
                 if (component) {
-                    // Component-specific input: store under component namespace
-                    if (!inputs[component]) inputs[component] = {};
-                    inputs[component][key] = parsedValue;
+                    if (!_components[component]) _components[component] = {};
+                    _components[component][key] = parsedValue;
                 } else {
-                    // Global input
-                    inputs[key] = parsedValue;
+                    _global[key] = parsedValue;
                 }
             }
         });
-        return inputs;
+        return {_global, _components};
     }
 
     get unsetVariables (): string[] {

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -239,7 +239,7 @@ export class Argv {
 
                 // Guard against prototype pollution
                 if (dangerousKeys.has(key) || dangerousKeys.has(component ?? "")) return;
-                
+
                 // Try to parse as JSON for arrays/objects/booleans/numbers
                 let parsedValue;
                 try {
@@ -247,7 +247,7 @@ export class Argv {
                 } catch {
                     parsedValue = value;
                 }
-                
+
                 if (component) {
                     // Component-specific input: store under component namespace
                     if (!inputs[component]) inputs[component] = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,12 @@ process.on("SIGUSR2", async () => {
             requiresArg: true,
             default: Argv.default.variablesFile,
         })
+        .option("inputs-file", {
+            type: "string",
+            description: "Path to the component inputs file",
+            requiresArg: true,
+            default: Argv.default.inputsFile,
+        })
         .option("completion", {
             type: "boolean",
             description: "Generate tab completion script",
@@ -166,6 +172,11 @@ process.on("SIGUSR2", async () => {
         .option("unset-variable", {
             type: "array",
             description: "Unsets a variable (--unset-variable HELLO)",
+            requiresArg: false,
+        })
+        .option("input", {
+            type: "array",
+            description: "Add input to component includes (--input KEY=value)",
             requiresArg: false,
         })
         .option("remote-variables", {

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -22,6 +22,7 @@ type ParserIncludesInitOptions = {
     variables: {[key: string]: string};
     expandVariables: boolean;
     maximumIncludes: number;
+    inputs: {[key: string]: any};
 };
 
 type ParsedComponent = {
@@ -54,7 +55,26 @@ export class ParserIncludes {
     }
 
     static async init (gitlabData: any, opts: ParserIncludesInitOptions): Promise<any[]> {
-        const {argv} = opts;
+        const {argv, inputs: inputsConfig} = opts;
+        const fileInputs = inputsConfig._file ?? {};
+        const cliInputs = inputsConfig._cli ?? {};
+        
+        // Extract global CLI inputs (non-component-specific)
+        const cliGlobalInputs: {[key: string]: any} = {};
+        const cliComponentInputs: {[key: string]: any} = {};
+        for (const [key, value] of Object.entries(cliInputs)) {
+            if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+                // This is a component-specific input (e.g., {deploy: {replicas: 5}})
+                cliComponentInputs[key] = value;
+            } else {
+                // This is a global input
+                cliGlobalInputs[key] = value;
+            }
+        }
+        
+        // If file has _global key, use structured format; otherwise treat entire file as global
+        const isStructured = fileInputs._global !== undefined || Object.keys(fileInputs).some(k => !k.startsWith('_') && typeof fileInputs[k] === 'object' && fileInputs[k] !== null && !Array.isArray(fileInputs[k]));
+        const globalInputs = isStructured ? {...(fileInputs._global ?? {}), ...cliGlobalInputs} : {...fileInputs, ...cliGlobalInputs};
         this.count++;
         assert(
             this.count <= opts.maximumIncludes + 1, // 1st init call is not counted
@@ -116,14 +136,16 @@ export class ParserIncludes {
                     throw new AssertionError({message: `Local include file cannot be found ${value["local"]}`});
                 }
                 for (const localFile of files) {
-                    const content = await Parser.loadYaml(localFile, {inputs: value.inputs ?? {}}, expandVariables, writeStreams);
+                    const mergedInputs = {...(value.inputs ?? {}), ...globalInputs};
+                    const content = await Parser.loadYaml(localFile, {inputs: mergedInputs}, expandVariables, writeStreams);
                     includeDatas = includeDatas.concat(await this.init(content, opts));
                 }
             } else if (value["project"]) {
                 for (const fileValue of Array.isArray(value["file"]) ? value["file"] : [value["file"]]) {
+                    const mergedInputs = {...(value.inputs ?? {}), ...globalInputs};
                     const fileDoc = await Parser.loadYaml(
                         `${cwd}/${stateDir}/includes/${gitData.remote.host}/${value["project"]}/${value["ref"] || "HEAD"}/${fileValue}`
-                        , {inputs: value.inputs || {}}
+                        , {inputs: mergedInputs}
                         , expandVariables, writeStreams);
                     // Expand local includes inside a "project"-like include
                     fileDoc["include"] = this.expandInnerLocalIncludes(fileDoc["include"], value["project"], value["ref"], opts);
@@ -148,21 +170,28 @@ export class ParserIncludes {
                 assert(file !== null, `This GitLab CI configuration is invalid: component: \`${value["component"]}\`. One of the files [${files}] must exist in \`${component.domain}` +
                                     (component.port ? `:${component.port}` : "") + `/${component.projectPath}\``);
 
-                const fileDoc = await Parser.loadYaml(file, {inputs: value.inputs || {}}, expandVariables, writeStreams);
+                // Extract component name for component-specific inputs
+                const componentName = component.name.replace(/^templates\//, "");
+                const fileComponentInputs = isStructured ? (fileInputs[componentName] ?? {}) : {};
+                const cliComponentSpecificInputs = cliComponentInputs[componentName] ?? {};
+                const mergedInputs = {...(value.inputs ?? {}), ...globalInputs, ...fileComponentInputs, ...cliComponentSpecificInputs, ...cliGlobalInputs};
+                const fileDoc = await Parser.loadYaml(file, {inputs: mergedInputs}, expandVariables, writeStreams);
                 // Expand local includes inside to a "project"-like include
                 fileDoc["include"] = this.expandInnerLocalIncludes(fileDoc["include"], component.projectPath, component.ref, opts);
                 includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
             } else if (value["template"]) {
                 const {project, ref, file, domain} = this.covertTemplateToProjectFile(value["template"]);
                 const fsUrl = Utils.fsUrl(`https://${domain}/${project}/-/raw/${ref}/${file}`);
+                const mergedInputs = {...(value.inputs ?? {}), ...globalInputs};
                 const fileDoc = await Parser.loadYaml(
-                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: value.inputs || {}}, expandVariables, writeStreams,
+                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: mergedInputs}, expandVariables, writeStreams,
                 );
                 includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
             } else if (value["remote"]) {
                 const fsUrl = Utils.fsUrl(value["remote"]);
+                const mergedInputs = {...(value.inputs ?? {}), ...globalInputs};
                 const fileDoc = await Parser.loadYaml(
-                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: value.inputs || {}}, expandVariables, writeStreams,
+                    `${cwd}/${stateDir}/includes/${fsUrl}`, {inputs: mergedInputs}, expandVariables, writeStreams,
                 );
                 includeDatas = includeDatas.concat(await this.init(fileDoc, opts));
             } else {

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -58,12 +58,12 @@ export class ParserIncludes {
         const {argv, inputs: inputsConfig} = opts;
         const fileInputs = inputsConfig._file ?? {};
         const cliInputs = inputsConfig._cli ?? {};
-        
+
         // Extract global CLI inputs (non-component-specific)
         const cliGlobalInputs: {[key: string]: any} = {};
         const cliComponentInputs: {[key: string]: any} = {};
         for (const [key, value] of Object.entries(cliInputs)) {
-            if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+            if (typeof value === "object" && value !== null && !Array.isArray(value)) {
                 // This is a component-specific input (e.g., {deploy: {replicas: 5}})
                 cliComponentInputs[key] = value;
             } else {
@@ -71,9 +71,9 @@ export class ParserIncludes {
                 cliGlobalInputs[key] = value;
             }
         }
-        
+
         // If file has _global key, use structured format; otherwise treat entire file as global
-        const isStructured = fileInputs._global !== undefined || Object.keys(fileInputs).some(k => !k.startsWith('_') && typeof fileInputs[k] === 'object' && fileInputs[k] !== null && !Array.isArray(fileInputs[k]));
+        const isStructured = fileInputs._global !== undefined || Object.keys(fileInputs).some(k => !k.startsWith("_") && typeof fileInputs[k] === "object" && fileInputs[k] !== null && !Array.isArray(fileInputs[k]));
         const globalInputs = isStructured ? {...(fileInputs._global ?? {}), ...cliGlobalInputs} : {...fileInputs, ...cliGlobalInputs};
         this.count++;
         assert(

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -174,7 +174,7 @@ export class ParserIncludes {
                 const componentName = component.name.replace(/^templates\//, "");
                 const fileComponentInputs = isStructured ? (fileInputs[componentName] ?? {}) : {};
                 const cliComponentSpecificInputs = cliComponentInputs[componentName] ?? {};
-                const mergedInputs = {...(value.inputs ?? {}), ...globalInputs, ...fileComponentInputs, ...cliComponentSpecificInputs, ...cliGlobalInputs};
+                const mergedInputs = {...(value.inputs ?? {}), ...globalInputs, ...fileComponentInputs, ...cliComponentSpecificInputs};
                 const fileDoc = await Parser.loadYaml(file, {inputs: mergedInputs}, expandVariables, writeStreams);
                 // Expand local includes inside to a "project"-like include
                 fileDoc["include"] = this.expandInnerLocalIncludes(fileDoc["include"], component.projectPath, component.ref, opts);

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -57,24 +57,11 @@ export class ParserIncludes {
     static async init (gitlabData: any, opts: ParserIncludesInitOptions): Promise<any[]> {
         const {argv, inputs: inputsConfig} = opts;
         const fileInputs = inputsConfig._file ?? {};
-        const cliInputs = inputsConfig._cli ?? {};
+        const cliGlobalInputs = inputsConfig._cliGlobal ?? {};
+        const cliComponentInputs = inputsConfig._cliComponents ?? {};
 
-        // Extract global CLI inputs (non-component-specific)
-        const cliGlobalInputs: {[key: string]: any} = {};
-        const cliComponentInputs: {[key: string]: any} = {};
-        for (const [key, value] of Object.entries(cliInputs)) {
-            if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-                // This is a component-specific input (e.g., {deploy: {replicas: 5}})
-                cliComponentInputs[key] = value;
-            } else {
-                // This is a global input
-                cliGlobalInputs[key] = value;
-            }
-        }
-
-        // If file has _global key, use structured format; otherwise treat entire file as global
-        const isStructured = fileInputs._global !== undefined || Object.keys(fileInputs).some(k => !k.startsWith("_") && typeof fileInputs[k] === "object" && fileInputs[k] !== null && !Array.isArray(fileInputs[k]));
-        const globalInputs = isStructured ? {...(fileInputs._global ?? {}), ...cliGlobalInputs} : {...fileInputs, ...cliGlobalInputs};
+        const isStructured = Utils.isStructuredInputsFile(fileInputs);
+        const globalInputs = {...Utils.getGlobalFileInputs(fileInputs), ...cliGlobalInputs};
         this.count++;
         assert(
             this.count <= opts.maximumIncludes + 1, // 1st init call is not counted

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -108,17 +108,8 @@ export class Parser {
         const inputs = await this.loadInputs(cwd, argv);
 
         // Build root-level inputs from global CLI + global file inputs
-        const cliInputs = inputs._cli ?? {};
         const fileInputs = inputs._file ?? {};
-        const globalCliInputs: {[key: string]: any} = {};
-        for (const [k, v] of Object.entries(cliInputs)) {
-            if (typeof v !== "object" || v === null || Array.isArray(v)) {
-                globalCliInputs[k] = v;
-            }
-        }
-        const isStructuredFile = fileInputs._global !== undefined || Object.keys(fileInputs).some(k => !k.startsWith("_") && typeof fileInputs[k] === "object" && fileInputs[k] !== null && !Array.isArray(fileInputs[k]));
-        const fileGlobalInputs = isStructuredFile ? (fileInputs._global ?? {}) : fileInputs;
-        const rootInputs = {...fileGlobalInputs, ...globalCliInputs};
+        const rootInputs = {...Utils.getGlobalFileInputs(fileInputs), ...inputs._cliGlobal};
 
         let yamlDataList: any[] = [{stages: [".pre", "build", "test", "deploy", ".post"]}];
         const gitlabCiData = await Parser.loadYaml(`${cwd}/${file}`, {inputs: rootInputs}, this.expandVariables, writeStreams);
@@ -258,8 +249,8 @@ export class Parser {
             }
         }
 
-        // Return both file inputs and CLI inputs separately for component-specific merging
-        return {_file: fileInputs, _cli: argv.input};
+        const cliInput = argv.input;
+        return {_file: fileInputs, _cliGlobal: cliInput._global, _cliComponents: cliInput._components};
     }
 
     static async loadYaml (filePath: string, ctx: any = {}, expandVariables: boolean = true, writeStreams?: WriteStreams): Promise<any> {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -104,14 +104,30 @@ export class Parser {
         const variables = {...predefinedVariables, ...envMatchedVariables, ...argv.variable};
         const expanded = Utils.expandVariables(variables);
 
-        let yamlDataList: any[] = [{stages: [".pre", "build", "test", "deploy", ".post"]}];
-        const gitlabCiData = await Parser.loadYaml(`${cwd}/${file}`, {}, this.expandVariables, writeStreams);
+        // Load inputs from file and merge with CLI inputs
+        const inputs = await this.loadInputs(cwd, argv);
 
-        yamlDataList = yamlDataList.concat(await ParserIncludes.init(gitlabCiData, {argv, cwd, stateDir, writeStreams, gitData, fetchIncludes, variables: expanded, expandVariables: this.expandVariables, maximumIncludes: argv.maximumIncludes}));
+        // Build root-level inputs from global CLI + global file inputs
+        const cliInputs = inputs._cli ?? {};
+        const fileInputs = inputs._file ?? {};
+        const globalCliInputs: {[key: string]: any} = {};
+        for (const [k, v] of Object.entries(cliInputs)) {
+            if (typeof v !== "object" || v === null || Array.isArray(v)) {
+                globalCliInputs[k] = v;
+            }
+        }
+        const isStructuredFile = fileInputs._global !== undefined || Object.keys(fileInputs).some(k => !k.startsWith("_") && typeof fileInputs[k] === "object" && fileInputs[k] !== null && !Array.isArray(fileInputs[k]));
+        const fileGlobalInputs = isStructuredFile ? (fileInputs._global ?? {}) : fileInputs;
+        const rootInputs = {...fileGlobalInputs, ...globalCliInputs};
+
+        let yamlDataList: any[] = [{stages: [".pre", "build", "test", "deploy", ".post"]}];
+        const gitlabCiData = await Parser.loadYaml(`${cwd}/${file}`, {inputs: rootInputs}, this.expandVariables, writeStreams);
+
+        yamlDataList = yamlDataList.concat(await ParserIncludes.init(gitlabCiData, {argv, cwd, stateDir, writeStreams, gitData, fetchIncludes, variables: expanded, expandVariables: this.expandVariables, maximumIncludes: argv.maximumIncludes, inputs}));
         ParserIncludes.resetCount();
 
         const gitlabCiLocalData = await Parser.loadYaml(`${cwd}/.gitlab-ci-local.yml`, {}, this.expandVariables, writeStreams);
-        yamlDataList = yamlDataList.concat(await ParserIncludes.init(gitlabCiLocalData, {argv, cwd, stateDir, writeStreams, gitData, fetchIncludes, variables: expanded, expandVariables: this.expandVariables, maximumIncludes: argv.maximumIncludes}));
+        yamlDataList = yamlDataList.concat(await ParserIncludes.init(gitlabCiLocalData, {argv, cwd, stateDir, writeStreams, gitData, fetchIncludes, variables: expanded, expandVariables: this.expandVariables, maximumIncludes: argv.maximumIncludes, inputs}));
         ParserIncludes.resetCount();
 
         const gitlabData: any = deepExtend({}, ...yamlDataList);
@@ -226,6 +242,24 @@ export class Parser {
         this.jobs.forEach((job) => {
             job.producers = Producers.init(this.jobs, this.stages, job);
         });
+    }
+
+    private async loadInputs (cwd: string, argv: Argv): Promise<{[key: string]: any}> {
+        const inputsFile = argv.inputsFile;
+        const inputsFilePath = path.isAbsolute(inputsFile) ? inputsFile : `${cwd}/${inputsFile}`;
+        let fileInputs: {[key: string]: any} = {};
+
+        if (fs.existsSync(inputsFilePath)) {
+            const content = await fs.readFile(inputsFilePath, "utf8");
+            try {
+                fileInputs = yaml.load(content) as {[key: string]: any} ?? {};
+            } catch (e: any) {
+                throw new Error(`Failed to parse inputs file ${inputsFilePath}: ${e.message}`);
+            }
+        }
+
+        // Return both file inputs and CLI inputs separately for component-specific merging
+        return {_file: fileInputs, _cli: argv.input};
     }
 
     static async loadYaml (filePath: string, ctx: any = {}, expandVariables: boolean = true, writeStreams?: WriteStreams): Promise<any> {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -254,7 +254,7 @@ export class Parser {
             try {
                 fileInputs = yaml.load(content) as {[key: string]: any} ?? {};
             } catch (e: any) {
-                throw new Error(`Failed to parse inputs file ${inputsFilePath}: ${e.message}`);
+                throw new Error(`Failed to parse inputs file ${inputsFilePath}: ${e.message}`, {cause: e});
             }
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -550,4 +550,12 @@ export class Utils {
         // Return the first alias in the set
         return aliases.values().next().value!;
     }
+
+    static isStructuredInputsFile (fileInputs: {[key: string]: any}): boolean {
+        return fileInputs._global !== undefined || Object.keys(fileInputs).some(k => !k.startsWith("_") && typeof fileInputs[k] === "object" && fileInputs[k] !== null && !Array.isArray(fileInputs[k]));
+    }
+
+    static getGlobalFileInputs (fileInputs: {[key: string]: any}): {[key: string]: any} {
+        return Utils.isStructuredInputsFile(fileInputs) ? (fileInputs._global ?? {}) : {...fileInputs};
+    }
 }

--- a/tests/argv-input.test.ts
+++ b/tests/argv-input.test.ts
@@ -11,31 +11,38 @@ beforeEach(() => {
 test("input parses component names with slashes", async () => {
     const argv = await Argv.build({input: ["templates/deploy:replicas=5"]}, writeStreams);
     const result = argv.input;
-    expect(result["templates/deploy"]).toEqual({replicas: 5});
+    expect(result._components["templates/deploy"]).toEqual({replicas: 5});
 });
 
 test("input keeps global and component keys separate", async () => {
     const argv = await Argv.build({input: ["deploy:replicas=5", "environment=prod"]}, writeStreams);
     const result = argv.input;
-    expect(result["deploy"]).toEqual({replicas: 5});
-    expect(result["environment"]).toEqual("prod");
+    expect(result._components["deploy"]).toEqual({replicas: 5});
+    expect(result._global["environment"]).toEqual("prod");
 });
 
 test("input ignores __proto__ component to prevent prototype pollution", async () => {
     const argv = await Argv.build({input: ["__proto__:polluted=true"]}, writeStreams);
     const result = argv.input;
-    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(Object.hasOwn(result._components, "__proto__")).toBe(false);
     expect(({} as any).polluted).toBeUndefined();
 });
 
 test("input ignores __proto__ key to prevent prototype pollution", async () => {
     const argv = await Argv.build({input: ["__proto__=true"]}, writeStreams);
     const result = argv.input;
-    expect(Object.keys(result)).not.toContain("__proto__");
+    expect(Object.keys(result._global)).not.toContain("__proto__");
 });
 
 test("input ignores constructor key to prevent prototype pollution", async () => {
     const argv = await Argv.build({input: ["constructor:toString=bad"]}, writeStreams);
     const result = argv.input;
-    expect(Object.hasOwn(result, "constructor")).toBe(false);
+    expect(Object.hasOwn(result._components, "constructor")).toBe(false);
+});
+
+test("input namespace collision: same key as global and component name", async () => {
+    const argv = await Argv.build({input: ["deploy=prod", "deploy:replicas=5"]}, writeStreams);
+    const result = argv.input;
+    expect(result._global["deploy"]).toEqual("prod");
+    expect(result._components["deploy"]).toEqual({replicas: 5});
 });

--- a/tests/argv-input.test.ts
+++ b/tests/argv-input.test.ts
@@ -1,0 +1,41 @@
+import "../src/global.js";
+import {Argv} from "../src/argv.js";
+import {WriteStreamsMock} from "../src/write-streams.js";
+
+let writeStreams: WriteStreamsMock;
+
+beforeEach(() => {
+    writeStreams = new WriteStreamsMock();
+});
+
+test("input parses component names with slashes", async () => {
+    const argv = await Argv.build({input: ["templates/deploy:replicas=5"]}, writeStreams);
+    const result = argv.input;
+    expect(result["templates/deploy"]).toEqual({replicas: 5});
+});
+
+test("input keeps global and component keys separate", async () => {
+    const argv = await Argv.build({input: ["deploy:replicas=5", "environment=prod"]}, writeStreams);
+    const result = argv.input;
+    expect(result["deploy"]).toEqual({replicas: 5});
+    expect(result["environment"]).toEqual("prod");
+});
+
+test("input ignores __proto__ component to prevent prototype pollution", async () => {
+    const argv = await Argv.build({input: ["__proto__:polluted=true"]}, writeStreams);
+    const result = argv.input;
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(({} as any).polluted).toBeUndefined();
+});
+
+test("input ignores __proto__ key to prevent prototype pollution", async () => {
+    const argv = await Argv.build({input: ["__proto__=true"]}, writeStreams);
+    const result = argv.input;
+    expect(Object.keys(result)).not.toContain("__proto__");
+});
+
+test("input ignores constructor key to prevent prototype pollution", async () => {
+    const argv = await Argv.build({input: ["constructor:toString=bad"]}, writeStreams);
+    const result = argv.input;
+    expect(Object.hasOwn(result, "constructor")).toBe(false);
+});

--- a/tests/test-cases/.gitignore
+++ b/tests/test-cases/.gitignore
@@ -6,3 +6,4 @@ artifacts/log.txt
 !gitignore/.gitlab-ci-local
 !component-inputs-cli/.gitlab-ci-local-inputs.yml
 !component-inputs-multiple/.gitlab-ci-local-inputs.yml
+!component-inputs-edge-cases/.gitlab-ci-local-inputs.yml

--- a/tests/test-cases/.gitignore
+++ b/tests/test-cases/.gitignore
@@ -4,3 +4,5 @@ artifacts/log.txt
 !custom-home/.home/.gitlab-ci-local
 !variable-order/.home/.gitlab-ci-local
 !gitignore/.gitlab-ci-local
+!component-inputs-cli/.gitlab-ci-local-inputs.yml
+!component-inputs-multiple/.gitlab-ci-local-inputs.yml

--- a/tests/test-cases/component-inputs-cli/.gitlab-ci-local-inputs.yml
+++ b/tests/test-cases/component-inputs-cli/.gitlab-ci-local-inputs.yml
@@ -1,0 +1,4 @@
+---
+environment: production
+replicas: 5
+enable_cache: true

--- a/tests/test-cases/component-inputs-cli/.gitlab-ci.yml
+++ b/tests/test-cases/component-inputs-cli/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+---
+include:
+  - component: $CI_SERVER_HOST/$CI_PROJECT_PATH/deploy@$CI_COMMIT_SHA
+
+stages:
+  - deploy

--- a/tests/test-cases/component-inputs-cli/integration.test.ts
+++ b/tests/test-cases/component-inputs-cli/integration.test.ts
@@ -1,0 +1,76 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("component-inputs-cli from file", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-cli",
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - deploy
+  - .post
+deploy-production:
+  stage: deploy
+  script:
+    - echo "Deploying to production"
+    - echo "Replicas 5"
+    - echo "Cache enabled true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});
+
+test("component-inputs-cli from CLI", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-cli",
+        input: ["environment=staging", "replicas=3"],
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - deploy
+  - .post
+deploy-staging:
+  stage: deploy
+  script:
+    - echo "Deploying to staging"
+    - echo "Replicas 3"
+    - echo "Cache enabled true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});
+
+test("component-inputs-cli CLI overrides file", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-cli",
+        input: ["environment=testing"],
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - deploy
+  - .post
+deploy-testing:
+  stage: deploy
+  script:
+    - echo "Deploying to testing"
+    - echo "Replicas 5"
+    - echo "Cache enabled true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});

--- a/tests/test-cases/component-inputs-cli/templates/deploy.yml
+++ b/tests/test-cases/component-inputs-cli/templates/deploy.yml
@@ -1,0 +1,19 @@
+---
+spec:
+  inputs:
+    environment:
+      type: string
+      default: dev
+    replicas:
+      type: number
+      default: 1
+    enable_cache:
+      type: boolean
+      default: false
+---
+deploy-$[[ inputs.environment ]]:
+  stage: deploy
+  script:
+    - echo "Deploying to $[[ inputs.environment ]]"
+    - echo "Replicas $[[ inputs.replicas ]]"
+    - echo "Cache enabled $[[ inputs.enable_cache ]]"

--- a/tests/test-cases/component-inputs-edge-cases/.gitlab-ci-local-inputs.yml
+++ b/tests/test-cases/component-inputs-edge-cases/.gitlab-ci-local-inputs.yml
@@ -1,0 +1,6 @@
+---
+_global:
+  environment: production
+
+deploy:
+  replicas: 3

--- a/tests/test-cases/component-inputs-edge-cases/.gitlab-ci.yml
+++ b/tests/test-cases/component-inputs-edge-cases/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+---
+include:
+  - component: $CI_SERVER_HOST/$CI_PROJECT_PATH/deploy@$CI_COMMIT_SHA
+
+stages:
+  - deploy

--- a/tests/test-cases/component-inputs-edge-cases/integration.test.ts
+++ b/tests/test-cases/component-inputs-edge-cases/integration.test.ts
@@ -1,0 +1,55 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+// Issue: component-specific CLI input must override global CLI input on key conflict
+test("component-specific CLI wins over global CLI on same key", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-edge-cases",
+        input: ["replicas=1", "deploy:replicas=10"],
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - deploy
+  - .post
+deploy-production:
+  stage: deploy
+  script:
+    - echo "Deploying to production"
+    - echo "Replicas 10"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});
+
+// Global CLI applies but file component-specific takes precedence
+test("file component-specific overrides global CLI", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-edge-cases",
+        input: ["replicas=7"],
+        preview: true,
+    }, writeStreams);
+
+    // File has deploy.replicas=3 (component-specific), which overrides global CLI replicas=7
+    const expected = `---
+stages:
+  - .pre
+  - deploy
+  - .post
+deploy-production:
+  stage: deploy
+  script:
+    - echo "Deploying to production"
+    - echo "Replicas 3"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});

--- a/tests/test-cases/component-inputs-edge-cases/templates/deploy.yml
+++ b/tests/test-cases/component-inputs-edge-cases/templates/deploy.yml
@@ -1,0 +1,15 @@
+---
+spec:
+  inputs:
+    environment:
+      type: string
+      default: dev
+    replicas:
+      type: number
+      default: 1
+---
+deploy-$[[ inputs.environment ]]:
+  stage: deploy
+  script:
+    - echo "Deploying to $[[ inputs.environment ]]"
+    - echo "Replicas $[[ inputs.replicas ]]"

--- a/tests/test-cases/component-inputs-multiple/.gitlab-ci-local-inputs.yml
+++ b/tests/test-cases/component-inputs-multiple/.gitlab-ci-local-inputs.yml
@@ -1,0 +1,10 @@
+---
+_global:
+  environment: production
+
+deploy:
+  replicas: 5
+
+build:
+  go_version: "1.21"
+  cache_enabled: true

--- a/tests/test-cases/component-inputs-multiple/.gitlab-ci.yml
+++ b/tests/test-cases/component-inputs-multiple/.gitlab-ci.yml
@@ -1,0 +1,8 @@
+---
+include:
+  - component: $CI_SERVER_HOST/$CI_PROJECT_PATH/deploy@$CI_COMMIT_SHA
+  - component: $CI_SERVER_HOST/$CI_PROJECT_PATH/build@$CI_COMMIT_SHA
+
+stages:
+  - build
+  - deploy

--- a/tests/test-cases/component-inputs-multiple/component-specific-cli.test.ts
+++ b/tests/test-cases/component-inputs-multiple/component-specific-cli.test.ts
@@ -1,0 +1,62 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("component-specific CLI inputs", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-multiple",
+        input: ["deploy:replicas=10", "build:go_version=\"1.22\"", "environment=staging"],
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - deploy
+  - .post
+deploy-job:
+  stage: deploy
+  script:
+    - echo "Deploy to staging with 10 replicas"
+build-job:
+  stage: build
+  script:
+    - echo "Build with Go 1.22"
+    - echo "Cache true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});
+
+test("component-specific CLI overrides file component-specific", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-multiple",
+        input: ["deploy:replicas=20"],
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - deploy
+  - .post
+deploy-job:
+  stage: deploy
+  script:
+    - echo "Deploy to production with 20 replicas"
+build-job:
+  stage: build
+  script:
+    - echo "Build with Go 1.21"
+    - echo "Cache true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});

--- a/tests/test-cases/component-inputs-multiple/integration.test.ts
+++ b/tests/test-cases/component-inputs-multiple/integration.test.ts
@@ -33,7 +33,7 @@ build-job:
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
 
-test("component-inputs-multiple CLI overrides component-specific", async () => {
+test("component-inputs-multiple global CLI does not override file component-specific", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
         cwd: "tests/test-cases/component-inputs-multiple",
@@ -41,6 +41,10 @@ test("component-inputs-multiple CLI overrides component-specific", async () => {
         preview: true,
     }, writeStreams);
 
+    // Global CLI inputs do NOT override file component-specific values.
+    // File has deploy.replicas=5 and build.go_version="1.21" (component-specific),
+    // so those take precedence over global CLI replicas=10 and go_version="1.22".
+    // Use component-specific CLI syntax (deploy:replicas=10) to override.
     const expected = `---
 stages:
   - .pre
@@ -50,11 +54,11 @@ stages:
 deploy-job:
   stage: deploy
   script:
-    - echo "Deploy to production with 10 replicas"
+    - echo "Deploy to production with 5 replicas"
 build-job:
   stage: build
   script:
-    - echo "Build with Go 1.22"
+    - echo "Build with Go 1.21"
     - echo "Cache true"`;
 
     expect(writeStreams.stdoutLines[0]).toEqual(expected);

--- a/tests/test-cases/component-inputs-multiple/integration.test.ts
+++ b/tests/test-cases/component-inputs-multiple/integration.test.ts
@@ -1,0 +1,88 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test("component-inputs-multiple from file", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-multiple",
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - deploy
+  - .post
+deploy-job:
+  stage: deploy
+  script:
+    - echo "Deploy to production with 5 replicas"
+build-job:
+  stage: build
+  script:
+    - echo "Build with Go 1.21"
+    - echo "Cache true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});
+
+test("component-inputs-multiple CLI overrides component-specific", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-multiple",
+        input: ["replicas=10", "go_version=\"1.22\""],
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - deploy
+  - .post
+deploy-job:
+  stage: deploy
+  script:
+    - echo "Deploy to production with 10 replicas"
+build-job:
+  stage: build
+  script:
+    - echo "Build with Go 1.22"
+    - echo "Cache true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});
+
+test("component-inputs-multiple CLI overrides global", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/component-inputs-multiple",
+        input: ["environment=staging"],
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - deploy
+  - .post
+deploy-job:
+  stage: deploy
+  script:
+    - echo "Deploy to staging with 5 replicas"
+build-job:
+  stage: build
+  script:
+    - echo "Build with Go 1.21"
+    - echo "Cache true"`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});

--- a/tests/test-cases/component-inputs-multiple/templates/build.yml
+++ b/tests/test-cases/component-inputs-multiple/templates/build.yml
@@ -1,0 +1,15 @@
+---
+spec:
+  inputs:
+    go_version:
+      type: string
+      default: "1.20"
+    cache_enabled:
+      type: boolean
+      default: false
+---
+build-job:
+  stage: build
+  script:
+    - echo "Build with Go $[[ inputs.go_version ]]"
+    - echo "Cache $[[ inputs.cache_enabled ]]"

--- a/tests/test-cases/component-inputs-multiple/templates/deploy.yml
+++ b/tests/test-cases/component-inputs-multiple/templates/deploy.yml
@@ -1,0 +1,14 @@
+---
+spec:
+  inputs:
+    environment:
+      type: string
+      default: dev
+    replicas:
+      type: number
+      default: 1
+---
+deploy-job:
+  stage: deploy
+  script:
+    - echo "Deploy to $[[ inputs.environment ]] with $[[ inputs.replicas ]] replicas"


### PR DESCRIPTION
## Summary

Adds support for providing `spec:inputs` values to the **root** `.gitlab-ci.yml` pipeline file — not just included files. This closes #1720.

## Problem

When the root `.gitlab-ci.yml` uses `spec:inputs`, there was no way to pass values for required inputs (those without a `default`). The root file was always loaded with an empty context:

```typescript
// parser.ts — was:
const gitlabCiData = await Parser.loadYaml(`${cwd}/${file}`, {}, ...);
```

Inputs on **included** files worked fine because `parser-includes.ts` forwarded `value.inputs` from the `include:` block. But the root file had no equivalent mechanism.

## Solution

### New CLI options

- `--input KEY=value` (repeatable) — provide global inputs
- `--input component:KEY=value` — provide component-specific inputs
- `--inputs-file PATH` — path to inputs YAML file (default: `.gitlab-ci-local-inputs.yml`)

### Inputs file formats

**Flat (all inputs are global):**
```yaml
environment: production
replicas: 5
```

**Structured (global + component-specific):**
```yaml
_global:
  environment: production
deploy:
  replicas: 5
build:
  go_version: "1.21"
```

### Priority order (highest to lowest)

1. Component-specific CLI inputs (`--input component:key=value`)
2. Component-specific file inputs
3. Global CLI inputs (`--input key=value`)
4. Global file inputs (`_global:` or flat format)
5. Inline inputs in `.gitlab-ci.yml` (`include: inputs:`)
6. Spec defaults

## Changes

| File | Change |
|------|--------|
| `src/argv.ts` | `inputsFile` getter, `input` getter with `key=value` and `component:key=value` parsing |
| `src/index.ts` | `--inputs-file` and `--input` yargs options |
| `src/parser.ts` | `loadInputs()` method; root `loadYaml()` now passes `{inputs: rootInputs}` instead of `{}`; absolute path support for `--inputs-file` |
| `src/parser-includes.ts` | `inputs` in opts type; merge logic for global/component-specific inputs across all include types |
| `tests/test-cases/component-inputs-cli/` | New test case: single component with CLI and file inputs |
| `tests/test-cases/component-inputs-multiple/` | New test case: multiple components with structured inputs |
| `tests/test-cases/.gitignore` | Exceptions for `.gitlab-ci-local-inputs.yml` fixture files |

## Testing

- 29 input-related tests pass (19 existing + 10 new)
- 130 core unit tests pass
- 88 non-Docker integration tests pass — zero regressions

### Corner cases verified

- Root required input via `--input` ✅
- Root defaults used when not overridden ✅
- CLI overrides file inputs ✅
- Structured file with `_global:` ✅
- Number/boolean type coercion ✅
- Options validation (valid + invalid) ✅
- Dynamic job names using inputs ✅
- Inputs in include paths ✅
- Type mismatch rejection ✅
- Normal pipelines without spec:inputs unaffected ✅
- Absolute `--inputs-file` path ✅

## Example

```yaml
# .gitlab-ci.yml
---
spec:
  inputs:
    environment:
      type: string
      default: dev
    build_type:
      type: string
---
stages:
  - build
build-job:
  stage: build
  script:
    - echo "env=$[[ inputs.environment ]] type=$[[ inputs.build_type ]]"
```

```bash
# Before: fails with "build_type input: required value has not been provided"
gitlab-ci-local --list

# After: works
gitlab-ci-local --input build_type=nightly --list
gitlab-ci-local --input build_type=nightly --input environment=prod --list
```

Fixes #1720

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for passing `spec:inputs` to the root `.gitlab-ci.yml`, with values from CLI or an inputs file. Inputs are applied to the root and all include types.

- **New Features**
  - `--input KEY=value` (repeatable) and `--input component:KEY=value` for global and component inputs.
  - `--inputs-file PATH` (default: `.gitlab-ci-local-inputs.yml`) with flat or structured formats (`_global` + components).
  - Inputs are merged into the root pipeline and all include types (local, project, component, template, remote).
  - Precedence: component CLI > file component > global CLI > file global > inline include inputs > spec defaults.

- **Bug Fixes**
  - Corrected merge order and separated CLI namespaces so component-specific CLI values win over global CLI on conflicts.
  - Allowed `/` in component names and blocked prototype-pollution keys (`__proto__`, `constructor`, `prototype`) in `--input`.
  - Support absolute paths for `--inputs-file`; ESLint cleanups (no functional changes).

<sup>Written for commit 4c3c13fb861f7c158a4c1d57680e5d7255080394. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

