### PR TITLE
fix(windows): skip id -u on Windows to avoid confusing startup error

### DIFF
--- a/src/git-data.ts
+++ b/src/git-data.ts
@@ -172,12 +172,19 @@ export class GitData {
         });
         promises.push(gitEmailPromise);
 
-        const osUidPromise = Utils.spawn(["id", "-u"], cwd).then(({stdout}) => {
-            this.user.GITLAB_USER_ID = stdout.trimEnd();
-        }).catch((e) => {
-            writeStreams.stderr(chalk`{yellow Using fallback linux user id}\n`);
-            writeStreams.stderr(chalk`{yellow   ${e.message}\n}`);
-        });
+        const osUidPromise = (async () => {
+            if (process.platform === "win32") {
+                // GITLAB_USER_ID is a Unix UID concept; keep default on Windows
+                return;
+            }
+            try {
+                const {stdout} = await Utils.spawn(["id", "-u"], cwd);
+                this.user.GITLAB_USER_ID = stdout.trimEnd();
+            } catch (e: any) {
+                writeStreams.stderr(chalk`{yellow Using fallback linux user id}\n`);
+                writeStreams.stderr(chalk`{yellow   ${e.message}\n}`);
+            }
+        })();
         promises.push(osUidPromise);
 
         await Promise.all(promises);


### PR DESCRIPTION
On Windows, `id -u` does not exist. Instead of spawning and catching the error (which prints a confusing warning), skip the call entirely and keep the default GITLAB_USER_ID value.

Closes #1684

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip calling `id -u` on Windows to remove the confusing startup warning and keep the default `GITLAB_USER_ID`. Closes #1684.

<sup>Written for commit 27b5809869bca3d48c2e58469ecd91a1d482fa47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

