### PR TITLE
fix: --completion outputs wrong script name when run via Bun

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -30,7 +30,7 @@ export async function handler (args: any, writeStreams: WriteStreams, jobs: Job[
     let parser: Parser;
 
     if (argv.completion) {
-        yargs(process.argv.slice(2)).showCompletionScript();
+        yargs(process.argv.slice(2)).scriptName("gitlab-ci-local").showCompletionScript();
         return [];
     }
 

--- a/tests/test-cases/completion/integration.test.ts
+++ b/tests/test-cases/completion/integration.test.ts
@@ -1,0 +1,12 @@
+import {execSync} from "child_process";
+
+// Runs the CLI as a subprocess to reliably capture console.log output,
+// which Bun implements natively and cannot be intercepted with vi.spyOn.
+test("--completion outputs gitlab-ci-local as script name", () => {
+    const output = execSync("bun src/index.ts --completion", {encoding: "utf8", stdio: ["pipe", "pipe", "pipe"]});
+
+    expect(output).toContain("###-begin-gitlab-ci-local-completions-###");
+    expect(output).toContain("###-end-gitlab-ci-local-completions-###");
+    expect(output).toContain("gitlab-ci-local --get-yargs-completions");
+    expect(output).not.toMatch(/###-begin-(?!gitlab-ci-local)/);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
                 extends: true,
                 test: {
                     name: "forks",
-                    include: ["tests/test-cases/argv-cwd/**/*.test.ts"],
+                    include: [
+                        "tests/test-cases/argv-cwd/**/*.test.ts",
+                        "tests/test-cases/completion/**/*.test.ts",
+                    ],
                     pool: "forks",
                 },
             },
@@ -16,7 +19,7 @@ export default defineConfig({
                 test: {
                     name: "threads",
                     include: ["tests/**/*.test.ts"],
-                    exclude: [...configDefaults.exclude, "**/.gitlab-ci-local*/**", "tests/test-cases/argv-cwd/**/*.test.ts"],
+                    exclude: [...configDefaults.exclude, "**/.gitlab-ci-local*/**", "tests/test-cases/argv-cwd/**/*.test.ts", "tests/test-cases/completion/**/*.test.ts"],
                     pool: "threads",
                 },
             },


### PR DESCRIPTION
## fix: --completion outputs wrong script name when run via Bun                                                                                                                                                  
                                                                                                                                                                                                                 
### Problem                                                                                                                                                                                                      
                                                                                                                                                                                                                 
Running `gitlab-ci-local --completion` generated a bash completion                                                                                                                                               
script referencing `bun` instead of `gitlab-ci-local`:          
                                                                                                                                                                                                                 
###-begin-bun-completions-###                                                                                                                                                                                    
...
mapfile -t type_list < <(bun --get-yargs-completions "${args[@]}")                                                                                                                                               
...                                                                                                                                                                                                              
complete -o bashdefault -o default -F _bun_yargs_completions bun
###-end-bun-completions-###                                                                                                                                                                                      
                                                                
When run via `bun run src/index.ts`, yargs derives `$0` from                                                                                                                                                     
`process.argv[0]`, which resolves to the `bun` binary instead of                                                                                                                                                 
the command name. The `handler.ts` completion branch was creating                                                                                                                                                
a fresh yargs instance without overriding this value.                                                                                                                                                            
                                                                                                                                                                                                                 
### Fix                                                                                                                                                                                                          
                                                                
Call `.scriptName("gitlab-ci-local")` on the yargs instance before                                                                                                                                               
`showCompletionScript()` to explicitly set `$0`.                
                                                                                                                                                                                                                 
### Test
                                                                                                                                                                                                                 
Added a subprocess-based regression test. `vi.spyOn(console, "log")`                                                                                                                                             
cannot intercept the output because Bun implements `console.log`
natively — the test runs the CLI via `execSync` and asserts the                                                                                                                                                  
generated script references `gitlab-ci-local` throughout.                                                                                                                                                        
The test is registered in the `forks` vitest pool and excluded from                                                                                                                                              
`threads` to avoid worker initialisation failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes --completion so the generated bash script uses `gitlab-ci-local` instead of `bun` when run via `bun`. Ensures the markers, function name, and complete directive reference the correct command.

- **Bug Fixes**
  - Set `yargs`.scriptName("gitlab-ci-local") before `.showCompletionScript()` to override `$0` (which `yargs` derived from `process.argv[0]` as `bun`).
  - Added a subprocess regression test that runs the CLI via `execSync` and asserts all references use `gitlab-ci-local`; test runs in the `forks` pool and is excluded from `threads`.

<sup>Written for commit 1eb7b49926389d9f068ed65db49092048dcd80bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

