### PR TITLE
feat: implement workflow:rules:variables support (#1832)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -131,6 +131,21 @@ export class Parser {
         DataExpander.inheritDefault(gitlabData);
         DataExpander.normalize(gitlabData);
 
+        // Evaluate workflow:rules and merge matched rule variables into global variables
+        const workflowRules = gitlabData.workflow?.rules;
+        if (workflowRules) {
+            const globalVars = gitlabData.variables ?? {};
+            const workflowVariables = {...predefinedVariables, ...globalVars, ...envMatchedVariables, ...argv.variable};
+            const ruleResult = Utils.getRulesResult({argv, cwd, rules: workflowRules, variables: workflowVariables}, gitData, "on_success");
+            if (ruleResult.variables) {
+                const normalizedRuleVars: {[key: string]: string} = {};
+                for (const [key, value] of Object.entries(ruleResult.variables)) {
+                    normalizedRuleVars[key] = Utils.normalizeVariables(value);
+                }
+                gitlabData.variables = {...globalVars, ...normalizedRuleVars};
+            }
+        }
+
         assert(gitlabData.stages && Array.isArray(gitlabData.stages), chalk`{yellow stages:} must be an array`);
         if (!gitlabData.stages.includes(".pre")) {
             gitlabData.stages.unshift(".pre");

--- a/tests/test-cases/workflow-rules-variables/.gitlab-ci-job-override.yml
+++ b/tests/test-cases/workflow-rules-variables/.gitlab-ci-job-override.yml
@@ -1,0 +1,13 @@
+---
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH
+      variables:
+        WORKFLOW_VAR: from-workflow-rules
+
+test-job:
+  stage: test
+  variables:
+    WORKFLOW_VAR: from-job
+  script:
+    - echo "WORKFLOW_VAR=${WORKFLOW_VAR}"

--- a/tests/test-cases/workflow-rules-variables/.gitlab-ci-no-match.yml
+++ b/tests/test-cases/workflow-rules-variables/.gitlab-ci-no-match.yml
@@ -1,0 +1,11 @@
+---
+workflow:
+  rules:
+    - if: $NONEXISTENT_VAR == 'something'
+      variables:
+        WORKFLOW_VAR: from-workflow-rules
+
+test-job:
+  stage: test
+  script:
+    - echo "WORKFLOW_VAR=${WORKFLOW_VAR}"

--- a/tests/test-cases/workflow-rules-variables/.gitlab-ci.yml
+++ b/tests/test-cases/workflow-rules-variables/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+---
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH
+      variables:
+        WORKFLOW_VAR: from-workflow-rules
+
+test-job:
+  stage: test
+  script:
+    - echo "WORKFLOW_VAR=${WORKFLOW_VAR}"

--- a/tests/test-cases/workflow-rules-variables/integration.test.ts
+++ b/tests/test-cases/workflow-rules-variables/integration.test.ts
@@ -1,0 +1,44 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+// workflow:rules:variables should be applied as global variables when a rule matches
+test.concurrent("workflow-rules-variables are applied", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/workflow-rules-variables",
+        stateDir: ".gitlab-ci-local-workflow-rules-variables",
+    }, writeStreams);
+
+    const output = writeStreams.stdoutLines.join("\n");
+    expect(output).toContain("WORKFLOW_VAR=from-workflow-rules");
+});
+
+test.concurrent("workflow-rules-variables not applied when rule does not match", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/workflow-rules-variables",
+        file: ".gitlab-ci-no-match.yml",
+        stateDir: ".gitlab-ci-local-workflow-rules-variables-no-match",
+    }, writeStreams);
+
+    const output = writeStreams.stdoutLines.join("\n");
+    expect(output).not.toContain("WORKFLOW_VAR=from-workflow-rules");
+});
+
+test.concurrent("workflow-rules-variables overridden by job variables", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/workflow-rules-variables",
+        file: ".gitlab-ci-job-override.yml",
+        stateDir: ".gitlab-ci-local-workflow-rules-variables-job-override",
+    }, writeStreams);
+
+    const output = writeStreams.stdoutLines.join("\n");
+    expect(output).toContain("WORKFLOW_VAR=from-job");
+});


### PR DESCRIPTION
Closes firecow/gitlab-ci-local#1832

Evaluate workflow:rules after data expansion and merge matched rule variables into global variables, making them available to all jobs.

Variables follow GitLab CI precedence: job-level variables override workflow:rules:variables.

 ## Variable precedence
 
 Per [GitLab docs](https://docs.gitlab.com/ci/yaml/#workflowrulesvariables), `workflow:rules:variables` override top-level `variables`, but are themselves overridden by job-level `variables`. This is tested and matches the official behavior.
