### PR TITLE
fix artifact file ownership inside container builds

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -694,12 +694,12 @@ If you know what you're doing and would like to suppress this warning, use one o
             const time = process.hrtime();
             this.refreshLongRunningSilentTimeout(writeStreams);
 
-            let chownOpt = "0:0";
+            let this.chownOpt = "0:0";
             let chmodOpt = "a+rw";
             if (!this.argv.umask) {
                 const {stdout} = await Utils.spawn([this.argv.containerExecutable, "run", "--rm", "--entrypoint", "sh", imageName, "-c", "echo \"$(id -u):$(id -g)\""]);
-                chownOpt = stdout;
-                if (chownOpt == "0:0") {
+                this.chownOpt = stdout;
+                if (this.chownOpt == "0:0") {
                     chmodOpt = "g-w";
                 }
             }
@@ -720,7 +720,7 @@ If you know what you're doing and would like to suppress this warning, use one o
                 }
             }
 
-            helperContainerArgs.push(`${helperImageName}`, "sh", "-c", `chown ${chownOpt} -R ${this.ciProjectDir} && chmod ${chmodOpt} -R ${this.ciProjectDir} && chown ${chownOpt} -R /tmp/ && chmod ${chmodOpt} -R /tmp/`);
+            helperContainerArgs.push(`${helperImageName}`, "sh", "-c", `chown ${this.chownOpt} -R ${this.ciProjectDir} && chmod ${chmodOpt} -R ${this.ciProjectDir} && chown ${this.chownOpt} -R /tmp/ && chmod ${chmodOpt} -R /tmp/`);
 
             const {stdout: containerId} = await Utils.spawn(helperContainerArgs, argv.cwd);
             this._containersToClean.push(containerId);
@@ -1336,7 +1336,7 @@ If you know what you're doing and would like to suppress this warning, use one o
         if (!this.imageName(this._variables) && this.argv.shellIsolation) {
             return Utils.spawn(["rsync", "-a", `${source}/.`, `${this.argv.cwd}/${this.argv.stateDir}/builds/${safeJobName}`]);
         }
-        return Utils.spawn([this.argv.containerExecutable, "cp", `${source}/.`, `${this._containerId}:${this.ciProjectDir}`]);
+        return Utils.spawn(["sh","-c" , `cd ${source}; tar -cf - . --owner ${this.chownOpt.split(":")[0]} --group ${this.chownOpt.split(":")[1]} | ${this.argv.containerExecutable} cp - ${this._containerId}:${this.ciProjectDir}`]);
     }
 
     private async copyCacheOut (writeStreams: WriteStreams, expanded: {[key: string]: string}) {


### PR DESCRIPTION
this fixes an issue that occurs when you use an image without root as the user
artifacts being copied into the container as the user outside of the container so changing the artifacts/anything in contained folders will fail due to permission denied
example dockerfile+gitlab-ci.yaml should fail on the dep step without this patch and work after
``` Dockerfile
FROM rockylinux:9
RUN useradd build
USER  build
```
``` yaml
--- 
build:
  stage: build
  artifacts:
    paths:
      - build
  image:
    name: rockyuser
  script:
    - mkdir -p build/river
    - echo "version=1.0.0" > build/river/release

dep:
  stage: deploy
  dependencies:
    - build
  tags:
    - on-prem
  image:
    name: rockyuser
  script:
    - id -g
    - id -u
    - ls -lah build
    - mkdir -p build/road
    - echo "version=1.1.1" > build/road/release
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes permission errors in non-root container builds by ensuring artifacts and the project directory are owned by the container user. We detect the image’s UID:GID and apply it when copying files and setting permissions.

- **Bug Fixes**
  - Detect UID:GID via `id -u:id -g` from the job image and reuse it across steps.
  - Chown/chmod the project dir and `/tmp` in the helper using the detected owner.
  - Copy build files via a tar stream with `--owner/--group` to ensure correct ownership inside the container.

<sup>Written for commit d80d1c62820326a28bd1e49dd59da940f9369e17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

