### PR TITLE
fix: connect service containers to local registry network

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1582,6 +1582,11 @@ If you know what you're doing and would like to suppress this warning, use one o
             dockerCmd += `--add-host=${extraHost} `;
         }
 
+        if (this.argv.registry) {
+            dockerCmd += `--volume ${Utils.gclRegistryPrefix}.certs:/etc/containers/certs.d:ro `;
+            dockerCmd += `--volume ${Utils.gclRegistryPrefix}.certs:/etc/docker/certs.d:ro `;
+        }
+
         if (this.argv.caFile) {
             const caFilePath = path.isAbsolute(this.argv.caFile) ? this.argv.caFile : path.resolve(this.argv.cwd, this.argv.caFile);
             if (await fs.pathExists(caFilePath)) {
@@ -1636,6 +1641,10 @@ If you know what you're doing and would like to suppress this warning, use one o
 
         for (const network of this.argv.network) {
             await Utils.spawn([this.argv.containerExecutable, "network", "connect", network, `${containerId}`]);
+        }
+
+        if (this.argv.registry) {
+            await Utils.spawn([this.argv.containerExecutable, "network", "connect", `${Utils.gclRegistryPrefix}.net`, `${containerId}`]);
         }
 
         await Utils.spawn([this.argv.containerExecutable, "start", `${containerId}`]);

--- a/tests/test-cases/local-registry/.gitlab-ci.yml
+++ b/tests/test-cases/local-registry/.gitlab-ci.yml
@@ -15,3 +15,10 @@ registry-login-oci:
   image: quay.io/podman/stable
   script:
     - echo "$CI_REGISTRY_PASSWORD" | podman login -u $CI_REGISTRY_USER --password-stdin $CI_REGISTRY
+
+registry-login-dind:
+  image: docker:cli
+  services:
+    - docker:dind
+  script:
+    - echo "$CI_REGISTRY_PASSWORD" | docker login -u $CI_REGISTRY_USER --password-stdin $CI_REGISTRY

--- a/tests/test-cases/local-registry/integration.test.ts
+++ b/tests/test-cases/local-registry/integration.test.ts
@@ -44,3 +44,16 @@ test("local-registry login <oci>", async () => {
 
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(["registry-login-oci > Login Succeeded!"]));
 });
+
+test("local-registry login <dind>", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/local-registry",
+        job: ["registry-login-dind"],
+        registry: true,
+        privileged: true,
+        noColor: true,
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(["registry-login-dind > Login Succeeded"]));
+});


### PR DESCRIPTION
Mount the registry cert volume and connect service containers to `registry.gcl.local.net`, so dind-style jobs can resolve and trust the local registry.

Closes #1844