### PR TITLE
test: ignore 'still running' heartbeat in stdout assertions

### DIFF
--- a/tests/test-cases/predefined-variables/integration.test.ts
+++ b/tests/test-cases/predefined-variables/integration.test.ts
@@ -141,7 +141,7 @@ describe("predefined-variables", () => {
             expected += `test-job > ${key}=${envVars[key]}\n`;
         });
 
-        const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("test-job > ")).join("\n");
+        const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("test-job > ") && !f.endsWith("> still running...")).join("\n");
         expect(filteredStdout).toEqual(expected.trim());
         expect(jobIdSpy).toHaveBeenCalledTimes(2);
     });
@@ -178,7 +178,7 @@ CI_SERVER_SHELL_SSH_PORT: 8022
         Object.keys(envVars).forEach(key => {
             expected += `test-job > ${key}=${envVars[key]}\n`;
         });
-        const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("test-job > ")).join("\n");
+        const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("test-job > ") && !f.endsWith("> still running...")).join("\n");
         expect(filteredStdout).toEqual(expected.trim());
         expect(jobIdSpy).toHaveBeenCalledTimes(2);
     });
@@ -218,7 +218,7 @@ CI_SERVER_SHELL_SSH_PORT: 8022
             expected += `test-job > ${key}=${envVars[key]}\n`;
         });
 
-        const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("test-job > ")).join("\n");
+        const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("test-job > ") && !f.endsWith("> still running...")).join("\n");
         expect(filteredStdout).toEqual(expected.trim());
         expect(jobIdSpy).toHaveBeenCalledTimes(2);
     });

--- a/tests/test-cases/services/integration.test.ts
+++ b/tests/test-cases/services/integration.test.ts
@@ -189,7 +189,7 @@ test.concurrent("services <services:entrypoint should support variable expansion
         stateDir: ".gitlab-ci-local-entrypoint",
     }, writeStreams);
 
-    const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("job1 >")).join("\n");
+    const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("job1 >") && !f.endsWith("> still running...")).join("\n");
     expect(filteredStdout).toEqual(`
 job1 > should support single quote       [']
 job1 > should support double quote       ["]


### PR DESCRIPTION
## Summary
- The 10s long-running silent timeout in `src/job.ts:1503` fires on slow CI runners and emits `<job> > still running...`, which slips through stdout filters that use `startsWith("<job> >")` and breaks equality assertions.
- Exclude heartbeat lines from the filters in the three currently-flaky tests so they only assert on real job output.

## Test plan
- [x] `bunx vitest run tests/test-cases/predefined-variables/ -t "normal|custom ports"` passes
- [x] `bunx vitest run tests/test-cases/services/ -t "should support variable expansion and double quotes"` passes
- [ ] CI run on this PR is green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore "still running..." heartbeat lines in test stdout assertions to fix flaky runs on slow CI. The affected tests now only capture real job output.

- Bug Fixes
  - Updated filters in `tests/test-cases/predefined-variables/integration.test.ts` and `tests/test-cases/services/integration.test.ts` to keep lines starting with the job prefix but ignore ones ending with "> still running...".

<sup>Written for commit 5fcf1669cc97b2d82f3da18bc2a0393a8386da2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

