### PR TITLE
fix: reject empty rules array instead of silently skipping job

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -133,6 +133,13 @@ For further troubleshooting, consider either of the following:
         }
     }
 
+    private static rulesBlank (jobs: ReadonlyArray<Job>) {
+        for (const job of jobs) {
+            if (job.rules === null) continue;
+            assert(job.rules.length > 0, chalk`{blue ${job.name}} {yellow rules:} config can't be blank`);
+        }
+    }
+
     private static arrayOfStrings (jobs: ReadonlyArray<Job>) {
         for (const job of jobs) {
             if (job.trigger) continue;
@@ -144,6 +151,7 @@ For further troubleshooting, consider either of the following:
 
     static async run (jobs: ReadonlyArray<Job>, stages: readonly string[]) {
         this.scriptBlank(jobs);
+        this.rulesBlank(jobs);
         this.arrayOfStrings(jobs);
         this.dependencies(jobs, stages);
         this.dependenciesContainment(jobs);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -135,7 +135,7 @@ For further troubleshooting, consider either of the following:
 
     private static rulesBlank (jobs: ReadonlyArray<Job>) {
         for (const job of jobs) {
-            if (job.rules === null) continue;
+            if (!job.rules) continue;
             assert(job.rules.length > 0, chalk`{blue ${job.name}} {yellow rules:} config can't be blank`);
         }
     }

--- a/tests/test-cases/rules-blank/.gitlab-ci.yml
+++ b/tests/test-cases/rules-blank/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+job:
+  rules: []
+  script:
+    - echo "Heya"

--- a/tests/test-cases/rules-blank/integration.test.ts
+++ b/tests/test-cases/rules-blank/integration.test.ts
@@ -1,0 +1,18 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import chalk from "chalk-template";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("rules-blank <job>", async () => {
+    const writeStreams = new WriteStreamsMock();
+
+    await expect(handler({
+        cwd: "tests/test-cases/rules-blank",
+        stateDir: ".gitlab-ci-local-rules-blank",
+    }, writeStreams)).rejects.toThrow(chalk`{blue job} {yellow rules:} config can't be blank`);
+});


### PR DESCRIPTION
Closes #1561. `rules: []` was silently treated as `when: never`; now rejected like gitlab.com does.