### PR TITLE
fix: reject ${VAR} in rules:if

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,6 +215,7 @@ export class Utils {
 
     static evaluateRuleIf (ruleIf: string | undefined, envs: {[key: string]: string}): boolean {
         if (ruleIf === undefined) return true;
+        assert(!/\$\{[A-Za-z_][A-Za-z0-9_]*\}/.test(ruleIf), chalk`rules:rule if invalid expression syntax: {blueBright ${ruleIf}}\nuse {green $VAR} not {red \${VAR\}} in rules:if`);
         let evalStr = ruleIf;
 
         const flagsToBinary = (flags: string): number => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,7 +215,7 @@ export class Utils {
 
     static evaluateRuleIf (ruleIf: string | undefined, envs: {[key: string]: string}): boolean {
         if (ruleIf === undefined) return true;
-        assert(!/\$\{[A-Za-z_][A-Za-z0-9_]*\}/.test(ruleIf), chalk`rules:rule if invalid expression syntax: {blueBright ${ruleIf}}\nuse {green $VAR} not {red \${VAR\}} in rules:if`);
+        assert(!/\$\{\w+\}/.test(ruleIf), chalk`rules:rule if invalid expression syntax: {blueBright ${ruleIf}}\nuse {green $VAR} not {red \${VAR\}} in rules:if`);
         let evalStr = ruleIf;
 
         const flagsToBinary = (flags: string): number => {

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -85,6 +85,11 @@ test.concurrent("VAR exists positive", () => {
     expect(val).toBe(true);
 });
 
+test.concurrent("rejects ${VAR} curly-bracket reference", () => {
+    expect(() => Utils.evaluateRuleIf("${VAR} == 'true'", {VAR: "true"}))
+        .toThrow(/rules:rule if invalid expression syntax/);
+});
+
 test.concurrent("VAR exists fail", () => {
     const ruleIf = "$VAR";
     const val = Utils.evaluateRuleIf(ruleIf, {});

--- a/tests/test-cases/rules-curly-bracket-if/.gitlab-ci.yml
+++ b/tests/test-cases/rules-curly-bracket-if/.gitlab-ci.yml
@@ -1,0 +1,6 @@
+---
+job:
+  rules:
+    - if: '${GITLAB_CI} == "true"'
+  script:
+    - echo "should not run"

--- a/tests/test-cases/rules-curly-bracket-if/integration.test.ts
+++ b/tests/test-cases/rules-curly-bracket-if/integration.test.ts
@@ -1,0 +1,17 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("rules-curly-bracket-if rejects ${VAR} in rules:if", async () => {
+    const writeStreams = new WriteStreamsMock();
+
+    await expect(handler({
+        cwd: "tests/test-cases/rules-curly-bracket-if",
+        stateDir: ".gitlab-ci-local-rules-curly-bracket-if",
+    }, writeStreams)).rejects.toThrow(/rules:rule if invalid expression syntax/);
+});


### PR DESCRIPTION
Closes #1652. GitLab fails with `rules:rule if invalid expression syntax`; gitlab-ci-local was silently expanding it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject `${VAR}` in `rules:if` and throw a clear error to match GitLab’s validation. This prevents silent expansion and makes local behavior consistent with GitLab.

- **Bug Fixes**
  - Validate `rules:if` and reject `${VAR}` in `Utils.evaluateRuleIf`, with guidance to use `$VAR`; simplified the detection regex to satisfy SonarCloud.
  - Added unit and integration tests for the failure case.

- **Migration**
  - If your `.gitlab-ci.yml` uses `${VAR}` in `rules:if`, replace it with `$VAR`.

<sup>Written for commit 9825decdfde2bb5e32baa55b955db59744cbcac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

