### PR TITLE
fix: wait for child stdio close before resolving exec

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1165,7 +1165,9 @@ If you know what you're doing and would like to suppress this warning, use one o
                 cp.stdout?.pipe(split2()).on("data", (e: string) => outFunc(e, writeStreams.stdout.bind(writeStreams), (s) => chalk`{greenBright ${s}}`));
                 cp.stderr?.pipe(split2()).on("data", (e: string) => outFunc(e, writeStreams.stderr.bind(writeStreams), (s) => chalk`{redBright ${s}}`));
             }
-            void cp.on("exit", (code) => {
+            // Wait for "close" rather than "exit" so all stdout/stderr data events
+            // have flushed to the output log file before we resolve.
+            void cp.on("close", (code) => {
                 clearTimeout(this._longRunningSilentTimeout);
                 return resolve(code ?? 0);},
             );


### PR DESCRIPTION
Resolve on `cp.on('close', ...)` instead of `cp.on('exit', ...)`. `exit` fires before stdio streams flush, so the `appendFileSync` calls in the data handler may not have written the last lines to the log file when the next code reads it — root cause of the flaky `script-failures` failure on #1854.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve on the child process `close` event instead of `exit` so stdout/stderr fully flush before we proceed. This fixes a race that sometimes dropped the last log lines and caused flaky post-failure summaries.

<sup>Written for commit 9ba849575737f0f6b7ca44a08dfd48e9c4dd5a55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

