### PR TITLE
chore: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: ibiqlik/action-yamllint@v3.1.1
+      - uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3.1.1
         with:
           strict: true
 
@@ -26,7 +26,7 @@ jobs:
         bun-version: [1.2.23, 1.3.10]
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: ${{ matrix.bun-version }}
       - uses: actions/setup-node@v6
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.13
       - run: bun install --frozen-lockfile
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.13
       - run: bun install --frozen-lockfile
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.13
       - run: bun install --frozen-lockfile
@@ -77,13 +77,13 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.13
       - run: bun install --frozen-lockfile
       - name: Run Tests
         run: bun run coverage
-      - uses: sonarsource/sonarqube-scan-action@v8.0
+      - uses: sonarsource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           sed -i "s/0.0.0/${GITHUB_REF_NAME}/g" package.json
 
-      - uses: oven-sh/setup-bun@v2.2.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.13
 


### PR DESCRIPTION
Closes SonarCloud S7637 (×8). Pin `oven-sh/setup-bun`, `ibiqlik/action-yamllint` and `sonarsource/sonarqube-scan-action` to commit SHAs to prevent tag-rewrite supply-chain attacks. Version retained as inline comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin GitHub Actions to immutable commit SHAs to prevent tag-rewrite supply-chain attacks and ensure reproducible CI runs. Pins `oven-sh/setup-bun`, `ibiqlik/action-yamllint`, and `sonarsource/sonarqube-scan-action`; keeps version numbers as inline comments and resolves SonarCloud rule S7637 (×8).

<sup>Written for commit 830885348fed56fdb9f7918c2702dbdfbc64044e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

