### PR TITLE
fix(rules): treat null RHS in =~ and !~ as false

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -299,6 +299,9 @@ export class Utils {
 
         evalStr = evalStr.replaceAll(/null.matchRE2JS\(.+?\)\s*!=\s*null/g, "false");
         evalStr = evalStr.replaceAll(/null.matchRE2JS\(.+?\)\s*==\s*null/g, "true");
+        // When RHS variable is undefined (null), GitLab CI returns null for both =~ and !~ (falsy)
+        evalStr = evalStr.replaceAll(/(?:null|"(?:[^"\\]|\\.)*")\s*=~\s*null/g, "false");
+        evalStr = evalStr.replaceAll(/(?:null|"(?:[^"\\]|\\.)*")\s*!~\s*null/g, "false");
 
         evalStr = evalStr.trim();
 

--- a/tests/test-cases/workflow-rules-variables/.gitlab-ci-null-rhs-regex.yml
+++ b/tests/test-cases/workflow-rules-variables/.gitlab-ci-null-rhs-regex.yml
@@ -1,0 +1,13 @@
+---
+workflow:
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ $PROD_REF || $CI_COMMIT_BRANCH =~ $UNDEFINED_INTEG_REF
+      when: never
+    - when: always
+variables:
+  PROD_REF: /^release$/
+
+test-job:
+  stage: test
+  script:
+    - echo "job ran"

--- a/tests/test-cases/workflow-rules-variables/integration.test.ts
+++ b/tests/test-cases/workflow-rules-variables/integration.test.ts
@@ -31,6 +31,18 @@ test.concurrent("workflow-rules-variables not applied when rule does not match",
     expect(output).not.toContain("WORKFLOW_VAR=from-workflow-rules");
 });
 
+test.concurrent("workflow-rules:if with null RHS regex variable does not throw", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/workflow-rules-variables",
+        file: ".gitlab-ci-null-rhs-regex.yml",
+        stateDir: ".gitlab-ci-local-workflow-rules-variables-null-rhs-regex",
+    }, writeStreams);
+
+    const output = writeStreams.stdoutLines.join("\n");
+    expect(output).toContain("job ran");
+});
+
 test.concurrent("workflow-rules-variables overridden by job variables", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({


### PR DESCRIPTION
fix for #1859 

When a variable used as the RHS of a regex match is undefined, GitLab CI evaluates the expression as null (falsy) for both =~ and !~. Previously gitlab-ci-local would throw or produce incorrect results. Replace such expressions with "false" before evaluation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rule evaluation when the RHS of =~ or !~ is undefined by treating it as false, matching GitLab CI and preventing crashes or wrong results. Affects workflow rule conditions that use regex with missing variables.

- **Bug Fixes**
  - Replace patterns like '... =~ null' and '... !~ null' with 'false' before evaluation.
  - Added `.gitlab-ci-null-rhs-regex.yml` and an integration test to verify the job runs and no error is thrown.

<sup>Written for commit 4fc232a86a980167db5d2f4cc12606a134c0424e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

