### PR TITLE
fix: reject non-array needs with clear error

### DIFF
--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -129,6 +129,7 @@ export function needsComplex (data: any) {
 export function needsEach (jobName: string, gitlabData: any) {
     const jobData = gitlabData[jobName];
     if (!jobData.needs) return;
+    assert(Array.isArray(jobData.needs), chalk`{blueBright ${jobName}} {yellow needs:} must be an array`);
 
     for (const [i, n] of Object.entries<any>(jobData.needs)) {
         jobData.needs[i] = needsComplex(n);

--- a/src/data-expander.ts
+++ b/src/data-expander.ts
@@ -132,6 +132,7 @@ export function needsEach (jobName: string, gitlabData: any) {
     assert(Array.isArray(jobData.needs), chalk`{blueBright ${jobName}} {yellow needs:} must be an array`);
 
     for (const [i, n] of Object.entries<any>(jobData.needs)) {
+        assert(n != null, chalk`{blueBright ${jobName}} {yellow needs:} entries cannot be empty`);
         jobData.needs[i] = needsComplex(n);
     }
 }

--- a/tests/test-cases/needs-empty-entry/.gitlab-ci.yml
+++ b/tests/test-cases/needs-empty-entry/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+---
+build-job:
+  script:
+    - echo "build"
+
+dev-job:
+  needs:
+    - ~
+  script:
+    - echo "dev"

--- a/tests/test-cases/needs-empty-entry/integration.test.ts
+++ b/tests/test-cases/needs-empty-entry/integration.test.ts
@@ -1,0 +1,18 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import chalk from "chalk-template";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("needs-empty-entry <dev-job>", async () => {
+    const writeStreams = new WriteStreamsMock();
+
+    await expect(handler({
+        cwd: "tests/test-cases/needs-empty-entry",
+        stateDir: ".gitlab-ci-local-needs-empty-entry",
+    }, writeStreams)).rejects.toThrow(chalk`{blueBright dev-job} {yellow needs:} entries cannot be empty`);
+});

--- a/tests/test-cases/needs-not-array/.gitlab-ci.yml
+++ b/tests/test-cases/needs-not-array/.gitlab-ci.yml
@@ -1,0 +1,9 @@
+---
+build-job:
+  script:
+    - echo "build"
+
+dev-job:
+  needs: build-job
+  script:
+    - echo "dev"

--- a/tests/test-cases/needs-not-array/integration.test.ts
+++ b/tests/test-cases/needs-not-array/integration.test.ts
@@ -1,0 +1,18 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import chalk from "chalk-template";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("needs-not-array <dev-job>", async () => {
+    const writeStreams = new WriteStreamsMock();
+
+    await expect(handler({
+        cwd: "tests/test-cases/needs-not-array",
+        stateDir: ".gitlab-ci-local-needs-not-array",
+    }, writeStreams)).rejects.toThrow(chalk`{blueBright dev-job} {yellow needs:} must be an array`);
+});


### PR DESCRIPTION
## Summary
- `needs: build` (scalar string instead of a list) crashed with `TypeError: Attempted to assign to readonly property` in `needsEach` because `Object.entries` iterated the string's characters and assignment to string indices is read-only.
- Now asserts `needs` is an array up front, matching the upstream GitLab schema (top-level `needs` is `"type": "array"`).

## Test plan
- [x] `bunx vitest run tests/test-cases/needs-not-array/` passes
- [x] Existing `needs-*` tests still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-array and empty job `needs` with clear errors. Prevents crashes and aligns with GitLab’s array schema.

- **Bug Fixes**
  - Enforce array type for `needs` in `needsEach`; add test for string `needs`.
  - Reject null/empty `needs` entries; add test for `needs: [~]`.

<sup>Written for commit 4648adcfb4e3a085cad7db599cfacdb1efa7ec20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

