### PR TITLE
fix: prevent ENAMETOOLONG crash for long parallel:matrix job names

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import checksum from "checksum";
 import base64url from "base64url";
 import execa, {ExecaError} from "execa";
 import assert from "node:assert";
+import {createHash} from "node:crypto";
 import {CICDVariable} from "./variables-from-files.js";
 import {GitData} from "./git-data.js";
 import {globbySync} from "globby";
@@ -49,10 +50,18 @@ export class Utils {
         return url.replace(/^https:\/\//g, "").replace(/^http:\/\//g, "");
     }
 
+    static readonly MAX_FILENAME_LENGTH = 238; // 255 (NAME_MAX) - 17 (longest suffix: "gcl-" + "-" + jobId + "-build")
+
     static safeDockerString (jobName: string) {
-        return jobName.replace(/[^\w-]+/g, (match) => {
+        const encoded = jobName.replace(/[^\w-]+/g, (match) => {
             return base64url.encode(match);
         });
+        if (encoded.length <= Utils.MAX_FILENAME_LENGTH) {
+            return encoded;
+        }
+        const hash = createHash("sha256").update(jobName).digest("hex").substring(0, 16);
+        const prefix = encoded.substring(0, Utils.MAX_FILENAME_LENGTH - 1 - hash.length);
+        return `${prefix}-${hash}`;
     }
 
     static safeBashString (s: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,9 +50,13 @@ export class Utils {
         return url.replace(/^https:\/\//g, "").replace(/^http:\/\//g, "");
     }
 
-    static readonly MAX_FILENAME_LENGTH = 238; // 255 (NAME_MAX) - 17 (longest suffix: "gcl-" + "-" + jobId + "-build")
+    // gcl-${safeJobName}-${jobId}-build → wrapper is 17 chars (jobId max 6 digits)
+    static readonly MAX_FILENAME_LENGTH = 255 - 17; // NAME_MAX (bytes) - wrapper
 
     static safeDockerString (jobName: string) {
+        // INVARIANT: \w without /u is ASCII-only ([A-Za-z0-9_]), so `encoded` is pure ASCII
+        // and .length === byte length. NAME_MAX is a byte limit — adding /u would break this.
+        // We hash `jobName` (not `encoded`) because base64url encoding isn't injective.
         const encoded = jobName.replace(/[^\w-]+/g, (match) => {
             return base64url.encode(match);
         });

--- a/tests/test-cases/parallel-matrix-long-name/.gitignore
+++ b/tests/test-cases/parallel-matrix-long-name/.gitignore
@@ -1,0 +1,1 @@
+.gitlab-ci-local-*

--- a/tests/test-cases/parallel-matrix-long-name/.gitlab-ci.yml
+++ b/tests/test-cases/parallel-matrix-long-name/.gitlab-ci.yml
@@ -1,0 +1,10 @@
+---
+build-job:
+  stage: build
+  script:
+    - echo "APP='${APP}' $CI_NODE_INDEX/$CI_NODE_TOTAL"
+  parallel:
+    matrix:
+      - APP:
+          - "my-app-controller,My app controller to be used as reference for development teams,python311,controller,common,controller/setup.py,controller/setup_c.py,controller/setup_n.py,controller/tests/**/*,controller/coverage/*,controller/build/**/*,controller/coverage/coverage-unit.xml,75,true"
+          - short

--- a/tests/test-cases/parallel-matrix-long-name/.gitlab-ci.yml
+++ b/tests/test-cases/parallel-matrix-long-name/.gitlab-ci.yml
@@ -6,5 +6,7 @@ build-job:
   parallel:
     matrix:
       - APP:
-          - "my-app-controller,My app controller to be used as reference for development teams,python311,controller,common,controller/setup.py,controller/setup_c.py,controller/setup_n.py,controller/tests/**/*,controller/coverage/*,controller/build/**/*,controller/coverage/coverage-unit.xml,75,true"
+          - "my-app-controller,My app controller to be used as reference for development teams,python311,\
+            controller,common,controller/setup.py,controller/setup_c.py,controller/setup_n.py,controller/tests/**/*,\
+            controller/coverage/*,controller/build/**/*,controller/coverage/coverage-unit.xml,75,true"
           - short

--- a/tests/test-cases/parallel-matrix-long-name/integration.test.ts
+++ b/tests/test-cases/parallel-matrix-long-name/integration.test.ts
@@ -1,0 +1,17 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+
+test.concurrent("parallel-matrix-long-name - completes without ENAMETOOLONG", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/parallel-matrix-long-name",
+        shellIsolation: true,
+        stateDir: ".gitlab-ci-local-parallel-matrix-long-name",
+    }, writeStreams);
+
+    // Both matrix entries must complete — the long one would crash with ENAMETOOLONG before the fix
+    const passing = writeStreams.stdoutLines.filter(l => l.includes(" PASS "));
+    expect(passing.length).toBe(2);
+    expect(writeStreams.stdoutLines.some(l => l.includes("build-job: [short]"))).toBe(true);
+    expect(writeStreams.stdoutLines.some(l => l.includes("build-job: [my-app-controller,"))).toBe(true);
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -275,7 +275,7 @@ describe("safeDockerString", () => {
 
     it("should encode non-alphanumeric characters", () => {
         const result = Utils.safeDockerString("job/name");
-        expect(result).toContain("Lw"); // '/' encodes to base64url
+        expect(result).toBe("jobLwname"); // '/' → 'Lw'
     });
 
     it("should truncate and hash when encoded name exceeds MAX_FILENAME_LENGTH", () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -266,3 +266,66 @@ describe("getServiceAlias", () => {
         expect(Utils.getServiceAlias({...base, name: "library/nginx", alias: "my-nginx"})).toBe("my-nginx");
     });
 });
+
+describe("safeDockerString", () => {
+    it("should return encoded name unchanged when within limit", () => {
+        const result = Utils.safeDockerString("short-job-name");
+        expect(result).toBe("short-job-name");
+    });
+
+    it("should encode non-alphanumeric characters", () => {
+        const result = Utils.safeDockerString("job/name");
+        expect(result).toContain("Lw"); // '/' encodes to base64url
+    });
+
+    it("should truncate and hash when encoded name exceeds MAX_FILENAME_LENGTH", () => {
+        const longName = "my-group/common/python-unit-test: [my-app-controller,My app controller to be used as reference for development teams,python311,controller,common,controller/setup.py,controller/setup_c.py,controller/setup_n.py,controller/tests/**/*,controller/coverage/*,controller/build/**/*,controller/coverage/coverage-unit.xml,75,true]";
+        const result = Utils.safeDockerString(longName);
+        expect(result.length).toBeLessThanOrEqual(Utils.MAX_FILENAME_LENGTH);
+    });
+
+    it("should produce deterministic output for the same input", () => {
+        const longName = "a".repeat(50) + "/" + "b".repeat(200);
+        const result1 = Utils.safeDockerString(longName);
+        const result2 = Utils.safeDockerString(longName);
+        expect(result1).toBe(result2);
+    });
+
+    it("should produce different output for different long inputs", () => {
+        const name1 = "job: [" + "a".repeat(300) + "]";
+        const name2 = "job: [" + "b".repeat(300) + "]";
+        const result1 = Utils.safeDockerString(name1);
+        const result2 = Utils.safeDockerString(name2);
+        expect(result1).not.toBe(result2);
+    });
+
+    it("should handle extremely long job names (1000+ chars)", () => {
+        const extremeName = "group/subgroup/job: [" + "x".repeat(2000) + "]";
+        const result = Utils.safeDockerString(extremeName);
+        expect(result.length).toBeLessThanOrEqual(Utils.MAX_FILENAME_LENGTH);
+        expect(result.length).toBeGreaterThan(16); // has prefix + hash
+    });
+
+    it("should keep volume name within NAME_MAX=255 (worst-case suffix)", () => {
+        const longName = "my-group/common/python-unit-test: [" + "a/b/c,".repeat(100) + "]";
+        const safeJobName = Utils.safeDockerString(longName);
+        const worstCaseVolume = `gcl-${safeJobName}-999999-build`;
+        expect(worstCaseVolume.length).toBeLessThanOrEqual(255);
+    });
+
+    it("should not hash names that are exactly at the limit", () => {
+        // Create a name whose encoded form is exactly MAX_FILENAME_LENGTH
+        const name = "a".repeat(Utils.MAX_FILENAME_LENGTH);
+        const result = Utils.safeDockerString(name);
+        expect(result).toBe(name); // all alphanumeric, no encoding, no hash
+    });
+
+    it("should hash names whose encoded form is one char over the limit", () => {
+        // 'a' stays as 'a', '/' encodes to 'Lw' (2 chars)
+        // Build a string that encodes to exactly MAX_FILENAME_LENGTH + 1
+        const name = "a".repeat(Utils.MAX_FILENAME_LENGTH - 1) + "/"; // '/' -> 'Lw' = +2, total = MAX+1
+        const result = Utils.safeDockerString(name);
+        expect(result.length).toBeLessThanOrEqual(Utils.MAX_FILENAME_LENGTH);
+        expect(result).toContain("-"); // has hash separator
+    });
+});


### PR DESCRIPTION
## Problem

When `parallel:matrix` entries contain long variable values, `safeDockerString()` encodes non-alphanumeric characters using base64url, which **expands** the string (e.g., `/` → `Lw`, ` ` → `IA`). The encoded name is used directly as a filename/volume name. Linux/macOS `NAME_MAX` is 255 bytes — the reproducer generates ~340 characters, causing an immediate crash.

Fixes #1862

## Fix

When the encoded name exceeds 238 chars, truncate to a readable prefix + `-` + 16-char SHA-256 hash of the original name.

- **Limit:** 238 chars (255 NAME_MAX − 17 worst-case suffix from `gcl-...-999999-build`)
- **Short names:** Unchanged — no hashing when already within limit
- **Deterministic:** Same input always produces same output
- **Unique:** SHA-256 at 64 bits makes collisions negligible
- **Arbitrary length:** Works for any job name length (500, 5000+ chars)

## Changes

- `src/utils.ts`: Added length guard to `safeDockerString()` with hash-based truncation
- `tests/utils.test.ts`: Added 9 test cases covering short names, long names, extreme lengths, boundary conditions, volume name safety, determinism, and uniqueness

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- All 61 unit tests pass ✅
- All 32 parallel-matrix integration tests pass ✅
- Live end-to-end validation with the exact issue reproducer ✅ (was crashing, now passes)
- Two-entry matrix with similar names produces separate files with different hashes ✅
- Short job names produce unchanged output (no regression) ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents ENAMETOOLONG crashes when `parallel:matrix` generates long job names whose `base64url`-expanded values exceed filesystem limits. Ensures Docker volume/file names stay within 255 bytes. Fixes #1862.

- **Bug Fixes**
  - Derive and enforce `MAX_FILENAME_LENGTH = 255 - 17` (NAME_MAX minus `gcl-${name}-999999-build`) in `safeDockerString`.
  - If over, truncate to a readable prefix and append a 16-char SHA-256 hash of the original; deterministic with low collision; short names unchanged.
  - Added tests: exact base64url assertion, boundaries, extreme lengths, volume safety, and an end-to-end `parallel-matrix-long-name` fixture (YAML updated) to ensure both long and short matrix entries complete.
  - Documented invariants: ASCII-only matching keeps length==bytes; hash the raw name since encoding isn’t injective.

<sup>Written for commit 62e73babe4ed517d2a550426f9987b3172432515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

