### PR TITLE
A support for GPU

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -388,6 +388,10 @@ export class Argv {
         return this.map.get("containerEmulate") ?? null;
     }
 
+    get gpus (): string | null {
+        return this.map.get("gpus") ?? null;
+    }
+
     get concurrency (): number | null {
         const concurrency = this.map.get("concurrency");
         if (!concurrency) return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,6 +366,11 @@ process.on("SIGUSR2", async () => {
             description: "The name, without the architecture, of a gitlab hosted runner to emulate. See here: https://docs.gitlab.com/ee/ci/runners/hosted_runners/linux.html#machine-types-available-for-linux---x86-64",
             choices: GitlabRunnerPresetValues,
         })
+        .option("gpus", {
+            type: "string",
+            description: "A list of GPU indexes or 'all'",
+            requiresArg: true,
+        })
         .option("color", {
             requiresArg: false,
             default: true,

--- a/src/job.ts
+++ b/src/job.ts
@@ -986,8 +986,8 @@ If you know what you're doing and would like to suppress this warning, use one o
                 dockerCmd += `--cpus=${cpuConfig} `;
             }
 
-            if (this.argv.gpus) {
-                dockerCmd += `--gpus ${this.argv.gpus} --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 `;
+            if (this.gpus) {
+                dockerCmd += `--gpus ${this.gpus} --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 `;
             }
 
             // host and none networks have to be specified using --network, since they cannot be used with
@@ -1221,6 +1221,19 @@ If you know what you're doing and would like to suppress this warning, use one o
         }
         assert(Array.isArray(image.entrypoint), "image:entrypoint must be an array");
         return image.entrypoint;
+    }
+
+    get gpus (): string | null {
+        if (this.argv.gpus) {
+            return this.argv.gpus;
+        } else if ("tags" in this.jobData) {
+            for (const tag of this.jobData["tags"]) {
+                if (tag.match(/^(.*-)?gpu(-.*)?$/)) {
+                    return "all";
+                }
+            }
+        }
+        return null;
     }
 
     private async validateCiDependencyProxyServerAuthentication (imageName: string) {
@@ -1583,8 +1596,8 @@ If you know what you're doing and would like to suppress this warning, use one o
             dockerCmd += `--shm-size=${this.argv.shmSize} `;
         }
 
-        if (this.argv.gpus) {
-            dockerCmd += `--gpus ${this.argv.gpus} --ipc=host --ulimit memlock=-1 --ulimit stack=67108864`;
+        if (this.gpus) {
+            dockerCmd += `--gpus ${this.gpus} --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 `;
         }
 
         for (const volume of this.argv.volume) {

--- a/src/job.ts
+++ b/src/job.ts
@@ -986,6 +986,10 @@ If you know what you're doing and would like to suppress this warning, use one o
                 dockerCmd += `--cpus=${cpuConfig} `;
             }
 
+            if (this.argv.gpus) {
+                dockerCmd += `--gpus ${this.argv.gpus} --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 `;
+            }
+
             // host and none networks have to be specified using --network, since they cannot be used with
             // `docker network connect`.
             for (const network of this.argv.network) {
@@ -1577,6 +1581,10 @@ If you know what you're doing and would like to suppress this warning, use one o
 
         if (this.argv.shmSize != undefined) {
             dockerCmd += `--shm-size=${this.argv.shmSize} `;
+        }
+
+        if (this.argv.gpus) {
+            dockerCmd += `--gpus ${this.argv.gpus} --ipc=host --ulimit memlock=-1 --ulimit stack=67108864`;
         }
 
         for (const volume of this.argv.volume) {


### PR DESCRIPTION
A new switch `--gpus` is introduced that is passed to the docker
It also tries to deduce if gpu is needed to run the ci based on tags. like `saas-linux-medium-amd64-gpu-standard`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GPU support for CI jobs via a new `--gpus` flag and automatic tag-based detection. When enabled, containers run with GPUs and the required IPC/ulimit settings.

- New Features
  - New `--gpus` CLI option (indexes or `all`), forwarded to Docker.
  - Auto-enables if a job tag includes `gpu` as a dash-delimited token (e.g., `saas-linux-medium-amd64-gpu-standard`), defaulting to `--gpus all`.
  - When GPUs are enabled, adds Docker flags: `--gpus ...`, `--ipc=host`, `--ulimit memlock=-1`, `--ulimit stack=67108864`.
  - No change for non-GPU jobs unless the flag or tag is used.

<sup>Written for commit baaca82bcb5c8b79f549d5e716466d8641df7179. Summary will update on new commits. <a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1866?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

