### PR TITLE
fix: validate spec:inputs:regex instead of logging a no-op warning

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -443,7 +443,13 @@ function validateInput (ctx: any) {
 
     const regex = inputsSpecification.spec.inputs[interpolationKey]?.regex;
     if (regex) {
-        assert(new RegExp(regex).test(String(inputValue)),
+        let re: RegExp;
+        try {
+            re = new RegExp(regex);
+        } catch {
+            assert(false, chalk`This GitLab CI configuration is invalid: \`{blueBright ${configFilePath}}\`: \`{blueBright ${interpolationKey}}\` input: regex \`{blueBright ${regex}}\` is not a valid regular expression.`);
+        }
+        assert(re.test(String(inputValue)),
             chalk`This GitLab CI configuration is invalid: \`{blueBright ${configFilePath}}\`: \`{blueBright ${interpolationKey}}\` input: \`{blueBright ${inputValue}}\` does not match required regex: {blueBright ${regex}}.`);
     }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -443,7 +443,8 @@ function validateInput (ctx: any) {
 
     const regex = inputsSpecification.spec.inputs[interpolationKey]?.regex;
     if (regex) {
-        ctx.writeStreams?.stderr(chalk`{black.bgYellowBright  WARN } spec:inputs:regex is currently not supported via gitlab-ci-local. This will just be a no-op.\n`);
+        assert(new RegExp(regex).test(String(inputValue)),
+            chalk`This GitLab CI configuration is invalid: \`{blueBright ${configFilePath}}\`: \`{blueBright ${interpolationKey}}\` input: \`{blueBright ${inputValue}}\` does not match required regex: {blueBright ${regex}}.`);
     }
 }
 

--- a/tests/test-cases/include-inputs/input-templates/regex-validation-invalid-pattern/.gitlab-ci-input-template.yml
+++ b/tests/test-cases/include-inputs/input-templates/regex-validation-invalid-pattern/.gitlab-ci-input-template.yml
@@ -1,0 +1,9 @@
+---
+spec:
+  inputs:
+    version:
+      regex: ^[unclosed
+---
+deploy:
+  script:
+    - echo $[[ inputs.version ]]

--- a/tests/test-cases/include-inputs/input-templates/regex-validation-invalid-pattern/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/regex-validation-invalid-pattern/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+---
+include:
+  - local: '/.gitlab-ci-input-template.yml'
+    inputs:
+      version: "v1.2.3"
+stages:
+  - test

--- a/tests/test-cases/include-inputs/input-templates/regex-validation-pass/.gitlab-ci-input-template.yml
+++ b/tests/test-cases/include-inputs/input-templates/regex-validation-pass/.gitlab-ci-input-template.yml
@@ -1,0 +1,9 @@
+---
+spec:
+  inputs:
+    version:
+      regex: ^v\d+\.\d+\.\d+$
+---
+deploy:
+  script:
+    - echo $[[ inputs.version ]]

--- a/tests/test-cases/include-inputs/input-templates/regex-validation-pass/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/regex-validation-pass/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+---
+include:
+  - local: '/.gitlab-ci-input-template.yml'
+    inputs:
+      version: "v1.2.3"
+stages:
+  - test

--- a/tests/test-cases/include-inputs/input-templates/regex-validation/.gitlab-ci-input-template.yml
+++ b/tests/test-cases/include-inputs/input-templates/regex-validation/.gitlab-ci-input-template.yml
@@ -1,0 +1,9 @@
+---
+spec:
+  inputs:
+    version:
+      regex: ^v\d+\.\d+\.\d+$
+---
+deploy:
+  script:
+    - echo $[[ inputs.version ]]

--- a/tests/test-cases/include-inputs/input-templates/regex-validation/.gitlab-ci.yml
+++ b/tests/test-cases/include-inputs/input-templates/regex-validation/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+---
+include:
+  - local: '/.gitlab-ci-input-template.yml'
+    inputs:
+      version: "invalid-version"
+stages:
+  - test

--- a/tests/test-cases/include-inputs/integration.test.ts
+++ b/tests/test-cases/include-inputs/integration.test.ts
@@ -358,3 +358,41 @@ scan-website:
 
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
+
+test.concurrent("include-inputs regex validation (invalid)", async () => {
+    try {
+        const writeStreams = new WriteStreamsMock();
+        await handler({
+            cwd: "tests/test-cases/include-inputs/input-templates/regex-validation",
+            preview: true,
+        }, writeStreams);
+    } catch (e: any) {
+        assert(e instanceof AssertionError, "e is not instanceof AssertionError");
+        expect(e.message).toContain("This GitLab CI configuration is invalid:");
+        expect(e.message).toContain(
+            chalk`\`{blueBright version}\` input: \`{blueBright invalid-version}\` does not match required regex: {blueBright ^v\\d+\\.\\d+\\.\\d+$}.`,
+        );
+        return;
+    }
+
+    throw new Error("Error is expected but not thrown/caught");
+});
+
+test.concurrent("include-inputs regex validation (valid)", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/include-inputs/input-templates/regex-validation-pass",
+        preview: true,
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - test
+  - .post
+deploy:
+  script:
+    - echo v1.2.3`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});

--- a/tests/test-cases/include-inputs/integration.test.ts
+++ b/tests/test-cases/include-inputs/integration.test.ts
@@ -396,3 +396,22 @@ deploy:
 
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
+
+test.concurrent("include-inputs regex validation (invalid pattern)", async () => {
+    try {
+        const writeStreams = new WriteStreamsMock();
+        await handler({
+            cwd: "tests/test-cases/include-inputs/input-templates/regex-validation-invalid-pattern",
+            preview: true,
+        }, writeStreams);
+    } catch (e: any) {
+        assert(e instanceof AssertionError, "e is not instanceof AssertionError");
+        expect(e.message).toContain("This GitLab CI configuration is invalid:");
+        expect(e.message).toContain(
+            chalk`\`{blueBright version}\` input: regex \`{blueBright ^[unclosed}\` is not a valid regular expression.`,
+        );
+        return;
+    }
+
+    throw new Error("Error is expected but not thrown/caught");
+});


### PR DESCRIPTION
## Pull Request: Validate spec:inputs:regex instead of logging a no-op warning

### Problem

When spec:inputs:regex is used in a GitLab CI configuration, gitlab-ci-local logs a misleading warning:

WARN spec:inputs:regex is currently not supported via gitlab-ci-local. This will just be a no-op.


The input value is never validated against the regex — it just passes through regardless of whether it matches. This means:
- Valid inputs produce an unnecessary warning
- Invalid inputs are silently accepted when they should be rejected

Fixes #1864

### Fix

Replaced the no-op warning with actual regex validation using JavaScript's RegExp. The input value is now tested against the provided regex pattern:
- If the value matches → passes silently (no warning)
- If the value doesn't match → throws a validation error consistent with GitLab's error format

### Changes

src/parser.ts
- Removed the WARN stderr message
- Added new RegExp(regex).test(String(inputValue)) assertion that produces a clear error message when validation fails

tests/test-cases/include-inputs/input-templates/regex-validation/ (new)
- .gitlab-ci-input-template.yml — template with regex: ^v\d+\.\d+\.\d+$
- .gitlab-ci.yml — provides invalid input "invalid-version"

tests/test-cases/include-inputs/input-templates/regex-validation-pass/ (new)
- .gitlab-ci-input-template.yml — template with regex: ^v\d+\.\d+\.\d+$
- .gitlab-ci.yml — provides valid input "v1.2.3"

tests/test-cases/include-inputs/integration.test.ts
- Added test: include-inputs regex validation (invalid) — verifies invalid input produces the expected assertion error
- Added test: include-inputs regex validation (valid) — verifies valid input passes and renders correctly

### Verification

bash
bun run vitest run tests/test-cases/include-inputs/integration.test.ts


All 20 tests pass, including the 2 new regex validation tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate spec:inputs:regex instead of logging a no-op warning. Valid inputs pass silently; invalid inputs or invalid regex patterns now raise clear, GitLab-style errors.

- **Bug Fixes**
  - Replaced the warning with real validation: compile with `new RegExp(regex)` and test `String(inputValue)`.
  - Throw assertion errors when input fails to match and when the regex pattern itself is invalid (no uncaught SyntaxError).
  - Added integration tests for pass, fail, and invalid-pattern cases.

<sup>Written for commit 5bd9d6509bbb790bd5a6ce7e15ed2d8f71f39a24. Summary will update on new commits. <a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1869?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

