### PR TITLE
ci: don't fail build when SonarQube scan step errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,8 @@ jobs:
       - name: Run Tests
         run: bun run coverage
       - uses: sonarsource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1
+        # Reporting only; a transient scanner-download 403 must not fail the build. The quality gate is reported via its own check.
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,9 +83,19 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Run Tests
         run: bun run coverage
+      # Persist the scanner CLI across runs so the action restores it from cache
+      # (tc.find short-circuits the download) instead of fetching it from the
+      # intermittently-403ing binaries.sonarsource.com on every run.
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: ${{ env.SONAR_TOKEN != '' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          path: ${{ runner.tool_cache }}/sonar-scanner-cli
+          key: sonar-scanner-cli-${{ runner.os }}-${{ runner.arch }}-8.1.0.6389
       - uses: sonarsource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1
-        # Reporting only; a transient scanner-download 403 must not fail the build. The quality gate is reported via its own check.
-        continue-on-error: true
+        with:
+          scannerVersion: 8.1.0.6389
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
The SonarQube scan runs as the final step of the `test` job and intermittently returns HTTP 403 while downloading the scanner CLI from `binaries.sonarsource.com`, failing the whole `master` build even though tests passed (seen across multiple re-runs of run 26933995675).

It is a reporting step — the quality gate is surfaced via its own `SonarCloud Code Analysis` check — so a transient scanner-download error should not block the build. Marked the step `continue-on-error: true`.

This does not mask test failures: `bun run coverage` runs in the prior step and still fails the job if any test fails.

## Test plan
- [x] YAML parses; step has `continue-on-error: true`
- [x] `.github/workflows/` is ignored by yamllint config, so no lint impact

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the SonarQube scan non-blocking and cache the SonarScanner CLI to avoid flaky 403 downloads that fail builds. Set `continue-on-error: true`, pin `scannerVersion: 8.1.0.6389`, and persist `${{ runner.tool_cache }}/sonar-scanner-cli`; tests still gate the job and the quality gate is reported via its own check.

<sup>Written for commit 637a89ad193e7271445c61f5c3585e1cd2f4db5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

