### PR TITLE
ci: cache SonarScanner CLI to avoid flaky CDN download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,8 @@ jobs:
       - name: Run Tests
         run: bun run coverage
       - uses: sonarsource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1
+        # Reporting only; a transient scanner-download 403 must not fail the build. The quality gate is reported via its own check.
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,9 +83,19 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Run Tests
         run: bun run coverage
+      # Persist the scanner CLI across runs so the action restores it from cache
+      # (tc.find short-circuits the download) instead of fetching it from the
+      # intermittently-403ing binaries.sonarsource.com on every run.
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: ${{ env.SONAR_TOKEN != '' }}
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          path: ${{ runner.tool_cache }}/sonar-scanner-cli
+          key: sonar-scanner-cli-${{ runner.os }}-${{ runner.arch }}-8.1.0.6389
       - uses: sonarsource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1
-        # Reporting only; a transient scanner-download 403 must not fail the build. The quality gate is reported via its own check.
-        continue-on-error: true
+        with:
+          scannerVersion: 8.1.0.6389
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The SonarQube scan action downloads the scanner CLI from `binaries.sonarsource.com` on every run, which intermittently returns HTTP 403 and fails the `master` build even though tests pass (a [known SonarSource CDN issue](https://community.sonarsource.com/t/intermittent-403-for-sonar-scanner-action-download/183214)).

The action checks the GitHub Actions tool-cache first (`tc.find`) and only downloads on a miss, so persisting that directory with `actions/cache` makes every run after the first restore the scanner and skip the CDN entirely — the scan still runs, nothing is suppressed. `scannerVersion` is pinned so the cache key invalidates on a version bump.

Residual: a cold cache (first run / scanner version bump) still hits the CDN once; if that transiently 403s, a single re-run seeds the cache permanently.

## Test plan
- [x] YAML parses; `continue-on-error` not used; cache key matches pinned `scannerVersion`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache the SonarScanner CLI in CI to avoid intermittent CDN 403s and keep builds stable. Restores the scanner from `actions/cache` and pins `scannerVersion: 8.1.0.6389`, so after the first run the CDN is skipped; the cache is only used when `SONAR_TOKEN` is set.

<sup>Written for commit 637a89ad193e7271445c61f5c3585e1cd2f4db5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

