### PR TITLE
fix: introduce per-job cert volume with %gcl% token

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -468,6 +468,10 @@ If you know what you're doing and would like to suppress this warning, use one o
         return this.jobData["needs"] ?? null;
     }
 
+    get certVolumeName (): string {
+        return `gcl-${this.safeJobName}-${this.jobId}-cert`;
+    }
+
     get buildVolumeName (): string {
         return `gcl-${this.safeJobName}-${this.jobId}-build`;
     }
@@ -689,10 +693,15 @@ If you know what you're doing and would like to suppress this warning, use one o
             const fileVariablesDir = this.fileVariablesDir;
 
             this._containerVolumeNames.push(buildVolumeName, tmpVolumeName);
-            await Promise.all([
+            const volumeCreatePromises = [
                 Utils.spawn([this.argv.containerExecutable, "volume", "create", `${buildVolumeName}`], argv.cwd),
                 Utils.spawn([this.argv.containerExecutable, "volume", "create", `${tmpVolumeName}`], argv.cwd),
-            ]);
+            ];
+            if (this.argv.volume.some(v => v.startsWith("%gcl-cert%:"))) {
+                this._containerVolumeNames.push(this.certVolumeName);
+                volumeCreatePromises.push(Utils.spawn([this.argv.containerExecutable, "volume", "create", this.certVolumeName], argv.cwd));
+            }
+            await Promise.all(volumeCreatePromises);
 
             const time = process.hrtime();
             this.refreshLongRunningSilentTimeout(writeStreams);
@@ -1017,7 +1026,8 @@ If you know what you're doing and would like to suppress this warning, use one o
             dockerCmd += `--workdir ${this.ciProjectDir} `;
 
             for (const volume of this.argv.volume) {
-                dockerCmd += `--volume ${volume} `;
+                const v = volume.startsWith("%gcl-cert%:") ? `${this.certVolumeName}${volume.slice("%gcl-cert%".length)}` : volume;
+                dockerCmd += `--volume ${v} `;
             }
 
             for (const extraHost of this.argv.extraHost) {
@@ -1580,7 +1590,8 @@ If you know what you're doing and would like to suppress this warning, use one o
         }
 
         for (const volume of this.argv.volume) {
-            dockerCmd += `--volume ${volume} `;
+            const v = volume.startsWith("%gcl-cert%:") ? `${this.certVolumeName}${volume.slice("%gcl-cert%".length)}` : volume;
+            dockerCmd += `--volume ${v} `;
         }
 
         for (const extraHost of this.argv.extraHost) {


### PR DESCRIPTION
Hello,

This addresses https://github.com/firecow/gitlab-ci-local/issues/918

Jobs using docker:dind as a service share TLS client certificates via a named volume. The previous approach relied on a static volume name (e.g. `certs`) configured in `.gitlab-ci-local-env`, which caused race conditions when concurrent jobs wrote to and cleaned up the same volume, each dind service writing its own certificates.

A new `%gcl-cert%:` prefix in VOLUME entries is now resolved at runtime to a per-job unique volume name (`gcl-<job>-<id>-cert`), matching the naming pattern of the existing build/tmp volumes.
The `%gcl-cert%` token was chosen because Docker hard-rejects it if it ever reaches the daemon unsubstituted (invalid volume name character), rather than silently bind-mounting an unintended host path.

Changes:
- get certVolumeName() getter returning a per-job unique name
- Cert volume is created and registered for cleanup alongside build/tmp volumes when any %gcl-cert%: entry is present in argv.volume
- %gcl-cert%: prefix is resolved to certVolumeName in both the job container and service container volume loops

I'm not sure how to add a test.

I used this config to test the implementation

```yaml
docker1:
  stage: test
  image: docker:29-cli
  services:
    - docker:29-dind
  before_script:
    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
  script:
    - docker info

docker2:
  stage: test
  image: docker:29-cli
  services:
    - docker:29-dind
  before_script:
    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
  script:
    - docker info
```

The `.gitlab-ci-local-env` looks like

```text
PRIVILEGED=true
ULIMIT=8000:16000
VOLUME=%gcl-cert%:/certs/client
VARIABLE="DOCKER_TLS_CERTDIR=/certs"
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-job cert volume for Docker-in-Docker by introducing a `%gcl-cert%:` volume token. This prevents cross-job TLS cert races and cleanup conflicts when jobs run in parallel.

- **Bug Fixes**
  - Create and track `certVolumeName` (`gcl-<job>-<id>-cert`) when any `argv.volume` starts with `%gcl-cert%:`, matching build/tmp naming.
  - Resolve `%gcl-cert%:` to the per-job name for both job and service `--volume` flags before invoking Docker, avoiding accidental host bind mounts.

- **Migration**
  - Replace a static cert volume like `certs:/certs/client` with `%gcl-cert%:/certs/client` to enable per-job isolation.

<sup>Written for commit 96b49ceecab1600a4bd61911a17ffd80bb979bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



