### PR TITLE
Cache for git remote

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -53,9 +53,11 @@ type GitRemoteInfoContext = {
 
 export class ParserIncludes {
     private static count: number = 0;
+    private static gitRemoteInfoCache: Record<string, string> = {};
 
     static resetCount (): void {
         this.count = 0;
+        this.gitRemoteInfoCache = {};
     }
 
     private static normalizeTriggerInclude (gitlabData: any, opts: ParserIncludesInitOptions) {
@@ -114,13 +116,13 @@ export class ParserIncludes {
                 promises.push(this.downloadIncludeRemote(cwd, stateDir, value["remote"], fetchIncludes, writeStreams));
             } else if (value["component"]) {
                 const component = this.parseIncludeComponent(value["component"], gitData);
-                componentParseCache.set(index, component);
-                if (!component.isLocal)
-                {
-                    promises.push(this.downloadIncludeComponent(opts, component.projectPath, component.effectiveRef, component.componentPath));
-                }
+                promises.push((async () => {
+                    if (!component.isLocal) {
+                        await this.downloadIncludeComponent(opts, component.projectPath, component.effectiveRef, component.componentPath);
+                    }
+                    componentParseCache.set(index, component);
+                })());
             }
-
         }
 
         await Promise.all(promises);
@@ -251,6 +253,20 @@ export class ParserIncludes {
         };
     }
 
+    static getGitRemoteInfo (ctx: GitRemoteInfoContext, ...args: string[]): string {
+        const cmdArgs = ["git", "ls-remote", ...args];
+        if (ctx.gitData.remote.schema == "git" || ctx.gitData.remote.schema == "ssh") {
+            cmdArgs.push(`git@${ctx.domain}:${ctx.projectPath}`);
+        } else {
+            cmdArgs.push(`${ctx.gitData.remote.schema}://${ctx.domain}:${ctx.port ?? 443}/${ctx.projectPath}.git`);
+        }
+        const cmdStr = cmdArgs.join(" ");
+        if (!(cmdStr in this.gitRemoteInfoCache)) {
+            this.gitRemoteInfoCache[cmdStr] = Utils.syncSpawn(cmdArgs).stdout;
+        }
+        return this.gitRemoteInfoCache[cmdStr];
+    };
+
     static parseIncludeComponent (component: string, gitData: GitData): ParsedComponent {
         assert(!component.includes("://"), `This GitLab CI configuration is invalid: component: \`${component}\` should not contain protocol`);
         const pattern = /(?<domain>[^/:\s]+)(:(?<port>\d+))?\/(?<projectPath>.+)\/(?<componentName>[^@]+)@(?<ref>.+)/; // https://regexr.com/7v7hm
@@ -279,7 +295,7 @@ export class ParserIncludes {
                         const semanticVersionRangesPattern = /^\d+(\.\d+)?$/;
                         if (this.reference == "~latest" || semanticVersionRangesPattern.test(this.reference)) {
                             // https://docs.gitlab.com/ci/components/#semantic-version-ranges
-                            const stdout = getGitRemoteInfo(this, "--tags");
+                            const stdout = ParserIncludes.getGitRemoteInfo(this, "--tags");
                             const tags = stdout.split("\n").map(line => line.split("\t")[1].split("/")[2]);
                             const version = resolveSemanticVersionRange(this.reference, tags);
                             assert(version ?? tags.includes(this.reference), `This GitLab CI configuration is invalid: component: \`${this.name}\` - The reference (${this.reference}) is invalid`);
@@ -305,7 +321,7 @@ export class ParserIncludes {
                         // effectiveRef may already be a sha, if so return it directly
                         this._cache.sha = this.effectiveRef;
                     } else {
-                        const stdout = getGitRemoteInfo(this);
+                        const stdout = ParserIncludes.getGitRemoteInfo(this);
                         const lines = stdout.split("\n");
                         // annotated tags: prefer the deref'd commit sha (refs/tags/x^{})
                         const match = lines.find(line => line.endsWith(`refs/tags/${this.effectiveRef}^{}`)) ??
@@ -508,14 +524,4 @@ export async function resolveIncludeLocal (pattern: string, cwd: string) {
 
     const re2js = RE2JS.compile(`^${pattern}`);
     return repoFiles.filter((f: any) => re2js.matches(f));
-}
-
-export function getGitRemoteInfo (ctx: GitRemoteInfoContext, ...args: string[]) {
-    const cmdArgs = ["git", "ls-remote", ...args];
-    if (ctx.gitData.remote.schema == "git" || ctx.gitData.remote.schema == "ssh") {
-        cmdArgs.push(`git@${ctx.domain}:${ctx.projectPath}`);
-    } else {
-        cmdArgs.push(`${ctx.gitData.remote.schema}://${ctx.domain}:${ctx.port ?? 443}/${ctx.projectPath}.git`);
-    }
-    return Utils.syncSpawn(cmdArgs).stdout;
 }


### PR DESCRIPTION
Based on #1836 it allows to keep some cache for remote refs so it’s a bit faster.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up include processing by caching identical `git ls-remote` calls and preventing races by writing the component parse cache only after remote downloads finish.

- **Performance**
  - Add in-memory cache for `git ls-remote` results keyed by the full command; cleared via `ParserIncludes.resetCount()`.
  - Defer `componentParseCache.set` until after remote component download completes to avoid parallel resolution races.

- **Refactors**
  - Replace exported `getGitRemoteInfo` with `ParserIncludes.getGitRemoteInfo` and update call sites.

<sup>Written for commit eeea380d899d255074850f43ef48bb0bc28ae07e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

