### PR TITLE
Honor dockerignore

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -731,7 +731,14 @@ If you know what you're doing and would like to suppress this warning, use one o
                 await Utils.spawn([this.argv.containerExecutable, "cp", `${fileVariablesDir}/.`, `${containerId}:${fileVariablesDir}`], argv.cwd);
                 this.refreshLongRunningSilentTimeout(writeStreams);
             }
-            await Utils.spawn([this.argv.containerExecutable, "cp", `${argv.stateDir}/builds/.docker/.`, `${containerId}:${this.ciProjectDir}`], argv.cwd);
+            const cmd = "sed -E -e 's,^[.]?/,,' -e '/^[.]git/d' /data/src/.dockerignore >/data/ignore 2>/dev/null; rsync -avh --exclude-from /data/ignore /data/src/. /data/dest";
+            await Utils.spawn([
+                this.argv.containerExecutable, "run", "--rm",
+                "-v", `${this.argv.cwd}/${this.argv.stateDir}/builds/.docker:/data/src:ro`,
+                "-v", `${this.buildVolumeName}:/data/dest:rw`,
+                this.argv.helperImage,
+                "bash", "-c", cmd,
+            ]);
             await Utils.spawn([this.argv.containerExecutable, "start", "--attach", containerId], argv.cwd);
             await Utils.spawn([this.argv.containerExecutable, "rm", "-vf", containerId], argv.cwd);
             const endTime = process.hrtime(time);
@@ -1336,12 +1343,19 @@ If you know what you're doing and would like to suppress this warning, use one o
         writeStreams.stdout(chalk`${this.formattedJobName} {magentaBright imported artifacts} in {magenta ${prettyHrtime(endTime)}}\n`);
     }
 
-    copyIn (source: string) {
+    async copyIn (source: string) {
         const safeJobName = this.safeJobName;
         if (!this.imageName(this._variables) && this.argv.shellIsolation) {
             return Utils.spawn(["rsync", "-a", `${source}/.`, `${this.argv.cwd}/${this.argv.stateDir}/builds/${safeJobName}`]);
         }
-        return Utils.spawn([this.argv.containerExecutable, "cp", `${source}/.`, `${this._containerId}:${this.ciProjectDir}`]);
+        const cmd = "sed -E -e 's,^[.]?/,,' -e '/^[.]git/d' /data/src/.dockerignore >/data/ignore 2>/dev/null; rsync -avh --exclude-from /data/ignore /data/src/. /data/dest";
+        return Utils.spawn([
+            this.argv.containerExecutable, "run", "--rm",
+            "-v", `${source}:/data/src:ro`,
+            "-v", `${this.buildVolumeName}:/data/dest:rw`,
+            this.argv.helperImage,
+            "bash", "-c", cmd,
+        ]);
     }
 
     private async copyCacheOut (writeStreams: WriteStreams, expanded: {[key: string]: string}) {


### PR DESCRIPTION
Try to address the issue #1879 by using `rsync` with a temporary container.

Modify the `.dockerignore` found to be compatible to rsync ignore file (quite the same format).

`.git` directory is removed from ignore as it is needed for some functions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `.dockerignore` when copying sources into job containers by replacing `docker cp` with helper-image `rsync`, and adds component context variables for templates. Also fixes array input validation and improves local component includes.

- **New Features**
  - Replace `docker cp` with helper-image `rsync` for copy-in and Docker context; honor `.dockerignore` (normalize patterns) and always include `.git`.
  - Support component context variables in components: `$[[ component.name ]]`, `$[[ component.reference ]]`, `$[[ component.version ]]`, `$[[ component.sha ]]` with lazy resolution (handles semantic ranges and annotated tags).
  - Local components can include other local files within the same project.

- **Bug Fixes**
  - Validate `options` for `array` input types element-by-element, rejecting values not in the allowed list.

<sup>Written for commit 283b112fc29cefda6a507ec73396ff46103476d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

