### PR TITLE
Artifacts "when" conditions support

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -1408,8 +1408,9 @@ If you know what you're doing and would like to suppress this warning, use one o
     }
 
     private async copyArtifactsOut (writeStreams: WriteStreams, expanded: {[key: string]: string}) {
-        // TODO: update the condition to support when:on_success / when:on_failure
-        if (this.jobStatus !== "success" && this.artifacts?.when !== "always") return;
+        if (this.jobStatus !== "success" && this.artifacts?.when === "on_success") return;
+        if (this.jobStatus !== "failed" && this.artifacts?.when === "on_failure") return;
+        if (this.artifacts?.when === "never") return;
         if (!this.artifacts) return;
         if ((this.artifacts.paths?.length ?? 0) === 0 && this.artifacts.reports?.dotenv == null) return;
 

--- a/src/job.ts
+++ b/src/job.ts
@@ -1464,10 +1464,20 @@ If you know what you're doing and would like to suppress this warning, use one o
     }
 
     private async copyArtifactsOut (writeStreams: WriteStreams, expanded: {[key: string]: string}) {
-        // TODO: update the condition to support when:on_success / when:on_failure
-        if (this.jobStatus !== "success" && this.artifacts?.when !== "always") return;
         if (!this.artifacts) return;
-        if ((this.artifacts.paths?.length ?? 0) === 0 && this.artifacts.reports?.dotenv == null) return;
+
+        const when = this.artifacts.when ?? "on_success";
+        const jobStatus = this.jobStatus == "success" ? "success" : "failed";
+
+        const copyArtifactsPaths: boolean = !(
+            (jobStatus !== "success" && when === "on_success") ||
+            (jobStatus !== "failed" && when === "on_failure")
+        );
+        const artifactsPaths = copyArtifactsPaths ? this.artifacts.paths ?? [] : [];
+
+        const copyDotEnv: boolean = this.artifacts.reports?.dotenv != null;
+
+        if (!(copyArtifactsPaths || copyDotEnv)) return;
 
         const safeJobName = this.safeJobName;
         const cwd = this.argv.cwd;
@@ -1486,7 +1496,7 @@ If you know what you're doing and would like to suppress this warning, use one o
         let cpCmd = "shopt -s globstar nullglob dotglob\n";
         cpCmd += `mkdir -p ${artifactsPath}/${safeJobName}\n`;
         cpCmd += "_gcl_files_tmp=\\$(mktemp)\n";
-        for (const artifactPath of this.artifacts?.paths ?? []) {
+        for (const artifactPath of artifactsPaths) {
             const expandedPath = Utils.expandText(artifactPath, expanded).replace(`${expanded.CI_PROJECT_DIR}/`, "");
             cpCmd += `for _gcl_f in ./${expandedPath}; do printf '%s\\n' "\\$_gcl_f"; done >> \\$_gcl_files_tmp\n`;
         }

--- a/tests/test-cases/artifacts-dotenv/.gitignore
+++ b/tests/test-cases/artifacts-dotenv/.gitignore
@@ -1,1 +1,3 @@
 build.env
+failure.env
+warning.env

--- a/tests/test-cases/artifacts-dotenv/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-dotenv/.gitlab-ci.yml
@@ -25,3 +25,32 @@ use-service-ref:
   image: docker.io/massenz/dnsutils:2.4.0
   script:
     - host $SERVICE_IMAGE_ALIAS
+
+# reports.dotenv is exported regardless of the producer's status, so a consumer
+# that still runs after a failed/warned producer gets its variables.
+build-failure-ref:
+  stage: build
+  needs: []
+  script:
+    - echo "FAILURE_REF=failure-value" > failure.env
+    - exit 1
+  artifacts:
+    reports: {dotenv: failure.env}
+
+build-warning-ref:
+  stage: build
+  needs: []
+  allow_failure: true
+  script:
+    - echo "WARNING_REF=warning-value" > warning.env
+    - exit 1
+  artifacts:
+    reports: {dotenv: warning.env}
+
+use-non-success-ref:
+  stage: deploy
+  when: always
+  needs: [build-failure-ref, build-warning-ref]
+  script:
+    - echo "FAILURE_REF is [$FAILURE_REF]"
+    - echo "WARNING_REF is [$WARNING_REF]"

--- a/tests/test-cases/artifacts-dotenv/integration.test.ts
+++ b/tests/test-cases/artifacts-dotenv/integration.test.ts
@@ -13,9 +13,12 @@ test.concurrent("artifacts-dotenv <use-image-ref> --needs", async () => {
         cwd: "tests/test-cases/artifacts-dotenv",
         job: ["use-image-ref"],
         needs: true,
+        noColor: true,
         stateDir: ".gitlab-ci-local-artifacts-dotenv-use-image-ref-needs",
     }, writeStreams);
 
+    // The job only runs at all if BUILD_IMAGE_REF expanded into `image`
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/use-image-ref\s+> NAME="Alpine Linux"/);
     expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
 });
 
@@ -25,8 +28,27 @@ test.concurrent("artifacts-dotenv <use-service-ref> --needs", async () => {
         cwd: "tests/test-cases/artifacts-dotenv",
         job: ["use-service-ref"],
         needs: true,
+        noColor: true,
         stateDir: ".gitlab-ci-local-artifacts-dotenv-use-service-ref-needs",
     }, writeStreams);
 
+    // SERVICE_IMAGE_ALIAS expanded into the service alias, so it resolves in DNS
+    expect(writeStreams.stdoutLines.join("\n")).toMatch(/use-service-ref\s+> redis has address/);
     expect(writeStreams.stderrLines.join("\n")).not.toMatch(/FAIL/);
+});
+
+test.concurrent("artifacts-dotenv <use-non-success-ref> --needs", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/artifacts-dotenv",
+        job: ["use-non-success-ref"],
+        needs: true,
+        noColor: true,
+        stateDir: ".gitlab-ci-local-artifacts-dotenv-use-non-success-ref-needs",
+    }, writeStreams);
+
+    const stdout = writeStreams.stdoutLines.join("\n");
+    expect(stdout).toMatch(/use-non-success-ref\s+> FAILURE_REF is \[failure-value\]/);
+    expect(stdout).toMatch(/use-non-success-ref\s+> WARNING_REF is \[warning-value\]/);
+    expect(writeStreams.stderrLines.join("\n")).not.toMatch(/use-non-success-ref.*FAIL/);
 });

--- a/tests/test-cases/artifacts-when/.gitignore
+++ b/tests/test-cases/artifacts-when/.gitignore
@@ -1,0 +1,3 @@
+/on_success*
+/on_failure*
+/always*

--- a/tests/test-cases/artifacts-when/.gitlab-ci.yml
+++ b/tests/test-cases/artifacts-when/.gitlab-ci.yml
@@ -1,0 +1,112 @@
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# Matrix:  when  ×  outcome
+#   when   = { on_success, on_failure, always }
+#   outcome= { success, failure, warning }
+# ─────────────────────────────────────────────────────────────────────────────
+
+on_success_success:
+  stage: build
+  script:
+    - touch on_success_success
+  artifacts:
+    paths:
+      - on_success_success
+    when: on_success
+
+on_success_failure:
+  stage: build
+  script:
+    - touch on_success_failure
+    - exit 1
+  artifacts:
+    paths:
+      - on_success_failure
+    when: on_success
+
+on_success_warning:
+  stage: build
+  allow_failure: true
+  script:
+    - touch on_success_warning
+    - exit 1
+  artifacts:
+    paths:
+      - on_success_warning
+    when: on_success
+
+on_failure_success:
+  stage: build
+  script:
+    - touch on_failure_success
+  artifacts:
+    paths:
+      - on_failure_success
+    when: on_failure
+
+on_failure_failure:
+  stage: build
+  script:
+    - touch on_failure_failure
+    - exit 1
+  artifacts:
+    paths:
+      - on_failure_failure
+    when: on_failure
+
+on_failure_warning:
+  stage: build
+  allow_failure: true
+  script:
+    - touch on_failure_warning
+    - exit 1
+  artifacts:
+    paths:
+      - on_failure_warning
+    when: on_failure
+
+always_success:
+  stage: build
+  script:
+    - touch always_success
+  artifacts:
+    paths:
+      - always_success
+    when: always
+
+always_failure:
+  stage: build
+  script:
+    - touch always_failure
+    - exit 1
+  artifacts:
+    paths:
+      - always_failure
+    when: always
+
+always_warning:
+  stage: build
+  allow_failure: true
+  script:
+    - touch always_warning
+    - exit 1
+  artifacts:
+    paths:
+      - always_warning
+    when: always
+
+consumer:
+  stage: test
+  needs:
+    - on_success_success
+    - on_success_failure
+    - on_success_warning
+    - on_failure_success
+    - on_failure_failure
+    - on_failure_warning
+    - always_success
+    - always_failure
+    - always_warning
+  when: always
+  script:
+    - echo consumer

--- a/tests/test-cases/artifacts-when/integration.test.ts
+++ b/tests/test-cases/artifacts-when/integration.test.ts
@@ -1,0 +1,30 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import fs from "fs-extra";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("artifacts-when <consumer> --needs", async () => {
+    await fs.promises.rm("tests/test-cases/artifacts-when/.gitlab-ci-local", {recursive: true, force: true});
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/artifacts-when",
+        job: ["consumer"],
+        needs: true,
+        noColor: true,
+    }, writeStreams);
+
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/on_success_success/on_success_success")).toBe(true);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/on_success_failure/on_success_failure")).toBe(false);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/on_success_warning/on_success_warning")).toBe(false);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/on_failure_success/on_failure_success")).toBe(false);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/on_failure_failure/on_failure_failure")).toBe(true);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/on_failure_warning/on_failure_warning")).toBe(true);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/always_success/always_success")).toBe(true);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/always_failure/always_failure")).toBe(true);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-when/.gitlab-ci-local/artifacts/always_warning/always_warning")).toBe(true);
+});


### PR DESCRIPTION
Fix copyArtifactsOut condition to support different `artifacts.when` field values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `artifacts.when` in `copyArtifactsOut`: previously artifacts were exported only on success or with `when: always`; now `on_success` (default), `on_failure`, and `always` are supported, treating `allow_failure` jobs as failed. Dotenv reports are still exported regardless of the producer's status.

**Tests**
- Adds an artifacts-when matrix test covering each `when` value against success, failure, and warning outcomes.
- Extends the dotenv test case to verify failed and `allow_failure` producers still pass their reports.

<sup>Written for commit d29bc6de113183503f69c05a4a75573a2d32ab0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

