### PR TITLE
fix(parser): anchor comment directives correctly and quote injected descriptions

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -321,7 +321,7 @@ export class Parser {
                         index++;
                     }
                     if (descriptionMatch) {
-                        fileSplitClone.splice(index + 1, 0, `  gclDescription: ${descriptionMatch?.groups?.description ?? ""}`);
+                        fileSplitClone.splice(index + 1, 0, `  gclDescription: ${JSON.stringify(descriptionMatch?.groups?.description ?? "")}`);
                         index++;
                     }
                     interactiveMatch = null;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -306,7 +306,7 @@ export class Parser {
                     continue;
                 }
 
-                const jobMatch = /^[\w.$-]+:/.exec(line);
+                const jobMatch = /^[^\s#].*:/.exec(line);
                 if (jobMatch && (interactiveMatch || descriptionMatch || injectSSHAgent || noArtifactsToSourceMatch)) {
                     if (interactiveMatch) {
                         fileSplitClone.splice(index + 1, 0, "  gclInteractive: true");

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -297,12 +297,16 @@ export class Parser {
         let index = 0;
         if (expandVariables) {
             for (const line of fileSplit) {
-                interactiveMatch = interactiveMatch ?? /#\s?@\s?[Ii]nteractive/.exec(line);
-                injectSSHAgent = injectSSHAgent ?? /#\s?@\s?[Ii]njectSSHAgent/.exec(line);
-                noArtifactsToSourceMatch = noArtifactsToSourceMatch ?? /#\s?@\s?NoArtifactsToSource/i.exec(line);
-                descriptionMatch = descriptionMatch ?? /#\s?@\s?[Dd]escription (?<description>.*)/.exec(line);
+                if (/^\s*#/.test(line)) {
+                    interactiveMatch = interactiveMatch ?? /#\s?@\s?[Ii]nteractive/.exec(line);
+                    injectSSHAgent = injectSSHAgent ?? /#\s?@\s?[Ii]njectSSHAgent/.exec(line);
+                    noArtifactsToSourceMatch = noArtifactsToSourceMatch ?? /#\s?@\s?NoArtifactsToSource/i.exec(line);
+                    descriptionMatch = descriptionMatch ?? /#\s?@\s?[Dd]escription (?<description>.*)/.exec(line);
+                    index++;
+                    continue;
+                }
 
-                const jobMatch = /\w:/.exec(line);
+                const jobMatch = /^[\w.$-]+:/.exec(line);
                 if (jobMatch && (interactiveMatch || descriptionMatch || injectSSHAgent || noArtifactsToSourceMatch)) {
                     if (interactiveMatch) {
                         fileSplitClone.splice(index + 1, 0, "  gclInteractive: true");

--- a/tests/test-cases/comment-directive-anchor/.gitlab-ci.yml
+++ b/tests/test-cases/comment-directive-anchor/.gitlab-ci.yml
@@ -21,6 +21,16 @@ build/image:
   script:
     - echo "build"
 
+# @Description Quoted with a colon: and "quotes"
+"quoted job":
+  script:
+    - echo "quoted"
+
+# @Description Single quoted job
+'single quoted':
+  script:
+    - echo "single"
+
 # @Description Runs the tests
 plainjob:
   script:

--- a/tests/test-cases/comment-directive-anchor/.gitlab-ci.yml
+++ b/tests/test-cases/comment-directive-anchor/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+---
+# @Description Runs first
+firstjob:
+  script:
+    - echo "first"
+
+# @Description Upload source maps. Opt in per brand:
+#   sourcemaps:
+#     extends: [.foo]
+sourcemaps:
+  script:
+    - echo "sourcemaps"
+
+# @Description Deploys everything
+deploy to prod:
+  script:
+    - echo "deploy"
+
+# @Description Builds the image
+build/image:
+  script:
+    - echo "build"
+
+# @Description Runs the tests
+plainjob:
+  script:
+    - echo "test"

--- a/tests/test-cases/comment-directive-anchor/integration.test.ts
+++ b/tests/test-cases/comment-directive-anchor/integration.test.ts
@@ -26,5 +26,7 @@ test.concurrent("comment-directive-anchor --list", async () => {
     expect(descriptionOf("sourcemaps")).toBe("Upload source maps. Opt in per brand:");
     expect(descriptionOf("deploy to prod")).toBe("Deploys everything");
     expect(descriptionOf("build/image")).toBe("Builds the image");
+    expect(descriptionOf("quoted job")).toBe("Quoted with a colon: and \"quotes\"");
+    expect(descriptionOf("single quoted")).toBe("Single quoted job");
     expect(descriptionOf("plainjob")).toBe("Runs the tests");
 });

--- a/tests/test-cases/comment-directive-anchor/integration.test.ts
+++ b/tests/test-cases/comment-directive-anchor/integration.test.ts
@@ -1,0 +1,30 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("comment-directive-anchor --list", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/comment-directive-anchor/",
+        list: true,
+        noColor: true,
+        stateDir: ".gitlab-ci-local-comment-directive-anchor",
+    }, writeStreams);
+
+    const descriptionOf = (jobName: string) => {
+        const line = writeStreams.stdoutLines.find(l => l.startsWith(`${jobName}  `));
+        expect(line, `no output line for job ${jobName}`).toBeDefined();
+        return line!.slice(jobName.length).trimStart().replace(/\s{2,}.*$/, "");
+    };
+
+    expect(descriptionOf("firstjob")).toBe("Runs first");
+    expect(descriptionOf("sourcemaps")).toBe("Upload source maps. Opt in per brand:");
+    expect(descriptionOf("deploy to prod")).toBe("Deploys everything");
+    expect(descriptionOf("build/image")).toBe("Builds the image");
+    expect(descriptionOf("plainjob")).toBe("Runs the tests");
+});


### PR DESCRIPTION
Comment directives were anchored with `/\w:/`, which also matched a `word:` inside a comment, so a multi-line `# @Description` containing a colon attached the injected key to the wrong job; directives now anchor only on unindented non-comment keys and injected descriptions are quoted so a colon in the text cannot produce invalid YAML.

The description-quoting bug is present on master independently of this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed directive injection to skip comment lines, anchor on real top-level job keys (including names with spaces, slashes, and quoted keys), and quote description values. Prevents mis-anchoring and invalid YAML, removing the "duplicated mapping key detected" warning.

- **Bug Fixes**
  - Scan only real top-level keys with `/^[^\s#].*:/`; ignore `#` lines and indented keys. Supports names with spaces, slashes, and quoted keys.
  - Quote injected `gclDescription` values to handle colons and quotes in descriptions.

<sup>Written for commit 0792fc516006de145ea0b202a02983aa1ce3ee31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

