### PR TITLE
fix: pull registry probe image before the timed readiness check

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^src/utils\\.ts$/"],
-      "matchStrings": ["Image: string = \"(?<depName>[^:\"]+):(?<currentValue>[^\"]+)\""],
-      "datasourceTemplate": "docker"
+      "matchStrings": ["// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+static readonly \\w+: string = \"[^:\"]+:(?<currentValue>[^\"]+)\";"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,13 @@
       "matchUpdateTypes": ["minor", "patch", "lockFileMaintenance"],
       "groupName": "All non-major"
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^src/utils\\.ts$/"],
+      "matchStrings": ["Image: string = \"(?<depName>[^:\"]+):(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "docker"
+    }
   ]
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -422,6 +422,9 @@ export class Utils {
     }
 
     static readonly gclRegistryPrefix: string = "registry.gcl.local";
+    static readonly gclRegistryImage: string = "registry:3.1.1";
+    static readonly gclOpensslImage: string = "alpine/openssl:3.5.7";
+    static readonly gclCurlImage: string = "curlimages/curl:8.21.0";
     static async startDockerRegistry (argv: Argv): Promise<void> {
         const gclRegistryCertVol = `${this.gclRegistryPrefix}.certs`;
         const gclRegistryDataVol = `${this.gclRegistryPrefix}.data`;
@@ -446,7 +449,7 @@ export class Utils {
                 "-addext", `subjectAltName=DNS:${this.gclRegistryPrefix}`,
             ];
             const generateCertsInPlace = [
-                argv.containerExecutable, "run", "--rm", "-v", `${gclRegistryCertVol}:/certs`, "--entrypoint", "sh", "alpine/openssl", "-c",
+                argv.containerExecutable, "run", "--rm", "-v", `${gclRegistryCertVol}:/certs`, "--entrypoint", "sh", this.gclOpensslImage, "-c",
                 [
                     "openssl", ...opensslArgs,
                     "&&", "mkdir", "-p", `/certs/${this.gclRegistryPrefix}`,
@@ -481,18 +484,20 @@ export class Utils {
             "-e", "REGISTRY_HTTP_ADDR=0.0.0.0:443",
             "-e", `REGISTRY_HTTP_TLS_CERTIFICATE=/certs/${this.gclRegistryPrefix}.crt`,
             "-e", `REGISTRY_HTTP_TLS_KEY=/certs/${this.gclRegistryPrefix}.key`,
-            "registry",
+            this.gclRegistryImage,
         ]);
+
+        await Utils.spawn([argv.containerExecutable, "pull", this.gclCurlImage]);
 
         try {
             await execa(argv.containerExecutable, [
                 "run", "--rm",
                 "--network", gclRegistryNet,
                 "--entrypoint", "sh",
-                "curlimages/curl",
+                this.gclCurlImage,
                 "-c", `until [ "$(curl -s -o /dev/null -k -w "%{http_code}" https://${this.gclRegistryPrefix}:443)" = "200" ]; do sleep 1; done;`,
             ], {
-                timeout: 4000,
+                timeout: 10000,
             });
         } catch (err) {
             await this.stopDockerRegistry(argv.containerExecutable);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -422,8 +422,11 @@ export class Utils {
     }
 
     static readonly gclRegistryPrefix: string = "registry.gcl.local";
+    // renovate: datasource=docker depName=registry
     static readonly gclRegistryImage: string = "registry:3.1.1";
+    // renovate: datasource=docker depName=alpine/openssl
     static readonly gclOpensslImage: string = "alpine/openssl:3.5.7";
+    // renovate: datasource=docker depName=curlimages/curl
     static readonly gclCurlImage: string = "curlimages/curl:8.21.0";
     static async startDockerRegistry (argv: Argv): Promise<void> {
         const gclRegistryCertVol = `${this.gclRegistryPrefix}.certs`;
@@ -487,9 +490,8 @@ export class Utils {
             this.gclRegistryImage,
         ]);
 
-        await Utils.spawn([argv.containerExecutable, "pull", this.gclCurlImage]);
-
         try {
+            await Utils.spawn([argv.containerExecutable, "pull", this.gclCurlImage]);
             await execa(argv.containerExecutable, [
                 "run", "--rm",
                 "--network", gclRegistryNet,


### PR DESCRIPTION
The local registry readiness probe timed out because its 4s budget also covered the `curlimages/curl` image pull, so the pull now runs before the timed probe and the three images the local registry uses are pinned with a renovate custom manager to keep them updated. I could not reproduce the timeout locally, so CI is the real check on the flake.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky local registry readiness probe by pulling the probe image before the timed check (now inside the try block) and increasing the timeout to 10s.

- **Bug Fixes**
  - Pull `curlimages/curl:8.21.0` inside the probe’s try block before the loop to avoid cold pull timeouts and ensure cleanup on failure.
  - Increase readiness check timeout from 4s to 10s.

- **Dependencies**
  - Pin images: `registry:3.1.1`, `alpine/openssl:3.5.7`, `curlimages/curl:8.21.0`.
  - Track these tags via Renovate using inline comments in `src/utils.ts` and a regex custom manager with the `docker` datasource.

<sup>Written for commit c4ac83fbac4695edc5476d4c1a649a39bc70c64c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

