### PR TITLE
fix: respect --no-color and NO_COLOR

### DIFF
--- a/src/argv.ts
+++ b/src/argv.ts
@@ -105,7 +105,7 @@ export class Argv {
     }
 
     private constructor (argv: any, writeStreams?: WriteStreams) {
-        if (argv.noColor) {
+        if (argv.noColor || argv.color === false || (process.env.NO_COLOR ?? "") !== "") {
             chalkBase.level = 0;
         }
         this.writeStreams = writeStreams;

--- a/tests/argv-color.test.ts
+++ b/tests/argv-color.test.ts
@@ -1,10 +1,10 @@
 import "../src/global.js";
-import chalkBase from "chalk";
+import chalkBase, {type ColorSupportLevel} from "chalk";
 import {Argv} from "../src/argv.js";
 import {WriteStreamsMock} from "../src/write-streams.js";
 
 let writeStreams: WriteStreamsMock;
-let originalLevel: number;
+let originalLevel: ColorSupportLevel;
 let originalNoColor: string | undefined;
 
 beforeEach(() => {

--- a/tests/argv-color.test.ts
+++ b/tests/argv-color.test.ts
@@ -1,0 +1,51 @@
+import "../src/global.js";
+import chalkBase from "chalk";
+import {Argv} from "../src/argv.js";
+import {WriteStreamsMock} from "../src/write-streams.js";
+
+let writeStreams: WriteStreamsMock;
+let originalLevel: number;
+let originalNoColor: string | undefined;
+
+beforeEach(() => {
+    writeStreams = new WriteStreamsMock();
+    originalLevel = chalkBase.level;
+    originalNoColor = process.env.NO_COLOR;
+});
+
+afterEach(() => {
+    chalkBase.level = originalLevel;
+    if (originalNoColor === undefined) {
+        delete process.env.NO_COLOR;
+    } else {
+        process.env.NO_COLOR = originalNoColor;
+    }
+});
+
+test("color stays enabled by default", async () => {
+    chalkBase.level = 2;
+    delete process.env.NO_COLOR;
+    await Argv.build({}, writeStreams);
+    expect(chalkBase.level).toBe(2);
+});
+
+test("--no-color disables color", async () => {
+    chalkBase.level = 2;
+    delete process.env.NO_COLOR;
+    await Argv.build({color: false}, writeStreams);
+    expect(chalkBase.level).toBe(0);
+});
+
+test("NO_COLOR disables color", async () => {
+    chalkBase.level = 2;
+    process.env.NO_COLOR = "1";
+    await Argv.build({}, writeStreams);
+    expect(chalkBase.level).toBe(0);
+});
+
+test("an empty NO_COLOR leaves color enabled", async () => {
+    chalkBase.level = 2;
+    process.env.NO_COLOR = "";
+    await Argv.build({}, writeStreams);
+    expect(chalkBase.level).toBe(2);
+});


### PR DESCRIPTION
The color guard checked `argv.noColor`, which yargs never sets because `--no-color` parses to `color=false`, so disabling color only worked via chalk's own argv sniffing, which `FORCE_COLOR` overrides and which ignores `NO_COLOR` entirely.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI color handling to respect --no-color and the NO_COLOR env var instead of relying on `chalk` argv sniffing that `FORCE_COLOR` can override. Colors disable when `--no-color` is passed or `NO_COLOR` is set, and stay enabled otherwise.

- **Bug Fixes**
  - Disable color when `argv.color === false` or `process.env.NO_COLOR` is non-empty; keep it enabled by default and when `NO_COLOR` is empty.
  - Add tests for default, `--no-color`, and `NO_COLOR` set/empty cases; type the saved `chalk` level as `ColorSupportLevel`.

<sup>Written for commit fdd2152caa4fc99f901525fbbd6b54c1e804f029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

