### PR TITLE
fix(tests): stop leaving artifacts in the working tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /node_modules/
+/.bun/
 /bin/
 /ppa/
 /dist/

--- a/tests/test-cases/needs-parallel-matrix-artifacts/integration.test.ts
+++ b/tests/test-cases/needs-parallel-matrix-artifacts/integration.test.ts
@@ -1,11 +1,18 @@
+import fs from "fs-extra";
 import {WriteStreamsMock} from "../../../src/write-streams.js";
 import {handler} from "../../../src/handler.js";
 import chalk from "chalk-template";
 
+const cwd = "tests/test-cases/needs-parallel-matrix-artifacts";
+
+afterAll(async () => {
+    await Promise.all(["aws", "gcp"].map(provider => fs.rm(`${cwd}/tag-${provider}.txt`, {force: true})));
+});
+
 test.concurrent("needs-parallel-matrix-artifacts cascades only the matching producer's artifacts to each consumer permutation", async () => {
     const writeStreams = new WriteStreamsMock();
     await handler({
-        cwd: "tests/test-cases/needs-parallel-matrix-artifacts",
+        cwd,
         shellIsolation: true,
         stateDir: ".gitlab-ci-local-needs-parallel-matrix-artifacts",
     }, writeStreams);


### PR DESCRIPTION
The parallel-matrix test exports `tag-*.txt` back into its own directory and never removed them, so running the suite left the tree dirty and a release could be cut from it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the working tree clean by removing `tag-*.txt` artifacts created by the parallel-matrix test after it runs. Also ignore `/.bun/` in `.gitignore`.

<sup>Written for commit 7f2b946fb581e8572d5de9db1f28982a3898220a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

