### PR TITLE
fix: reject non-string rules:if

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -228,6 +228,7 @@ export class Utils {
 
     static evaluateRuleIf (ruleIf: string | undefined, envs: {[key: string]: string}): boolean {
         if (ruleIf === undefined) return true;
+        assert(typeof ruleIf === "string", chalk`This GitLab CI configuration is invalid: {blueBright rules:if} must be a string, but got {red ${JSON.stringify(ruleIf)}}`);
         assert(!/\$\{\w+\}/.test(ruleIf), chalk`rules:rule if invalid expression syntax: {blueBright ${ruleIf}}\nuse {green $VAR} not {red \${VAR\}} in rules:if`);
         let evalStr = ruleIf;
 

--- a/tests/rules.test.ts
+++ b/tests/rules.test.ts
@@ -334,3 +334,11 @@ test.concurrent("https://github.com/firecow/gitlab-ci-local/issues/1252", () => 
     const rulesResult = Utils.getRulesResult({argv, cwd: "", rules, variables}, gitData);
     expect(rulesResult).toEqual({when: "on_success", allowFailure: false, variables: undefined});
 });
+
+test.concurrent("https://github.com/firecow/gitlab-ci-local/issues/1841", () => {
+    for (const ruleIf of [null, 1, true, ["a"]]) {
+        const rules = [ {if: ruleIf} as any ];
+        expect(() => Utils.getRulesResult({argv, cwd: "", rules, variables: {}}, gitData))
+            .toThrow(/must be a string, but got/);
+    }
+});


### PR DESCRIPTION
A rules entry with an empty `if:` key parses as `null` and reached string methods directly, so a config mistake surfaced as `TypeError: null is not an object` instead of a config error. Fixes #1841.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-string values in `rules:if` and show a clear config error instead of a TypeError (fixes #1841). Adds a type check in `Utils.evaluateRuleIf` and tests for `null`, number, boolean, and array inputs.

<sup>Written for commit 71f128281c6bb3ec08555862ff8ff5aac56ae65c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

