### PR TITLE
fix: support including by commit sha over http

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -377,13 +377,15 @@ export class ParserIncludes {
                 await fs.mkdirp(path.dirname(`${cwd}/${target}/${normalizedFile}`));
                 tmpDir = `${cwd}/${target}.${ext}`;
 
-                const gitCloneBranch = (ref === "HEAD") ? "" : `--branch ${ref}`;
+                const isCommitSha = /^[0-9a-f]{40}$/.test(ref);
+                const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
                 await Utils.bashMulti([
                     `cd ${cwd}/${stateDir}`,
                     `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remote.schema}://${remote.host}:${remote.port}/${project}.git ${tmpDir}`,
                     `cd ${tmpDir}`,
+                    ...isCommitSha ? [`git fetch --depth=1 --filter=tree:0 origin ${ref}`] : [],
                     `git sparse-checkout set --no-cone ${normalizedFile}`,
-                    "git checkout",
+                    isCommitSha ? "git checkout FETCH_HEAD" : "git checkout",
                     `cd ${cwd}/${stateDir}`,
                     `cp ${tmpDir}/${normalizedFile} ${cwd}/${target}/${normalizedFile}`,
                 ], cwd);
@@ -418,13 +420,15 @@ export class ParserIncludes {
                 await fs.mkdirp(path.dirname(`${cwd}/${target}/templates`));
                 tmpDir = `${cwd}/${target}.${ext}`;
 
-                const gitCloneBranch = (ref === "HEAD") ? "" : `--branch ${ref}`;
+                const isCommitSha = /^[0-9a-f]{40}$/.test(ref);
+                const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
                 await Utils.bashMulti([
                     `cd ${cwd}/${stateDir}`,
                     `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remote.schema}://${remote.host}:${remote.port}/${project}.git ${tmpDir}`,
                     `cd ${tmpDir}`,
+                    ...isCommitSha ? [`git fetch --depth=1 --filter=tree:0 origin ${ref}`] : [],
                     `git sparse-checkout set --no-cone ${files[0]} ${files[1]}`,
-                    "git checkout",
+                    isCommitSha ? "git checkout FETCH_HEAD" : "git checkout",
                     `cd ${cwd}/${stateDir}`,
                     `mkdir -p ${tmpDir}/templates`, // create templates subdir (if it doesn't exist), as the check out may not create it
                     `cp -r ${tmpDir}/templates ${cwd}/${target}`,

--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -301,7 +301,7 @@ export class ParserIncludes {
                 if (this._cache.sha === undefined) {
                     if (this.isLocal) {
                         this._cache.sha = this.gitData.commit.SHA;
-                    } else if (/^[0-9a-f]{40}$/.test(this.effectiveRef)) {
+                    } else if (/^[0-9a-f]{40}$/i.test(this.effectiveRef)) {
                         // effectiveRef may already be a sha, if so return it directly
                         this._cache.sha = this.effectiveRef;
                     } else {
@@ -377,7 +377,7 @@ export class ParserIncludes {
                 await fs.mkdirp(path.dirname(`${cwd}/${target}/${normalizedFile}`));
                 tmpDir = `${cwd}/${target}.${ext}`;
 
-                const isCommitSha = /^[0-9a-f]{40}$/.test(ref);
+                const isCommitSha = /^[0-9a-f]{40}$/i.test(ref);
                 const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
                 await Utils.bashMulti([
                     `cd ${cwd}/${stateDir}`,
@@ -420,7 +420,7 @@ export class ParserIncludes {
                 await fs.mkdirp(path.dirname(`${cwd}/${target}/templates`));
                 tmpDir = `${cwd}/${target}.${ext}`;
 
-                const isCommitSha = /^[0-9a-f]{40}$/.test(ref);
+                const isCommitSha = /^[0-9a-f]{40}$/i.test(ref);
                 const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
                 await Utils.bashMulti([
                     `cd ${cwd}/${stateDir}`,

--- a/tests/test-cases/include-project-file/.gitlab-ci-4.yml
+++ b/tests/test-cases/include-project-file/.gitlab-ci-4.yml
@@ -1,0 +1,7 @@
+---
+include:
+  # https://gitlab.com/ANGkeith/gitlab-ci-local-test/-/tree/dev?ref_type=heads
+  - project: angkeith/gitlab-ci-local-test
+    ref: 126db0b30c40344e135a0335fdfd3d5f26af3b6d
+    file:
+      - .gitlab-ci.yml

--- a/tests/test-cases/include-project-file/integration.test.ts
+++ b/tests/test-cases/include-project-file/integration.test.ts
@@ -66,3 +66,19 @@ test.concurrent("include:project should respect rules specified in included proj
 
     expect(writeStreams.stdoutLines.join("\n")).toEqual(expected.join("\n"));
 });
+
+test.concurrent("include:project be able to target a commit sha via ref", async () => {
+    const writeStreams = new WriteStreamsMock();
+
+    await handler({
+        file: ".gitlab-ci-4.yml",
+        cwd: "tests/test-cases/include-project-file",
+        noColor: true,
+        stateDir: ".gitlab-ci-local-include-project-file-sha",
+    }, writeStreams);
+
+    const expected = "job > hello world from dev branch";
+
+    const filteredStdout = writeStreams.stdoutLines.filter(f => f.startsWith("job >")).join("\n");
+    expect(filteredStdout).toEqual(expected);
+});


### PR DESCRIPTION
`git clone --branch` cannot resolve a commit sha, so a project or component include pinned to one always failed to fetch; a 40-hex ref is now fetched explicitly and checked out from FETCH_HEAD. Fixes #1800.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Includes pinned to a commit SHA over HTTP work; we detect 40‑char SHAs case‑insensitively, skip `git clone --branch`, fetch the commit, and checkout `FETCH_HEAD`, with an integration test. Fixes #1800.

<sup>Written for commit b0997ef23ee74b3f3e2c25be73fd028405c78b1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

