### PR TITLE
fix: fall back to a literal tag when a component ref is not a semver range

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -282,8 +282,8 @@ export class ParserIncludes {
                             const stdout = getGitRemoteInfo(this, "--tags");
                             const tags = stdout.split("\n").map(line => line.split("\t")[1].split("/")[2]);
                             const version = resolveSemanticVersionRange(this.reference, tags);
-                            assert(version, `This GitLab CI configuration is invalid: component: \`${this.name}\` - The reference (${this.reference}) is invalid`);
-                            this._cache.version = version;
+                            assert(version ?? tags.includes(this.reference), `This GitLab CI configuration is invalid: component: \`${this.name}\` - The reference (${this.reference}) is invalid`);
+                            this._cache.version = version ?? null;
                         } else {
                             this._cache.version = null;
                         }

--- a/tests/test-cases/include-component/component-non-semver-tag/.gitlab-ci.yml
+++ b/tests/test-cases/include-component/component-non-semver-tag/.gitlab-ci.yml
@@ -1,0 +1,5 @@
+---
+# https://gitlab.com/ANGkeith/gitlab-ci-local-test tags a commit as `1`, which
+# matches the semver range pattern but is not a valid semver version.
+include:
+  - component: gitlab.com/angkeith/gitlab-ci-local-test/my-components@1

--- a/tests/test-cases/include-component/integration.test.ts
+++ b/tests/test-cases/include-component/integration.test.ts
@@ -197,3 +197,28 @@ component-job:
 
     expect(writeStreams.stdoutLines[0]).toEqual(expected);
 });
+
+test.concurrent("include-component component (non semver tag)", async () => {
+    initSpawnSpy([WhenStatics.mockGitRemoteHttp]);
+
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd: "tests/test-cases/include-component/component-non-semver-tag",
+        preview: true,
+        stateDir: ".gitlab-ci-local-include-component-non-semver-tag",
+    }, writeStreams);
+
+    const expected = `---
+stages:
+  - .pre
+  - build
+  - test
+  - deploy
+  - .post
+component-job:
+  script:
+    - echo job 1
+  stage: test`;
+
+    expect(writeStreams.stdoutLines[0]).toEqual(expected);
+});


### PR DESCRIPTION
A component ref of only digits matches the semver range pattern, but a tag literally named `9` or `0.1` is not valid semver, so range resolution found nothing and the assertion fired instead of using the ref as a plain tag. Fixes #1604.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fall back to a literal Git tag when a component ref looks like a semver range but isn’t valid semver (e.g., `9`, `0.1`). If range resolution finds nothing but the tag exists, accept it instead of asserting, and add an integration test for `@1`.

<sup>Written for commit 5ccab0ecb375c83c8f67e75aa6d87d9754575ea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

