### PR TITLE
fix: omit the default port from include clone urls

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -402,7 +402,7 @@ export class ParserIncludes {
                 const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
                 await Utils.bashMulti([
                     `cd ${cwd}/${stateDir}`,
-                    `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remote.schema}://${remote.host}:${remote.port}/${project}.git ${tmpDir}`,
+                    `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remoteProjectUrl(remote, project)} ${tmpDir}`,
                     `cd ${tmpDir}`,
                     ...isCommitSha ? [`git fetch --depth=1 --filter=tree:0 origin ${ref}`] : [],
                     `git sparse-checkout set --no-cone ${normalizedFile}`,
@@ -445,7 +445,7 @@ export class ParserIncludes {
                 const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
                 await Utils.bashMulti([
                     `cd ${cwd}/${stateDir}`,
-                    `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remote.schema}://${remote.host}:${remote.port}/${project}.git ${tmpDir}`,
+                    `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remoteProjectUrl(remote, project)} ${tmpDir}`,
                     `cd ${tmpDir}`,
                     ...isCommitSha ? [`git fetch --depth=1 --filter=tree:0 origin ${ref}`] : [],
                     `git sparse-checkout set --no-cone ${files[0]} ${files[1]}`,
@@ -529,4 +529,10 @@ export async function resolveIncludeLocal (pattern: string, cwd: string) {
 
     const re2js = RE2JS.compile(`^${pattern}`);
     return repoFiles.filter((f: any) => re2js.matches(f));
+}
+
+export function remoteProjectUrl (remote: {schema: string; host: string; port: string}, project: string) {
+    const defaultPort = remote.schema === "http" ? "80" : "443";
+    const port = remote.port === defaultPort ? "" : `:${remote.port}`;
+    return `${remote.schema}://${remote.host}${port}/${project}.git`;
 }

--- a/tests/parser-includes.test.ts
+++ b/tests/parser-includes.test.ts
@@ -1,4 +1,4 @@
-import {resolveSemanticVersionRange} from "../src/parser-includes.js";
+import {remoteProjectUrl, resolveSemanticVersionRange} from "../src/parser-includes.js";
 
 const tests = [
     {
@@ -43,5 +43,27 @@ describe("resolveSemanticVersionRange", () => {
             const result = resolveSemanticVersionRange(t.range, gitTags);
             expect(result).toEqual(t.expect);
         });
+    });
+});
+
+describe("remoteProjectUrl", () => {
+    test("omits the default https port", () => {
+        expect(remoteProjectUrl({schema: "https", host: "git.example.com", port: "443"}, "grp/proj"))
+            .toEqual("https://git.example.com/grp/proj.git");
+    });
+
+    test("omits the default http port", () => {
+        expect(remoteProjectUrl({schema: "http", host: "git.example.com", port: "80"}, "grp/proj"))
+            .toEqual("http://git.example.com/grp/proj.git");
+    });
+
+    test("keeps a non-default port", () => {
+        expect(remoteProjectUrl({schema: "https", host: "git.example.com", port: "8443"}, "grp/proj"))
+            .toEqual("https://git.example.com:8443/grp/proj.git");
+    });
+
+    test("keeps port 80 when the schema is https", () => {
+        expect(remoteProjectUrl({schema: "https", host: "git.example.com", port: "80"}, "grp/proj"))
+            .toEqual("https://git.example.com:80/grp/proj.git");
     });
 });


### PR DESCRIPTION
Include clone urls always carried an explicit `:443`/`:80`, which git credential helpers treat as a different host than the bare url, so lookups failed on self-hosted instances. Fixes #1918.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit default ports from include clone URLs to match credential helper host matching. Previously clone URLs always included :443 or :80; now we drop the port for https and http when default, and keep non-default ports. This prevents credential lookups failing on self-hosted instances. Fixes #1918.

**Review notes**
- `ParserIncludes` now builds clone URLs via `remoteProjectUrl(remote, project)` instead of inlining `schema://host:port/...`.
- Tests cover `remoteProjectUrl` behavior: omits https:443 and http:80; retains non-default ports and https:80.

<sup>Written for commit 071758f0722d7c8b5b52f76e5a5a39298de08853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

