### PR TITLE
fix: report a failed parse during completion instead of crashing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,8 @@ process.on("SIGUSR2", async () => {
                         .then((parser) => {
                             const jobNames = [...parser.jobs.values()].filter((j) => j.when != "never").map((j) => j.name);
                             done(jobNames);
-                        });
+                        })
+                        .catch(() => done(["Parser-Failed!"]));
                 }
             } catch {
                 return ["Parser-Failed!"];

--- a/tests/test-cases/completion/.gitlab-ci.yml
+++ b/tests/test-cases/completion/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+---
+include:
+  - { local: .gitlab-ci-invalid.yml }
+
+job:
+  script:
+    - echo "hello"

--- a/tests/test-cases/completion/integration.test.ts
+++ b/tests/test-cases/completion/integration.test.ts
@@ -17,10 +17,10 @@ test("completion reports a failed parse instead of crashing", () => {
     const {stdout, stderr, status} = spawnSync(
         "bun",
         ["src/index.ts", "--get-yargs-completions", "gitlab-ci-local", "--cwd", "tests/test-cases/completion", ""],
-        {encoding: "utf8", shell: true},
+        {encoding: "utf8", shell: false},
     );
 
-    expect(stderr).not.toContain("AssertionError");
+    expect(stderr).toBe("");
     expect(stdout).toContain("Parser-Failed!");
     expect(status).toBe(0);
 });

--- a/tests/test-cases/completion/integration.test.ts
+++ b/tests/test-cases/completion/integration.test.ts
@@ -1,4 +1,4 @@
-import {execSync} from "child_process";
+import {execSync, spawnSync} from "child_process";
 
 // Runs the CLI as a subprocess to reliably capture console.log output,
 // which Bun implements natively and cannot be intercepted with vi.spyOn.
@@ -9,4 +9,18 @@ test("--completion outputs gitlab-ci-local as script name", () => {
     expect(output).toContain("###-end-gitlab-ci-local-completions-###");
     expect(output).toContain("gitlab-ci-local --get-yargs-completions");
     expect(output).not.toMatch(/###-begin-(?!gitlab-ci-local)/);
+});
+
+// The .gitlab-ci.yml in this folder includes a local file that does not exist,
+// so building the pipeline rejects while the shell is asking for completions.
+test("completion reports a failed parse instead of crashing", () => {
+    const {stdout, stderr, status} = spawnSync(
+        "bun",
+        ["src/index.ts", "--get-yargs-completions", "gitlab-ci-local", "--cwd", "tests/test-cases/completion", ""],
+        {encoding: "utf8", shell: true},
+    );
+
+    expect(stderr).not.toContain("AssertionError");
+    expect(stdout).toContain("Parser-Failed!");
+    expect(status).toBe(0);
 });


### PR DESCRIPTION
Closes #1867.

When building the pipeline fails while the shell is asking for completions, gitlab-ci-local prints a raw Node stack trace into the terminal instead of the `Parser-Failed!` sentinel.

## Reproducing

A repository whose `.gitlab-ci.yml` has a local include that resolves to no file:

```yaml
include:
  - local: ".gitlab/ci/templates/**.gitlab-ci.yml"
```

Pressing TAB there, or calling the completion hook directly (paths shortened):

```
$ gitlab-ci-local --get-yargs-completions gitlab-ci-local ""
AssertionError: Local include file cannot be found .gitlab/ci/templates/**.gitlab-ci.yml
        code: "ERR_ASSERTION"

      at new AssertionError (internal:assert/assertion_error:222:27)
      at init (src/parser-includes.ts:260:30)
      at init (src/parser.ts:210:21)
      at create (src/parser.ts:122:24)
      at processTicksAndRejections (native:7:39)
```

The ordinary path is fine. `gitlab-ci-local --list` on the same repository prints `Local include file cannot be found ...` in red and nothing else, because the command handler in `src/index.ts` already catches `AssertionError`. Only the completion callback is affected.

## Cause

8998b96 ("Made tab completion a little more resilient") wrapped the callback in `try`/`catch`. The callback was `async` and used `await` back then, so the catch really did cover the parse and returned `["Parser-Failed!"]`.

ce51732 rewrote the callback to take `done` and build a `.then()` chain. The `try`/`catch` stayed where it was, but there is no longer an `await` inside it and the chain has no `.catch()`, so a rejection escapes the synchronous block and Node reports it as an unhandled rejection.

## Change

The missing `.catch()`, so a failed parse ends in the same sentinel the 2021 commit intended.

## Test

`tests/test-cases/completion/` gets a `.gitlab-ci.yml` with an include that cannot be resolved, plus a test that runs the completion hook against it. The fixture uses a plain missing file rather than the glob above, since `resolveIncludeLocal` treats every `include:local` value as a glob and both end at the same assertion.

Without the `.catch()` the test fails on `stderr` containing `AssertionError`. With it, `stdout` carries `Parser-Failed!` and the exit code is 0.

```
bunx vitest run tests/test-cases/completion/
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tab completion now reports a failed pipeline parse with "Parser-Failed!" instead of crashing with an unhandled rejection and printing a Node stack trace. Normal command behavior is unchanged; completion output remains clean and exit code stays 0.

- Add .catch(() => done(["Parser-Failed!"])) to the completion promise chain in src/index.ts; keep the existing synchronous try/catch.
- Add an integration test and fixture under tests/test-cases/completion/ with a missing local include; the test calls the completion hook with an empty completion word and asserts stdout contains "Parser-Failed!", stderr is empty, and status is 0.
- No impact to normal command execution; --list already handles AssertionError.

<sup>Written for commit 71bf3c8807ae8ccfbc6ea6ff57170e66e9c0a9c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

