### PR TITLE
fix: expand variables in the rules:exists:paths form

### DIFF
--- a/src/job.ts
+++ b/src/job.ts
@@ -79,7 +79,7 @@ export type JobRule = {
     if?: string;
     when?: string;
     changes?: string[] | {paths: string[]};
-    exists?: string[];
+    exists?: string[] | {paths: string[]};
     allow_failure?: boolean;
     variables?: {[name: string]: string};
     needs?: any[];
@@ -197,7 +197,7 @@ export class Job {
 
             // Expand variables in rules:exists
             this.rules.forEach((rule, ruleIdx, rules) => {
-                const exists = Array.isArray(rule.exists) ? rule.exists : null;
+                const exists = Array.isArray(rule.exists) ? rule.exists : rule.exists?.paths;
                 if (!exists) {
                     return;
                 }

--- a/src/job.ts
+++ b/src/job.ts
@@ -196,7 +196,9 @@ export class Job {
             });
 
             // Expand variables in rules:exists
-            this.rules.forEach((rule, ruleIdx, rules) => {
+            this.rules.forEach((rule) => {
+                // The object form shares this array with rule.exists.paths, so
+                // expanding in place is enough and leaves project/ref alone.
                 const exists = Array.isArray(rule.exists) ? rule.exists : rule.exists?.paths;
                 if (!exists) {
                     return;
@@ -204,7 +206,6 @@ export class Job {
                 exists.forEach((exist, existId, exists) => {
                     exists[existId] = Utils.expandText(exist, expanded);
                 });
-                rules[ruleIdx].exists = exists;
             });
         }
 

--- a/tests/test-cases/rules-exists/.gitlab-ci.yml
+++ b/tests/test-cases/rules-exists/.gitlab-ci.yml
@@ -72,3 +72,11 @@ rule-exist-empty-string:
   rules:
     - exists:
         - ""
+
+var-expand-paths-test:
+  script:
+    - echo "${DIR}/recursive.file successfully found through the paths form"
+  rules:
+    - exists:
+        paths:
+          - ${DIR}/recursive.file

--- a/tests/test-cases/rules-exists/integration.test.ts
+++ b/tests/test-cases/rules-exists/integration.test.ts
@@ -24,4 +24,5 @@ test.concurrent("rules-exists", async () => {
     expect(output).not.toContain("Directory Recursive Skipped!");
     expect(output).not.toContain("rule-exist-empty-string Executed!");
     expect(output).toContain("rules:exists:paths works!");
+    expect(output).toContain("existsDir/existDirNested/recursive.file successfully found through the paths form");
 });


### PR DESCRIPTION
`rules:exists` accepts two shapes, a list of globs and an object with a `paths` key. `Utils.evaluateRuleExist` knows both and normalises them:

```ts
// src/utils.ts
static evaluateRuleExist (cwd: string, ruleExists: string[] | {paths: string[]} | undefined): boolean {
    if (ruleExists === undefined) return true;

    // Normalize rules:exists:paths to rules:exists
    if (!Array.isArray(ruleExists)) ruleExists = ruleExists.paths;
```

The variable expansion in the `Job` constructor only knows one:

```ts
// src/job.ts, two blocks apart
const changes = Array.isArray(rule.changes) ? rule.changes : rule.changes?.paths;
const exists = Array.isArray(rule.exists) ? rule.exists : null;
```

So a job written with the `paths` form keeps its `${VAR}` literals, `globbySync` gets a pattern with a dollar sign in it, nothing matches, and the rule quietly evaluates to false. The job is skipped and nothing is printed to explain why, which is the part that makes it hard to spot from the outside.

The declared type shows the same asymmetry, `changes?: string[] | {paths: string[]}` next to `exists?: string[]`, which is what let the `null` branch look complete.

The fix is the `exists` line rewritten to match the `changes` line above it, plus the type. The `paths` form arrived in #1530 for `exists` and the expansion was not extended along with it.

## Testing

`tests/test-cases/rules-exists/.gitlab-ci.yml` already has `var-expand-test`, which uses `${DIR}` in the list form, and `executed-job-paths`, which uses the `paths` form without a variable. The gap was exactly the combination of the two, so I added `var-expand-paths-test` for it and one assertion in `integration.test.ts`.

On `master` the new job never starts, so the assertion fails on missing output while `var-expand-test` right beside it runs and expands correctly. With the change both run.

```
bunx vitest run tests/test-cases/rules-exists/
  Tests  1 passed (1)
```

I also ran the neighbouring rule suites, `rules-blank`, `rules-curly-bracket-if`, `rules-needs`, `include-rules` and `workflow-rules-variables`, all passing. `rules-changes` fails for me with `spawn docker ENOENT`, and it fails the same way on a clean `master` checkout in the same environment, so that one is my sandbox and not this change.

`tsc --noEmit` and `eslint` are clean.

A note on the environment, since it affects what I can claim: my machine is Windows and the suite needs `rsync`, which `Utils.rsyncTrackedFiles` calls through `Utils.bash`, so everything above was run inside a Debian container on Bun 1.3.14 with `--pool=forks`. The default threads pool crashes there on `this._thread.stdout.pipe`, which looks like a Bun and vitest interaction rather than anything about this repository, so I did not chase it. I did not run the full suite or the `dind-*` tests.

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands variable placeholders in `rules:exists:paths` and preserves other object fields. Previously, only the list form expanded `${VAR}` and the code reassigned `exists`, which could drop `project`/`ref`; now both forms expand and object fields remain intact.

- Update `Job` to expand `rule.exists?.paths` in place; widen type to `exists?: string[] | {paths: string[]}` and mirror `rules:changes`.
- Add `var-expand-paths-test` and an integration assertion to verify `${VAR}` expansion in the `paths` form.
- No migration required. Pipelines using `rules:exists:paths` with variables may now trigger where they previously did not.

<sup>Written for commit f15ff1e4cc008182de9f2465886c830cb8f9dac7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

