### PR TITLE
fix: accept an absolute --variables-file

### DIFF
--- a/src/variables-from-files.ts
+++ b/src/variables-from-files.ts
@@ -6,6 +6,7 @@ import chalk from "chalk-template";
 import prettyHrtime from "pretty-hrtime";
 import {Argv} from "./argv.js";
 import assert from "node:assert";
+import path from "node:path";
 import {Utils} from "./utils.js";
 import dotenv from "dotenv";
 import deepExtend from "deep-extend";
@@ -123,7 +124,7 @@ export class VariablesFromFiles {
         await addVariableFileToVariables(remoteFileData, 0);
         await addVariableFileToVariables(homeFileData, 10);
 
-        const projectVariablesFile = `${argv.cwd}/${argv.variablesFile}`;
+        const projectVariablesFile = path.resolve(argv.cwd, argv.variablesFile);
         if (fs.existsSync(projectVariablesFile)) {
             let isDotEnvFormat = false;
             const projectVariablesFileRawContent = await fs.readFile(projectVariablesFile, "utf8");

--- a/tests/test-cases/variables-file-absolute/.gitlab-ci.yml
+++ b/tests/test-cases/variables-file-absolute/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+---
+test-job:
+  script:
+    - echo "MYVAR=$MYVAR"

--- a/tests/test-cases/variables-file-absolute/integration.test.ts
+++ b/tests/test-cases/variables-file-absolute/integration.test.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+const cwd = "tests/test-cases/variables-file-absolute";
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+});
+
+test.concurrent("a relative variables file is read", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd,
+        variablesFile: "my-variables.yml",
+        noColor: true,
+        stateDir: ".gitlab-ci-local-variables-file-relative",
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(["test-job > MYVAR=from-variables-file"]));
+});
+
+test.concurrent("an absolute variables file is read", async () => {
+    const writeStreams = new WriteStreamsMock();
+    await handler({
+        cwd,
+        variablesFile: path.resolve(cwd, "my-variables.yml"),
+        noColor: true,
+        stateDir: ".gitlab-ci-local-variables-file-absolute",
+    }, writeStreams);
+
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(["test-job > MYVAR=from-variables-file"]));
+});

--- a/tests/test-cases/variables-file-absolute/my-variables.yml
+++ b/tests/test-cases/variables-file-absolute/my-variables.yml
@@ -1,0 +1,2 @@
+---
+MYVAR: from-variables-file


### PR DESCRIPTION
`--variables-file` was joined onto cwd unconditionally, so an absolute value became `cwd//abs/path` and was silently ignored, unlike `--inputs-file` and `--ignores-file` which both accept either form. Fixes #1926.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts absolute paths for --variables-file and keeps relative paths working, matching --inputs-file and --ignores-file. Previously, an absolute value was prefixed with the cwd, so the file was skipped; now we resolve the path correctly.

- Use path.resolve(argv.cwd, argv.variablesFile) in `src/variables-from-files.ts`.
- Add integration tests for relative and absolute variables files.
- No migration. Commands passing an absolute --variables-file now load that file’s variables.

<sup>Written for commit 663fb803b7869da21bad43c4c8dd37852029d313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

