### PR TITLE
fix: write the rsync exclude list to a file

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -382,7 +382,7 @@ export class Utils {
         const time = process.hrtime();
         await fs.mkdirp(`${cwd}/${stateDir}/builds/${target}`);
         const {stdout: untracked} = await Utils.bash("git ls-files -o --directory", cwd);
-        const untrackedFile = `${cwd}/${stateDir}/rsync-exclude-${target.replaceAll(/[^\w.-]/g, "_")}`;
+        const untrackedFile = `${cwd}/${stateDir}/rsync-exclude-${target}`;
         await fs.writeFile(untrackedFile, untracked.split("\n").filter(line => line !== "").map(line => `/${line}`).join("\n"));
         const cmd = [
             "rsync -a --delete-excluded --delete",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -381,9 +381,12 @@ export class Utils {
     static async rsyncTrackedFiles (cwd: string, stateDir: string, ignoresFile: string, target: string): Promise<{hrdeltatime: [number, number]}> {
         const time = process.hrtime();
         await fs.mkdirp(`${cwd}/${stateDir}/builds/${target}`);
+        const {stdout: untracked} = await Utils.bash("git ls-files -o --directory", cwd);
+        const untrackedFile = `${cwd}/${stateDir}/rsync-exclude-${target.replaceAll(/[^\w.-]/g, "_")}`;
+        await fs.writeFile(untrackedFile, untracked.split("\n").filter(line => line !== "").map(line => `/${line}`).join("\n"));
         const cmd = [
             "rsync -a --delete-excluded --delete",
-            "--exclude-from=<(git ls-files -o --directory | awk '{print \"/\"$0}')",
+            `--exclude-from=${Utils.safeBashString(untrackedFile)}`,
             ...await fs.pathExists(ignoresFile) ? [`--exclude-from=${Utils.safeBashString(ignoresFile)}`] : [],
             "--exclude .git/lfs",
             `--exclude ${stateDir}/`,

--- a/tests/test-cases/rsync-untracked-exclude/.gitlab-ci.yml
+++ b/tests/test-cases/rsync-untracked-exclude/.gitlab-ci.yml
@@ -1,0 +1,4 @@
+---
+test-job:
+  script:
+    - find . -name '*.marker' -not -path './.gitlab-ci-local*/*' | sort

--- a/tests/test-cases/rsync-untracked-exclude/integration.test.ts
+++ b/tests/test-cases/rsync-untracked-exclude/integration.test.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import fs from "fs-extra";
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+
+const cwd = "tests/test-cases/rsync-untracked-exclude";
+const untracked = path.join(cwd, "untracked.marker");
+
+beforeAll(() => {
+    initSpawnSpy(WhenStatics.all);
+    fs.writeFileSync(untracked, "untracked\n");
+});
+
+afterAll(() => {
+    fs.removeSync(untracked);
+});
+
+test("shell isolation syncs tracked files and excludes untracked ones", async () => {
+    const writeStreams = new WriteStreamsMock();
+
+    await handler({
+        cwd,
+        shellIsolation: true,
+        noColor: true,
+        stateDir: ".gitlab-ci-local-rsync-untracked-exclude",
+    }, writeStreams);
+
+    const markers = writeStreams.stdoutLines.filter(l => l.startsWith("test-job > "));
+    expect(markers).toEqual(["test-job > ./tracked.marker"]);
+
+    // rsync 3.5.0 cannot read an exclude file from a process substitution, so the
+    // untracked list has to reach it as a real file on disk.
+    const excludeFile = path.join(cwd, ".gitlab-ci-local-rsync-untracked-exclude", "rsync-exclude-test-job");
+    expect(fs.readFileSync(excludeFile, "utf8")).toContain("/untracked.marker");
+});

--- a/tests/test-cases/rsync-untracked-exclude/tracked.marker
+++ b/tests/test-cases/rsync-untracked-exclude/tracked.marker
@@ -1,0 +1,1 @@
+tracked


### PR DESCRIPTION
rsync 3.5.0 refuses to open an exclude file passed as a process substitution (`/dev/fd/63`), so every sync failed with exit code 11; the untracked list is now written into the state dir and passed as a real path. Fixes #1925.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rsync sync failures by writing the untracked exclude list to a real file and passing its path to `rsync`. Previously we used process substitution (`/dev/fd/*`), which `rsync` 3.5.0 refuses to read, causing exit code 11.

- Generate untracked paths via `git ls-files -o --directory`, prefix with "/", and write to `${stateDir}/rsync-exclude-${target}` (file is now named directly after the target; extra sanitizing removed).
- Pass `--exclude-from=<that-file>` to `rsync`; still honor the optional `ignoresFile`.
- Add an integration test that asserts tracked files sync, untracked files are excluded, and the exclude file exists with the expected entry.
- Side effect: exclude files persist under the state directory; no config or CLI changes required.

<sup>Written for commit 3c2ba4658f2e6a1ed181cf9b06068b7526327d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

