### PR TITLE
fix: stop encoded job names colliding with literal ones

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,9 +60,7 @@ export class Utils {
         const encoded = jobName.replace(/[^\w-]+/g, (match) => {
             return base64url.encode(match);
         });
-        const unambiguous = encoded === jobName ?
-            encoded :
-            `${encoded}.${createHash("sha256").update(jobName).digest("hex").substring(0, 8)}`;
+        const unambiguous = encoded === jobName ? encoded : ${encoded}.${createHash("sha256").update(jobName).digest("hex").substring(0, 8)}`;
         if (unambiguous.length <= Utils.MAX_FILENAME_LENGTH) {
             return unambiguous;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,11 +60,14 @@ export class Utils {
         const encoded = jobName.replace(/[^\w-]+/g, (match) => {
             return base64url.encode(match);
         });
-        if (encoded.length <= Utils.MAX_FILENAME_LENGTH) {
-            return encoded;
+        const unambiguous = encoded === jobName ?
+            encoded :
+            `${encoded}-${createHash("sha256").update(jobName).digest("hex").substring(0, 8)}`;
+        if (unambiguous.length <= Utils.MAX_FILENAME_LENGTH) {
+            return unambiguous;
         }
         const hash = createHash("sha256").update(jobName).digest("hex").substring(0, 16);
-        const prefix = encoded.substring(0, Utils.MAX_FILENAME_LENGTH - 1 - hash.length);
+        const prefix = unambiguous.substring(0, Utils.MAX_FILENAME_LENGTH - 1 - hash.length);
         return `${prefix}-${hash}`;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,7 +60,7 @@ export class Utils {
         const encoded = jobName.replace(/[^\w-]+/g, (match) => {
             return base64url.encode(match);
         });
-        const unambiguous = encoded === jobName ? encoded : ${encoded}.${createHash("sha256").update(jobName).digest("hex").substring(0, 8)}`;
+        const unambiguous = encoded === jobName ? encoded : `${encoded}.${createHash("sha256").update(jobName).digest("hex").substring(0, 8)}`;
         if (unambiguous.length <= Utils.MAX_FILENAME_LENGTH) {
             return unambiguous;
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,13 +62,13 @@ export class Utils {
         });
         const unambiguous = encoded === jobName ?
             encoded :
-            `${encoded}-${createHash("sha256").update(jobName).digest("hex").substring(0, 8)}`;
+            `${encoded}.${createHash("sha256").update(jobName).digest("hex").substring(0, 8)}`;
         if (unambiguous.length <= Utils.MAX_FILENAME_LENGTH) {
             return unambiguous;
         }
         const hash = createHash("sha256").update(jobName).digest("hex").substring(0, 16);
-        const prefix = unambiguous.substring(0, Utils.MAX_FILENAME_LENGTH - 1 - hash.length);
-        return `${prefix}-${hash}`;
+        const prefix = encoded.substring(0, Utils.MAX_FILENAME_LENGTH - 1 - hash.length);
+        return `${prefix}.${hash}`;
     }
 
     static safeBashString (s: string) {

--- a/tests/test-cases/artifacts-docker/integration.test.ts
+++ b/tests/test-cases/artifacts-docker/integration.test.ts
@@ -3,7 +3,6 @@ import {handler} from "../../../src/handler.js";
 import {initSpawnSpy} from "../../mocks/utils.mock.js";
 import {WhenStatics} from "../../mocks/when-statics.js";
 import fs from "fs-extra";
-import {Utils} from "../../../src/utils.js";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
@@ -24,7 +23,6 @@ test.concurrent("artifacts-docker <consume artifacts> --needs", async () => {
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 
-    const artifactsDir = `tests/test-cases/artifacts-docker/.gitlab-ci-local/artifacts/${Utils.safeDockerString("produce artifacts 📝")}`;
-    expect(fs.pathExistsSync(`${artifactsDir}/file2`)).toBe(true);
-    expect(fs.pathExistsSync(`${artifactsDir}/path/to/deep/folder/file3`)).toBe(true);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-docker/.gitlab-ci-local/artifacts/produceIAartifactsIPCfk50.c2393d2b/file2")).toBe(true);
+    expect(fs.pathExistsSync("tests/test-cases/artifacts-docker/.gitlab-ci-local/artifacts/produceIAartifactsIPCfk50.c2393d2b/path/to/deep/folder/file3")).toBe(true);
 });

--- a/tests/test-cases/artifacts-docker/integration.test.ts
+++ b/tests/test-cases/artifacts-docker/integration.test.ts
@@ -3,6 +3,7 @@ import {handler} from "../../../src/handler.js";
 import {initSpawnSpy} from "../../mocks/utils.mock.js";
 import {WhenStatics} from "../../mocks/when-statics.js";
 import fs from "fs-extra";
+import {Utils} from "../../../src/utils.js";
 
 beforeAll(() => {
     initSpawnSpy(WhenStatics.all);
@@ -23,6 +24,7 @@ test.concurrent("artifacts-docker <consume artifacts> --needs", async () => {
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
 
-    expect(fs.pathExistsSync("tests/test-cases/artifacts-docker/.gitlab-ci-local/artifacts/produceIAartifactsIPCfk50/file2")).toBe(true);
-    expect(fs.pathExistsSync("tests/test-cases/artifacts-docker/.gitlab-ci-local/artifacts/produceIAartifactsIPCfk50/path/to/deep/folder/file3")).toBe(true);
+    const artifactsDir = `tests/test-cases/artifacts-docker/.gitlab-ci-local/artifacts/${Utils.safeDockerString("produce artifacts 📝")}`;
+    expect(fs.pathExistsSync(`${artifactsDir}/file2`)).toBe(true);
+    expect(fs.pathExistsSync(`${artifactsDir}/path/to/deep/folder/file3`)).toBe(true);
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -275,15 +275,15 @@ describe("safeDockerString", () => {
 
     it("should encode non-alphanumeric characters", () => {
         const result = Utils.safeDockerString("job/name");
-        expect(result).toMatch(/^jobLwname\.[0-9a-f]{8}$/); // '/' → 'Lw'
+        expect(result).toBe("jobLwname.90354188"); // '/' → 'Lw'
     });
 
     it("should not collide an encoded name with a literal one", () => {
-        expect(Utils.safeDockerString("a.b")).not.toBe(Utils.safeDockerString("aLgb"));
-        expect(Utils.safeDockerString("job/name")).not.toBe(Utils.safeDockerString("jobLwname"));
+        expect(Utils.safeDockerString("a.b")).toBe("aLgb.2e7336dc");
+        expect(Utils.safeDockerString("aLgb")).toBe("aLgb");
         // A dot cannot survive encoding, so it separates the two namespaces for good.
-        expect(Utils.safeDockerString("a.b")).not.toBe(Utils.safeDockerString("aLgb.2e7336dc"));
-        expect(Utils.safeDockerString("a.b")).not.toBe(Utils.safeDockerString("aLgb-2e7336dc"));
+        expect(Utils.safeDockerString("aLgb.2e7336dc")).toBe("aLgbLg2e7336dc.bd36d3d5");
+        expect(Utils.safeDockerString("aLgb-2e7336dc")).toBe("aLgb-2e7336dc");
     });
 
     it("should leave already safe names untouched", () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -275,12 +275,15 @@ describe("safeDockerString", () => {
 
     it("should encode non-alphanumeric characters", () => {
         const result = Utils.safeDockerString("job/name");
-        expect(result).toMatch(/^jobLwname-[0-9a-f]{8}$/); // '/' → 'Lw'
+        expect(result).toMatch(/^jobLwname\.[0-9a-f]{8}$/); // '/' → 'Lw'
     });
 
     it("should not collide an encoded name with a literal one", () => {
         expect(Utils.safeDockerString("a.b")).not.toBe(Utils.safeDockerString("aLgb"));
         expect(Utils.safeDockerString("job/name")).not.toBe(Utils.safeDockerString("jobLwname"));
+        // A dot cannot survive encoding, so it separates the two namespaces for good.
+        expect(Utils.safeDockerString("a.b")).not.toBe(Utils.safeDockerString("aLgb.2e7336dc"));
+        expect(Utils.safeDockerString("a.b")).not.toBe(Utils.safeDockerString("aLgb-2e7336dc"));
     });
 
     it("should leave already safe names untouched", () => {
@@ -337,6 +340,6 @@ describe("safeDockerString", () => {
         const name = "a".repeat(Utils.MAX_FILENAME_LENGTH - 1) + "/"; // '/' -> 'Lw' = +2, total = MAX+1
         const result = Utils.safeDockerString(name);
         expect(result.length).toBeLessThanOrEqual(Utils.MAX_FILENAME_LENGTH);
-        expect(result).toContain("-"); // has hash separator
+        expect(result).toContain("."); // has hash separator
     });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -275,7 +275,18 @@ describe("safeDockerString", () => {
 
     it("should encode non-alphanumeric characters", () => {
         const result = Utils.safeDockerString("job/name");
-        expect(result).toBe("jobLwname"); // '/' → 'Lw'
+        expect(result).toMatch(/^jobLwname-[0-9a-f]{8}$/); // '/' → 'Lw'
+    });
+
+    it("should not collide an encoded name with a literal one", () => {
+        expect(Utils.safeDockerString("a.b")).not.toBe(Utils.safeDockerString("aLgb"));
+        expect(Utils.safeDockerString("job/name")).not.toBe(Utils.safeDockerString("jobLwname"));
+    });
+
+    it("should leave already safe names untouched", () => {
+        for (const name of ["short-job-name", "my_job", "aLgb", "job-1"]) {
+            expect(Utils.safeDockerString(name)).toBe(name);
+        }
     });
 
     it("should truncate and hash when encoded name exceeds MAX_FILENAME_LENGTH", () => {


### PR DESCRIPTION
base64url output reuses the same characters that pass through unencoded, so a job named `aLgb` took the same safe name as one named `a.b` and the two silently shared a build directory; encoded names now carry a short digest of the original. Job names that need no encoding are unchanged, but any name containing a special character gets a new safe name, so existing build dirs, containers and cache volumes for those jobs are orphaned on first run after upgrade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop encoded job names colliding with literal ones in `Utils.safeDockerString`. Previously, `a.b` and `aLgb` could map to the same safe name; now any encoded name is suffixed with `.XXXXXXXX` (8-hex digest), and all hashes use a dot separator so literal names (which never include dots) cannot collide. Names that need no encoding are unchanged. If the result exceeds the filename limit, we truncate the encoded prefix and append `.YYYYYYYYYYYYYYYY` (16-hex digest).

- Rollout and migration
  - Jobs with special characters will get new safe names. Prune orphaned build directories, containers, and cache volumes after deploy.
  - Verify long names still respect the filename limit; truncation now yields `<prefix>.<16-hex>`.

- Review notes
  - Tests assert explicit safe names; artifact paths now include a dot and digest (e.g., `produceIAartifactsIPCfk50.c2393d2b`).

<sup>Written for commit 48e79a84790434fe0e7a8f668dd46c3bc8c8d552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

