### PR TITLE
fix: serialize rsync into shared build directories

### DIFF
--- a/src/pid-file-lock.ts
+++ b/src/pid-file-lock.ts
@@ -53,12 +53,12 @@ const tryRemoveStaleLock = (lockPath: string): boolean => {
     return true;
 };
 
-export const withFileLock = async <T>(lockPath: string, fn: () => Promise<T>): Promise<T> => {
+export const withFileLock = async <T>(lockPath: string, fn: () => Promise<T>, timeoutMs = LOCK_TIMEOUT_MS): Promise<T> => {
     await fs.ensureDir(path.dirname(lockPath));
     const startTime = Date.now();
 
     while (!acquireLock(lockPath)) {
-        if (Date.now() - startTime > LOCK_TIMEOUT_MS) {
+        if (Date.now() - startTime > timeoutMs) {
             throw new Error(`Timed out waiting for lock: ${lockPath}`);
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,8 @@ import path from "node:path";
 import {Argv} from "./argv.js";
 import {withFileLock} from "./pid-file-lock.js";
 
+const RSYNC_LOCK_TIMEOUT_MS = 3_600_000;
+
 type RuleResultOpt = {
     argv: Argv;
     cwd: string;
@@ -397,7 +399,7 @@ export class Utils {
                 `${stateDir}/builds/${target}/`,
             ].join(" ");
             await Utils.bash(cmd, cwd);
-        });
+        }, RSYNC_LOCK_TIMEOUT_MS);
         return {hrdeltatime: process.hrtime(time)};
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ import micromatch from "micromatch";
 import {AxiosRequestConfig} from "axios";
 import path from "node:path";
 import {Argv} from "./argv.js";
+import {withFileLock} from "./pid-file-lock.js";
 
 type RuleResultOpt = {
     argv: Argv;
@@ -380,20 +381,23 @@ export class Utils {
 
     static async rsyncTrackedFiles (cwd: string, stateDir: string, ignoresFile: string, target: string): Promise<{hrdeltatime: [number, number]}> {
         const time = process.hrtime();
-        await fs.mkdirp(`${cwd}/${stateDir}/builds/${target}`);
-        const {stdout: untracked} = await Utils.bash("git ls-files -o --directory", cwd);
-        const untrackedFile = `${cwd}/${stateDir}/rsync-exclude-${target}`;
-        await fs.writeFile(untrackedFile, untracked.split("\n").filter(line => line !== "").map(line => `/${line}`).join("\n"));
-        const cmd = [
-            "rsync -a --delete-excluded --delete",
-            `--exclude-from=${Utils.safeBashString(untrackedFile)}`,
-            ...await fs.pathExists(ignoresFile) ? [`--exclude-from=${Utils.safeBashString(ignoresFile)}`] : [],
-            "--exclude .git/lfs",
-            `--exclude ${stateDir}/`,
-            "./",
-            `${stateDir}/builds/${target}/`,
-        ].join(" ");
-        await Utils.bash(cmd, cwd);
+        const lockPath = `${cwd}/${stateDir}/rsync-${target}.lock`;
+        await withFileLock(lockPath, async () => {
+            await fs.mkdirp(`${cwd}/${stateDir}/builds/${target}`);
+            const {stdout: untracked} = await Utils.bash("git ls-files -o --directory", cwd);
+            const untrackedFile = `${cwd}/${stateDir}/rsync-exclude-${target}`;
+            await fs.writeFile(untrackedFile, untracked.split("\n").filter(line => line !== "").map(line => `/${line}`).join("\n"));
+            const cmd = [
+                "rsync -a --delete-excluded --delete",
+                `--exclude-from=${Utils.safeBashString(untrackedFile)}`,
+                ...await fs.pathExists(ignoresFile) ? [`--exclude-from=${Utils.safeBashString(ignoresFile)}`] : [],
+                "--exclude .git/lfs",
+                `--exclude ${stateDir}/`,
+                "./",
+                `${stateDir}/builds/${target}/`,
+            ].join(" ");
+            await Utils.bash(cmd, cwd);
+        });
         return {hrdeltatime: process.hrtime(time)};
     }
 

--- a/tests/pid-file-lock.test.ts
+++ b/tests/pid-file-lock.test.ts
@@ -1,0 +1,67 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import {withFileLock} from "../src/pid-file-lock.js";
+
+let lockPath: string;
+
+describe("withFileLock", () => {
+    beforeEach(async () => {
+        lockPath = path.join(await fs.mkdtemp(path.join(os.tmpdir(), "gcl-lock-")), "test.lock");
+    });
+
+    afterEach(async () => {
+        await fs.remove(path.dirname(lockPath));
+    });
+
+    test("serializes overlapping holders and releases the lock", async () => {
+        const events: string[] = [];
+        const hold = (name: string) => withFileLock(lockPath, async () => {
+            events.push(`${name}-enter`);
+            await new Promise(resolve => setTimeout(resolve, 100));
+            events.push(`${name}-exit`);
+        });
+
+        await Promise.all([hold("a"), hold("b")]);
+
+        expect(events).toHaveLength(4);
+        expect(events[1]).toBe(`${events[0].replace("-enter", "")}-exit`);
+        expect(events[3]).toBe(`${events[2].replace("-enter", "")}-exit`);
+        expect(await fs.pathExists(lockPath)).toBe(false);
+    });
+
+    const holdFor = (ms: number) => {
+        let held: () => void;
+        const holding = new Promise<void>(resolve => (held = resolve));
+        const holder = withFileLock(lockPath, async () => {
+            held();
+            await new Promise(resolve => setTimeout(resolve, ms));
+        });
+        return {holder, holding};
+    };
+
+    test("waits beyond the default timeout when a longer one is given", async () => {
+        const {holder, holding} = holdFor(400);
+        await holding;
+
+        expect(await withFileLock(lockPath, async () => "acquired", 60_000)).toBe("acquired");
+        await holder;
+    });
+
+    test("throws once the given timeout elapses", async () => {
+        const {holder, holding} = holdFor(1500);
+        await holding;
+
+        await expect(withFileLock(lockPath, async () => "acquired", 100)).rejects.toThrow(`Timed out waiting for lock: ${lockPath}`);
+        await holder;
+    });
+
+    test("releases the lock when the callback throws", async () => {
+        await expect(withFileLock(lockPath, async () => {
+            throw new Error("boom");
+        })).rejects.toThrow("boom");
+
+        expect(await fs.pathExists(lockPath)).toBe(false);
+        expect(await withFileLock(lockPath, async () => "acquired")).toBe("acquired");
+    });
+});

--- a/tests/pid-file-lock.test.ts
+++ b/tests/pid-file-lock.test.ts
@@ -30,26 +30,13 @@ describe("withFileLock", () => {
         expect(await fs.pathExists(lockPath)).toBe(false);
     });
 
-    const holdFor = (ms: number) => {
+    test("uses the given timeout instead of the default", async () => {
         let held: () => void;
         const holding = new Promise<void>(resolve => (held = resolve));
         const holder = withFileLock(lockPath, async () => {
             held();
-            await new Promise(resolve => setTimeout(resolve, ms));
+            await new Promise(resolve => setTimeout(resolve, 1500));
         });
-        return {holder, holding};
-    };
-
-    test("waits beyond the default timeout when a longer one is given", async () => {
-        const {holder, holding} = holdFor(400);
-        await holding;
-
-        expect(await withFileLock(lockPath, async () => "acquired", 60_000)).toBe("acquired");
-        await holder;
-    });
-
-    test("throws once the given timeout elapses", async () => {
-        const {holder, holding} = holdFor(1500);
         await holding;
 
         await expect(withFileLock(lockPath, async () => "acquired", 100)).rejects.toThrow(`Timed out waiting for lock: ${lockPath}`);

--- a/tests/rsync-tracked-files.test.ts
+++ b/tests/rsync-tracked-files.test.ts
@@ -6,71 +6,72 @@ import {Utils} from "../src/utils.js";
 
 const stateDir = ".gitlab-ci-local";
 
-const createRepo = async () => {
-    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gcl-rsync-"));
-    const refsDir = `${cwd}/.git/logs/refs/remotes/origin`;
-    for (let i = 0; i < 100; i++) {
-        await fs.outputFile(`${refsDir}/renovate${i}/registry.example.com-image-1.x`, "a".repeat(4096));
-    }
-    for (let i = 0; i < 50; i++) {
-        await fs.outputFile(`${cwd}/src/file${i}.txt`, `content ${i}`);
-    }
-    await Utils.bash("git init -q && git add -A", cwd);
-    return cwd;
-};
+let cwd: string;
+let ignoresFile: string;
 
 const recordRsyncIntervals = () => {
     const intervals: {target: string; start: number; end: number}[] = [];
     const original = Utils.bash.bind(Utils);
     let clock = 0;
-    vi.spyOn(Utils, "bash").mockImplementation(async (shellScript: string, cwd?: string) => {
+    vi.spyOn(Utils, "bash").mockImplementation(async (shellScript: string, bashCwd?: string) => {
         const target = /builds\/(\S+)\/$/.exec(shellScript)?.[1];
         if (!shellScript.startsWith("rsync ") || !target) {
-            return original(shellScript, cwd);
+            return original(shellScript, bashCwd);
         }
         const start = clock++;
-        const result = await original(shellScript, cwd);
+        const result = await original(shellScript, bashCwd);
         intervals.push({target, start, end: clock++});
         return result;
     });
     return intervals;
 };
 
+const overlaps = (a: {start: number; end: number}, b: {start: number; end: number}) => a.start < b.end && b.start < a.end;
+
 describe("rsyncTrackedFiles", () => {
-    afterEach(() => {
+    beforeEach(async () => {
+        cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gcl-rsync-"));
+        ignoresFile = `${cwd}/.gitlab-ci-local-ignore`;
+        const refsDir = `${cwd}/.git/logs/refs/remotes/origin`;
+        for (let i = 0; i < 100; i++) {
+            await fs.outputFile(`${refsDir}/renovate${i}/registry.example.com-image-1.x`, "a".repeat(4096));
+        }
+        for (let i = 0; i < 50; i++) {
+            await fs.outputFile(`${cwd}/src/file${i}.txt`, `content ${i}`);
+        }
+        await Utils.bash("git init -q && git add -A", cwd);
+    });
+
+    afterEach(async () => {
         vi.restoreAllMocks();
+        await fs.remove(cwd);
     });
 
     test("concurrent calls for the same target never overlap", async () => {
-        const cwd = await createRepo();
         const intervals = recordRsyncIntervals();
 
-        await Promise.all(Array.from({length: 4}, () => Utils.rsyncTrackedFiles(cwd, stateDir, `${cwd}/.gitlab-ci-local-ignore`, ".docker")));
+        await Promise.all(Array.from({length: 4}, () => Utils.rsyncTrackedFiles(cwd, stateDir, ignoresFile, ".docker")));
 
         expect(intervals).toHaveLength(4);
-        const overlapping = intervals.filter(a => intervals.some(b => a !== b && a.start < b.end && b.start < a.end));
-        expect(overlapping).toEqual([]);
+        expect(intervals.filter(a => intervals.some(b => a !== b && overlaps(a, b)))).toEqual([]);
 
         expect(await fs.pathExists(`${cwd}/${stateDir}/builds/.docker/.git/logs/refs/remotes/origin/renovate99/registry.example.com-image-1.x`)).toBe(true);
         expect(await fs.pathExists(`${cwd}/${stateDir}/builds/.docker/src/file49.txt`)).toBe(true);
         expect(await fs.pathExists(`${cwd}/${stateDir}/rsync-.docker.lock`)).toBe(false);
-
-        await fs.remove(cwd);
     });
 
-    test("distinct targets are not serialized against each other", async () => {
-        const cwd = await createRepo();
+    test("concurrent calls for distinct targets do overlap", async () => {
         const intervals = recordRsyncIntervals();
 
         await Promise.all([
-            Utils.rsyncTrackedFiles(cwd, stateDir, `${cwd}/.gitlab-ci-local-ignore`, "job-a"),
-            Utils.rsyncTrackedFiles(cwd, stateDir, `${cwd}/.gitlab-ci-local-ignore`, "job-b"),
+            Utils.rsyncTrackedFiles(cwd, stateDir, ignoresFile, "job-a"),
+            Utils.rsyncTrackedFiles(cwd, stateDir, ignoresFile, "job-b"),
         ]);
 
         expect(intervals.map(i => i.target).sort()).toEqual(["job-a", "job-b"]);
+        expect(overlaps(intervals[0], intervals[1])).toBe(true);
+
         expect(await fs.pathExists(`${cwd}/${stateDir}/builds/job-a/src/file49.txt`)).toBe(true);
         expect(await fs.pathExists(`${cwd}/${stateDir}/builds/job-b/src/file49.txt`)).toBe(true);
-
-        await fs.remove(cwd);
     });
 });

--- a/tests/rsync-tracked-files.test.ts
+++ b/tests/rsync-tracked-files.test.ts
@@ -1,0 +1,76 @@
+import {vi} from "vitest";
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import {Utils} from "../src/utils.js";
+
+const stateDir = ".gitlab-ci-local";
+
+const createRepo = async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "gcl-rsync-"));
+    const refsDir = `${cwd}/.git/logs/refs/remotes/origin`;
+    for (let i = 0; i < 100; i++) {
+        await fs.outputFile(`${refsDir}/renovate${i}/registry.example.com-image-1.x`, "a".repeat(4096));
+    }
+    for (let i = 0; i < 50; i++) {
+        await fs.outputFile(`${cwd}/src/file${i}.txt`, `content ${i}`);
+    }
+    await Utils.bash("git init -q && git add -A", cwd);
+    return cwd;
+};
+
+const recordRsyncIntervals = () => {
+    const intervals: {target: string; start: number; end: number}[] = [];
+    const original = Utils.bash.bind(Utils);
+    let clock = 0;
+    vi.spyOn(Utils, "bash").mockImplementation(async (shellScript: string, cwd?: string) => {
+        const target = /builds\/(\S+)\/$/.exec(shellScript)?.[1];
+        if (!shellScript.startsWith("rsync ") || !target) {
+            return original(shellScript, cwd);
+        }
+        const start = clock++;
+        const result = await original(shellScript, cwd);
+        intervals.push({target, start, end: clock++});
+        return result;
+    });
+    return intervals;
+};
+
+describe("rsyncTrackedFiles", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("concurrent calls for the same target never overlap", async () => {
+        const cwd = await createRepo();
+        const intervals = recordRsyncIntervals();
+
+        await Promise.all(Array.from({length: 4}, () => Utils.rsyncTrackedFiles(cwd, stateDir, `${cwd}/.gitlab-ci-local-ignore`, ".docker")));
+
+        expect(intervals).toHaveLength(4);
+        const overlapping = intervals.filter(a => intervals.some(b => a !== b && a.start < b.end && b.start < a.end));
+        expect(overlapping).toEqual([]);
+
+        expect(await fs.pathExists(`${cwd}/${stateDir}/builds/.docker/.git/logs/refs/remotes/origin/renovate99/registry.example.com-image-1.x`)).toBe(true);
+        expect(await fs.pathExists(`${cwd}/${stateDir}/builds/.docker/src/file49.txt`)).toBe(true);
+        expect(await fs.pathExists(`${cwd}/${stateDir}/rsync-.docker.lock`)).toBe(false);
+
+        await fs.remove(cwd);
+    });
+
+    test("distinct targets are not serialized against each other", async () => {
+        const cwd = await createRepo();
+        const intervals = recordRsyncIntervals();
+
+        await Promise.all([
+            Utils.rsyncTrackedFiles(cwd, stateDir, `${cwd}/.gitlab-ci-local-ignore`, "job-a"),
+            Utils.rsyncTrackedFiles(cwd, stateDir, `${cwd}/.gitlab-ci-local-ignore`, "job-b"),
+        ]);
+
+        expect(intervals.map(i => i.target).sort()).toEqual(["job-a", "job-b"]);
+        expect(await fs.pathExists(`${cwd}/${stateDir}/builds/job-a/src/file49.txt`)).toBe(true);
+        expect(await fs.pathExists(`${cwd}/${stateDir}/builds/job-b/src/file49.txt`)).toBe(true);
+
+        await fs.remove(cwd);
+    });
+});


### PR DESCRIPTION
Concurrent `rsyncTrackedFiles` calls for the same target raced on `.gitlab-ci-local/builds/<target>/`, so one run deleted destination directories while another was writing into them and rsync failed its temp file rename with ENOENT and exit 23; the existing pid file lock is now taken per target.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes rsync into shared build directories per target and lets queued rsyncs wait up to 1 hour. Previously, concurrent rsyncTrackedFiles for the same target raced and rsync exited 23 (ENOENT) with a 30s lock timeout; now a per-target PID-file lock gates each target with a longer timeout while different targets still run in parallel.

- Uses withFileLock on ${stateDir}/rsync-<target>.lock during sync with timeoutMs = 3_600_000; lock files are removed after completion and stale holders are reclaimed.
- Adds a timeoutMs parameter to withFileLock and tests for per-target serialization, cross-target parallelism, timeout override, and cleanup on throw.

<sup>Written for commit f5ac6964f16f5bf5e98271465406c01fbc776c92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

