### PR TITLE
fix: quote filenames when fetching remote includes

### DIFF
--- a/src/parser-includes.ts
+++ b/src/parser-includes.ts
@@ -382,6 +382,24 @@ export class ParserIncludes {
         }
     }
 
+    private static async gitCloneSparseCheckout (cwd: string, stateDir: string, tmpDir: string, remote: GitData["remote"], project: string, ref: string, sparsePaths: string[]): Promise<void> {
+        await fs.mkdirp(`${cwd}/${stateDir}`);
+        const isCommitSha = /^[0-9a-f]{40}$/i.test(ref);
+        const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${Utils.safeBashString(ref)}`;
+        await Utils.bashMulti([
+            `cd ${Utils.safeBashString(cwd)}/${Utils.safeBashString(stateDir)}`,
+            `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${Utils.safeBashString(remoteProjectUrl(remote, project))} ${Utils.safeBashString(tmpDir)}`,
+            `cd ${Utils.safeBashString(tmpDir)}`,
+            ...isCommitSha ? [`git fetch --depth=1 --filter=tree:0 origin ${Utils.safeBashString(ref)}`] : [],
+            `git sparse-checkout set --no-cone ${sparsePaths.map((p) => Utils.safeBashString(p)).join(" ")}`,
+            isCommitSha ? "git checkout FETCH_HEAD" : "git checkout",
+        ], cwd);
+    }
+
+    private static safeArchiveUrl (remote: GitData["remote"], project: string): string {
+        return Utils.safeBashString(`ssh://git@${remote.host}:${remote.port}/${project}.git`);
+    }
+
     static async downloadIncludeProjectFile (opts: ParserIncludesInitOptions, project: string, ref: string, file: string): Promise<void> {
         const {cwd, stateDir, gitData, fetchIncludes, writeStreams} = opts;
         const remote = gitData.remote;
@@ -394,25 +412,20 @@ export class ParserIncludes {
 
             if (remote.schema.startsWith("http")) {
                 const ext = "tmp-" + Math.random();
-                const destDir = path.dirname(`${cwd}/${target}/${normalizedFile}`);
-                await fs.mkdirp(destDir);
                 tmpDir = `${cwd}/${target}.${ext}`;
 
-                const isCommitSha = /^[0-9a-f]{40}$/i.test(ref);
-                const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
-                await Utils.bashMulti([
-                    `cd ${cwd}/${stateDir}`,
-                    `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remoteProjectUrl(remote, project)} ${tmpDir}`,
-                    `cd ${tmpDir}`,
-                    ...isCommitSha ? [`git fetch --depth=1 --filter=tree:0 origin ${ref}`] : [],
-                    `git sparse-checkout set --no-cone ${normalizedFile}`,
-                    isCommitSha ? "git checkout FETCH_HEAD" : "git checkout",
-                    `cd ${cwd}/${stateDir}`,
-                    `cp ${tmpDir}/${normalizedFile} ${destDir}/`,
-                ], cwd);
+                await this.gitCloneSparseCheckout(cwd, stateDir, tmpDir, remote, project, ref, [normalizedFile]);
+
+                const matches = globbySync(normalizedFile, {cwd: tmpDir, absolute: true});
+                const filesToCopy = matches.length > 0 ? matches : [`${tmpDir}/${normalizedFile}`];
+                for (const matchedFile of filesToCopy) {
+                    const relativePath = path.relative(tmpDir, matchedFile);
+                    assert(!relativePath.startsWith("..") && !path.isAbsolute(relativePath), `Include file path escapes the fetched project: ${normalizedFile}`);
+                    await fs.copy(matchedFile, `${cwd}/${target}/${relativePath}`);
+                }
             } else {
                 await fs.mkdirp(`${cwd}/${target}`);
-                await Utils.bash(`set -eou pipefail; git archive --remote=ssh://git@${remote.host}:${remote.port}/${project}.git ${ref} ${normalizedFile} | tar -f - -xC ${target}/`, cwd);
+                await Utils.bash(`set -eou pipefail; git archive --remote=${this.safeArchiveUrl(remote, project)} -- ${Utils.safeBashString(ref)} ${Utils.safeBashString(normalizedFile)} | tar -f - -xC ${Utils.safeBashString(`${target}/`)}`, cwd);
             }
             writeStreams.stderr(chalk`{grey downloaded ${project} ${ref} ${normalizedFile} in ${prettyHrtime(process.hrtime(time))}}\n`);
         } catch (e) {
@@ -441,19 +454,11 @@ export class ParserIncludes {
                 await fs.mkdirp(path.dirname(`${cwd}/${target}/templates`));
                 tmpDir = `${cwd}/${target}.${ext}`;
 
-                const isCommitSha = /^[0-9a-f]{40}$/i.test(ref);
-                const gitCloneBranch = (ref === "HEAD" || isCommitSha) ? "" : `--branch ${ref}`;
-                await Utils.bashMulti([
-                    `cd ${cwd}/${stateDir}`,
-                    `git clone ${gitCloneBranch} -n --depth=1 --filter=tree:0 ${remoteProjectUrl(remote, project)} ${tmpDir}`,
-                    `cd ${tmpDir}`,
-                    ...isCommitSha ? [`git fetch --depth=1 --filter=tree:0 origin ${ref}`] : [],
-                    `git sparse-checkout set --no-cone ${files[0]} ${files[1]}`,
-                    isCommitSha ? "git checkout FETCH_HEAD" : "git checkout",
-                    `cd ${cwd}/${stateDir}`,
-                    `mkdir -p ${tmpDir}/templates`, // create templates subdir (if it doesn't exist), as the check out may not create it
-                    `cp -r ${tmpDir}/templates ${cwd}/${target}`,
-                ], cwd);
+                await this.gitCloneSparseCheckout(cwd, stateDir, tmpDir, remote, project, ref, files);
+
+                // create templates subdir (if it doesn't exist), as the check out may not create it
+                await fs.mkdirp(`${tmpDir}/templates`);
+                await fs.copy(`${tmpDir}/templates`, `${cwd}/${target}/templates`);
             } else {
                 // git archive fails if the paths do not exist, to work around this we use a wildcard "templates/component*.yml"
                 // this resolves to either "templates/component.yml" or "templates/component/template.yml"
@@ -461,7 +466,7 @@ export class ParserIncludes {
                 // Drawback: also pulls all other .yml files from templates/component/ directory
                 const componentWildcard = `${componentName}*.yml`;
                 await fs.mkdirp(`${cwd}/${target}`);
-                await Utils.bash(`set -eou pipefail; git archive --remote=ssh://git@${remote.host}:${remote.port}/${project}.git ${ref} ${componentWildcard} | tar -f - -xC ${target}/`, cwd);
+                await Utils.bash(`set -eou pipefail; git archive --remote=${this.safeArchiveUrl(remote, project)} -- ${Utils.safeBashString(ref)} ${Utils.safeBashString(componentWildcard)} | tar -f - -xC ${Utils.safeBashString(`${target}/`)}`, cwd);
             }
             writeStreams.stderr(chalk`{grey downloaded ${project} ${ref} ${componentName} in ${prettyHrtime(process.hrtime(time))}}\n`);
         } catch (e) {

--- a/src/variables-from-files.ts
+++ b/src/variables-from-files.ts
@@ -43,7 +43,8 @@ export class VariablesFromFiles {
                 const file = match.groups?.file;
                 const ref = match.groups?.ref;
                 const time = process.hrtime();
-                const res = await Utils.bash(`set -eou pipefail; git archive --remote=${url} ${ref} ${file} | tar -xO ${file}`, cwd);
+                const safeFile = Utils.safeBashString(file ?? "");
+                const res = await Utils.bash(`set -eou pipefail; git archive --remote=${Utils.safeBashString(url ?? "")} -- ${Utils.safeBashString(ref ?? "")} ${safeFile} | tar -xO -- ${safeFile}`, cwd);
                 writeStreams.stderr(chalk`{grey downloaded ${url} ${ref} ${file} in ${prettyHrtime(process.hrtime(time))}}\n`);
                 const loadedYaml = yaml.load(`${res.stdout}`);
                 // Check if loadedYaml is an object

--- a/tests/test-cases/include-project-file-path-traversal/.gitlab-ci.yml
+++ b/tests/test-cases/include-project-file-path-traversal/.gitlab-ci.yml
@@ -1,0 +1,3 @@
+---
+include:
+  - { project: some/project, file: "../victim file.yml", ref: main }

--- a/tests/test-cases/include-project-file-path-traversal/integration.test.ts
+++ b/tests/test-cases/include-project-file-path-traversal/integration.test.ts
@@ -1,0 +1,34 @@
+import {vi} from "vitest";
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import {initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import {Utils} from "../../../src/utils.js";
+import fs from "fs-extra";
+import path from "node:path";
+
+test("include-project-file-path-traversal", async () => {
+    const cwd = "tests/test-cases/include-project-file-path-traversal";
+    const stateDir = ".gitlab-ci-local";
+    const includeFile = "../victim file.yml";
+    await fs.rm(`${cwd}/${stateDir}/`, {recursive: true, force: true});
+
+    initSpawnSpy([...WhenStatics.all, WhenStatics.mockGitRemoteHttp]);
+    const bashMultiSpy = vi.spyOn(Utils, "bashMulti").mockResolvedValue({stdout: "", stderr: ""});
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const copySpy = vi.spyOn(fs, "copy");
+
+    const includesRoot = `${cwd}/${stateDir}/includes/gitlab.com/some/project`;
+    const tmpDir = `${includesRoot}/main.tmp-0.5`;
+    await fs.mkdirp(tmpDir);
+    await fs.outputFile(`${includesRoot}/victim file.yml`, "should-not-be-copied: true\n");
+
+    const writeStreams = new WriteStreamsMock();
+    await expect(handler({cwd, fetchIncludes: true}, writeStreams)).rejects.toThrow(/escapes the fetched project/);
+
+    expect(copySpy).not.toHaveBeenCalled();
+
+    const bashScripts = bashMultiSpy.mock.calls.flatMap(([scripts]) => scripts);
+    expect(bashScripts).toContain(`cd '${path.resolve(tmpDir)}'`);
+    expect(bashScripts).toContain(`git sparse-checkout set --no-cone ${Utils.safeBashString(includeFile)}`);
+});

--- a/tests/test-cases/include-project-file-ref-with-inner-local/integration.test.ts
+++ b/tests/test-cases/include-project-file-ref-with-inner-local/integration.test.ts
@@ -15,14 +15,14 @@ test("include-project-file-ref-with-inner-local", async () => {
     };
     const target = ".gitlab-ci-local/includes/gitlab.com/firecow/gitlab-ci-local-includes/include-string-list/";
     const spyGitArchive1 = {
-        cmd: `git archive --remote=ssh://git@gitlab.com:22/firecow/gitlab-ci-local-includes.git include-string-list .gitlab-module-with-local.yml | tar -f - -xC ${target}`,
+        cmd: `set -eou pipefail; git archive --remote='ssh://git@gitlab.com:22/firecow/gitlab-ci-local-includes.git' -- 'include-string-list' '.gitlab-module-with-local.yml' | tar -f - -xC '${target}'`,
         returnValue: {output: ""},
     };
     const spyGitArchive2 = {
-        cmd: `git archive --remote=ssh://git@gitlab.com:22/firecow/gitlab-ci-local-includes.git include-string-list .gitlab-local.yml | tar -f - -xC ${target}`,
+        cmd: `set -eou pipefail; git archive --remote='ssh://git@gitlab.com:22/firecow/gitlab-ci-local-includes.git' -- 'include-string-list' '.gitlab-local.yml' | tar -f - -xC '${target}'`,
         returnValue: {output: ""},
     };
-    initBashSpy([spyGitArchive1, spyGitArchive2]);
+    const bashSpy = initBashSpy([spyGitArchive1, spyGitArchive2]);
     initSpawnSpy([...WhenStatics.all, spyGitRemote]);
 
     let mock = `${cwd}/mock-gitlab-module-with-local.yml`;
@@ -35,11 +35,15 @@ test("include-project-file-ref-with-inner-local", async () => {
     await fs.ensureFile(mockTarget);
     await fs.copyFile(mock, mockTarget);
 
-    await handler({cwd}, writeStreams);
+    await handler({cwd, fetchIncludes: true}, writeStreams);
 
     const expected = [
         chalk`{blueBright test-job  } {greenBright >} Test something`,
         chalk`{blueBright deploy-job} {greenBright >} Deploy something`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+
+    const invokedCommands = bashSpy.mock.calls.map((call) => call[0]);
+    expect(invokedCommands).toContainEqual(spyGitArchive1.cmd);
+    expect(invokedCommands).toContainEqual(spyGitArchive2.cmd);
 });

--- a/tests/test-cases/include-project-file-with-space-in-filename/.gitlab-ci.yml
+++ b/tests/test-cases/include-project-file-with-space-in-filename/.gitlab-ci.yml
@@ -1,0 +1,3 @@
+---
+include:
+  - { project: firecow/gitlab-ci-local-includes, file: "file with spaces.yml", ref: include-string-list }

--- a/tests/test-cases/include-project-file-with-space-in-filename/integration.test.ts
+++ b/tests/test-cases/include-project-file-with-space-in-filename/integration.test.ts
@@ -1,0 +1,40 @@
+import {WriteStreamsMock} from "../../../src/write-streams.js";
+import {handler} from "../../../src/handler.js";
+import chalk from "chalk-template";
+import {initBashSpy, initSpawnSpy} from "../../mocks/utils.mock.js";
+import {WhenStatics} from "../../mocks/when-statics.js";
+import {Utils} from "../../../src/utils.js";
+import fs from "fs-extra";
+
+test("include-project-file-with-space-in-filename", async () => {
+    const cwd = "tests/test-cases/include-project-file-with-space-in-filename";
+    await fs.rm(`${cwd}/.gitlab-ci-local/`, {recursive: true, force: true});
+    const writeStreams = new WriteStreamsMock();
+    const spyGitRemote = {
+        cmdArgs: ["git", "remote", "get-url", "origin"],
+        returnValue: {stdout: "git@gitlab.com:gcl/test-hest.git"},
+    };
+    const spyGitArchiveAny = {
+        cmd: expect.stringContaining("git archive --remote="),
+        returnValue: {output: ""},
+    };
+    const bashSpy = initBashSpy([spyGitArchiveAny]);
+    initSpawnSpy([...WhenStatics.all, spyGitRemote]);
+
+    const target = ".gitlab-ci-local/includes/gitlab.com/firecow/gitlab-ci-local-includes/include-string-list/";
+    const mock = `${cwd}/mock-file with spaces.yml`;
+    const mockTarget = `${cwd}/${target}file with spaces.yml`;
+    await fs.ensureFile(mockTarget);
+    await fs.copyFile(mock, mockTarget);
+
+    await handler({cwd, fetchIncludes: true}, writeStreams);
+
+    const expected = [
+        chalk`{blueBright test-job} {greenBright >} Test something`,
+    ];
+    expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+
+    const invokedCommand = bashSpy.mock.calls.map((call) => call[0]).find((cmd) => cmd.includes("file with spaces.yml"));
+    expect(invokedCommand).toBeDefined();
+    expect(invokedCommand).toContain(`-- ${Utils.safeBashString("include-string-list")} ${Utils.safeBashString("file with spaces.yml")}`);
+});

--- a/tests/test-cases/include-project-file-with-space-in-filename/mock-file with spaces.yml
+++ b/tests/test-cases/include-project-file-with-space-in-filename/mock-file with spaces.yml
@@ -1,0 +1,5 @@
+---
+test-job:
+  stage: test
+  script:
+    - echo "Test something"

--- a/tests/test-cases/include-project-file-with-variable/integration.test.ts
+++ b/tests/test-cases/include-project-file-with-variable/integration.test.ts
@@ -21,10 +21,10 @@ test.concurrent("include-project-file-with-variable test-job", async () => {
 
     const target = `${stateDir}/includes/gitlab.com/test-group/gitlab-ci-local-test/HEAD/`;
     const spyGitArchive1 = {
-        cmd: `git archive --remote=ssh://git@gitlab.com:22/test-group/gitlab-ci-local-test.git HEAD test-file.yml | tar -f - -xC ${target}`,
+        cmd: `set -eou pipefail; git archive --remote='ssh://git@gitlab.com:22/test-group/gitlab-ci-local-test.git' -- 'HEAD' 'test-file.yml' | tar -f - -xC '${target}'`,
         returnValue: {output: ""},
     };
-    initBashSpy([spyGitArchive1]);
+    const bashSpy = initBashSpy([spyGitArchive1]);
 
     const mock = `${cwd}/mock-test-file.yml`;
     const mockTarget = `${cwd}/${stateDir}/includes/gitlab.com/test-group/gitlab-ci-local-test/HEAD/test-file.yml`;
@@ -36,10 +36,13 @@ test.concurrent("include-project-file-with-variable test-job", async () => {
         cwd,
         job: ["test-job"],
         stateDir,
+        fetchIncludes: true,
     }, writeStreams);
 
     const expected = [
         chalk`{blueBright test-job} {greenBright >} Hello from test file`,
     ];
     expect(writeStreams.stdoutLines).toEqual(expect.arrayContaining(expected));
+
+    expect(bashSpy.mock.calls.map((call) => call[0])).toContainEqual(spyGitArchive1.cmd);
 });

--- a/tests/test-cases/remote-variables-file/integration.test.ts
+++ b/tests/test-cases/remote-variables-file/integration.test.ts
@@ -6,7 +6,7 @@ import {WhenStatics} from "../../mocks/when-statics.js";
 
 beforeAll(() => {
     const spyGitArchive = {
-        cmd: "set -eou pipefail; git archive --remote=git@gitlab.com:example/firecow.git main variables.yml | tar -xO variables.yml",
+        cmd: "set -eou pipefail; git archive --remote='git@gitlab.com:example/firecow.git' -- 'main' 'variables.yml' | tar -xO -- 'variables.yml'",
         returnValue: {stdout: "---\nglobal:\n  SOMEVARIABLE: very-special-value"},
     };
     initSpawnSpy([...WhenStatics.all]);


### PR DESCRIPTION
Resolve an issue where unquoted filenames in an `include` block can break the fetch. Interpolated values are now properly escaped with `Utils.safeBashString` and a `--` guard was added to prevent potential injection of shell commands.

Resolves #1934  

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote includes and variable files with spaces or special characters in filenames so fetches no longer break. Interpolated values are now quoted with a `--` end-of-options guard to prevent shell injection, and path traversal is blocked so include paths cannot escape the fetched project. Resolves #1934.

<sup>Written for commit 22847c619073938edf3184fc2a666c44016ae334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

