### PR TITLE
fix: correctly interpret escaped characters in quoted regexes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -309,7 +309,8 @@ export class Utils {
             const regex = /\/(?<pattern>.*)\/(?<flags>[igmsuy]*)/;
             const _rhs = rhs.replace(regex, (_: string, pattern: string, flags: string) => {
                 const flagsBinary = flagsToBinary(flags);
-                return `RE2JS.compile("${pattern}", ${flagsBinary})`;
+                const escapedPattern = JSON.stringify(pattern);
+                return `RE2JS.compile(${escapedPattern}, ${flagsBinary})`;
             });
             return `.matchRE2JS(${_rhs}) ${_operator} null`;
         });

--- a/tests/rules-regex.test.ts
+++ b/tests/rules-regex.test.ts
@@ -64,6 +64,16 @@ const tests = [
         evalResult: true,
     },
     {
+        rule: '"[foo" =~ /\\[foo/',
+        jsExpression: '"[foo".matchRE2JS(RE2JS.compile("\\\\[foo", 0)) != null',
+        evalResult: true,
+    },
+    {
+        rule: '"[foo" =~ /\\[bar/',
+        jsExpression: '"[foo".matchRE2JS(RE2JS.compile("\\\\[bar", 0)) != null',
+        evalResult: false,
+    },
+    {
         rule: '"foo" =~ "/foo/"',
         jsExpression: '"foo".matchRE2JS(RE2JS.compile("foo", 0)) != null',
         evalResult: true,
@@ -75,12 +85,27 @@ const tests = [
     },
     {
         rule: '"test/url" =~ "/test\\/ur/"',
-        jsExpression: '"test/url".matchRE2JS(RE2JS.compile("test\\/ur", 0)) != null',
+        jsExpression: '"test/url".matchRE2JS(RE2JS.compile("test\\\\/ur", 0)) != null',
         evalResult: true,
     },
     {
         rule: '"test/url" =~ /test/ur/',
         expectedErrSubStr: "Error attempting to evaluate the following rules:",
+    },
+    {
+        rule: '"[foo" =~ "/\\[foo/"',
+        jsExpression: '"[foo".matchRE2JS(RE2JS.compile("\\\\[foo", 0)) != null',
+        evalResult: true,
+    },
+    {
+        rule: '"foo" =~ "/\\[foo/"',
+        jsExpression: '"foo".matchRE2JS(RE2JS.compile("\\\\[foo", 0)) != null',
+        evalResult: false,
+    },
+    {
+        rule: '"[foo" =~ "/\\[bar/"',
+        jsExpression: '"[foo".matchRE2JS(RE2JS.compile("\\\\[bar", 0)) != null',
+        evalResult: false,
     },
     {
         rule: '"master" =~ /master$/',


### PR DESCRIPTION
In the first example below, `gitlab-ci-local` was not parsing the `\[` in the regex properly, interpreting it as a non-escaped `[`, and therefore failing with "Error attempting to evaluate the following rules".

```yaml
---
test:
  stage: test
  script:
    - echo test
  rules:
    - if: '"[foo" =~ "/\[foo/"'
      when: always
    - when: never
```

The second example below (without quotes around the regex) was already working properly.

```yaml
---
test:
  stage: test
  script:
    - echo test
  rules:
    - if: '"[foo" =~ /\[foo/'
      when: always
    - when: never
```

This change fixes the behavior of quoted regexes to match unquoted regexes, by properly re-escaping the regex patterns to account for the subsequent `eval`.

Also adds a few tests, and fixes an existing incorrect test, to ensure correct parsing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of escaped characters in quoted regexes in `rules:` conditions. Previously, a quoted regex like `"/\\[foo/"` was interpreted incorrectly, causing an evaluation error, while the unquoted equivalent worked. Now the pattern is properly re-escaped before evaluation, so quoted and unquoted regexes behave consistently.

Also adds tests for the new behavior and corrects an existing test that expected the wrong output.

<sup>Written for commit 0734ec493499962e62e119d1e12a6da54fbe96b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

