### PR TITLE
fix: match gitlab's behavior for non-regexes after `=~`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -300,11 +300,16 @@ export class Utils {
                     throw operator;
             }
 
-            const assertMsg = [
-                "RHS (${rhs}) must be a regex pattern. Do not rely on this behavior!",
-                "Refer to https://docs.gitlab.com/ee/ci/jobs/job_rules.html#unexpected-behavior-from-regular-expression-matching-with- for more info...",
-            ];
-            assert((/\/(.*)\/(\w*)/.test(rhs)), assertMsg.join("\n"));
+            if (!(/\/(.*)\/(\w*)/.test(rhs))) {
+                // Pattern is not a regex
+                // This is discouraged by gitlab, but it is supported
+                // We match gitlab's behavior which is to check if lhs is a substring of rhs
+                // See https://docs.gitlab.com/ci/jobs/job_rules/#unexpected-behavior-from-regular-expression-matching-with-
+
+                // This is a weird construction, as the lhs string will be prepended, and we have to be able to use it as a parameter of includes
+                rhs = rhs.replaceAll(/(?<!\\)"/g, '\\"');
+                return `?.split().some((lhs) => "${rhs}".includes(lhs)) ${operator === "=~" ? "!==" : "==="} false`;
+            }
 
             const regex = /\/(?<pattern>.*)\/(?<flags>[igmsuy]*)/;
             const _rhs = rhs.replace(regex, (_: string, pattern: string, flags: string) => {

--- a/tests/rules-regex.test.ts
+++ b/tests/rules-regex.test.ts
@@ -89,11 +89,58 @@ const tests = [
     },
     {
         rule: '"23" =~ "1234"',
-        expectedErrSubStr: "must be a regex pattern. Do not rely on this behavior!",
+        jsExpression: '"23"?.split().some((lhs) => "1234".includes(lhs)) !== false',
+        evalResult: true,
     },
     {
         rule: '"23" =~ \'1234\'',
-        expectedErrSubStr: "must be a regex pattern. Do not rely on this behavior!",
+        jsExpression: '"23"?.split().some((lhs) => "1234".includes(lhs)) !== false',
+        evalResult: true,
+    },
+    {
+        rule: '"1234" =~ "23"',
+        jsExpression: '"1234"?.split().some((lhs) => "23".includes(lhs)) !== false',
+        evalResult: false,
+    },
+    {
+        rule: '"1234" =~ \'23\'',
+        jsExpression: '"1234"?.split().some((lhs) => "23".includes(lhs)) !== false',
+        evalResult: false,
+    },
+    {
+        rule: '"23" !~ "1234"',
+        jsExpression: '"23"?.split().some((lhs) => "1234".includes(lhs)) === false',
+        evalResult: false,
+    },
+    {
+        rule: '"1234" !~ "23"',
+        jsExpression: '"1234"?.split().some((lhs) => "23".includes(lhs)) === false',
+        evalResult: true,
+    },
+    {
+        rule: '"23" =~ "\\"1234"',
+        jsExpression: '"23"?.split().some((lhs) => "\\"1234".includes(lhs)) !== false',
+        evalResult: true,
+    },
+    {
+        rule: '"23" =~ \'"1234\'',
+        jsExpression: '"23"?.split().some((lhs) => "\\"1234".includes(lhs)) !== false',
+        evalResult: true,
+    },
+    {
+        rule: '"23" =~ "\'1234"',
+        jsExpression: '"23"?.split().some((lhs) => "\'1234".includes(lhs)) !== false',
+        evalResult: true,
+    },
+    {
+        rule: '$MISSING =~ "foo"',
+        jsExpression: 'null?.split().some((lhs) => "foo".includes(lhs)) !== false',
+        evalResult: true,
+    },
+    {
+        rule: '$MISSING !~ "foo"',
+        jsExpression: 'null?.split().some((lhs) => "foo".includes(lhs)) === false',
+        evalResult: false,
     },
     {
         rule: '"23" =~ /1234/',


### PR DESCRIPTION
As explained in the [Gitlab documentation](https://docs.gitlab.com/ci/jobs/job_rules/#unexpected-behavior-from-regular-expression-matching-with-), the `=~` operator in if-expressions is supposed to be followed by a regex. Having a non-regex has a weird behavior and is not recommended.

Currently, `gitlab-ci-local` does not support this construction, and gives out a (fairly explicit) error message.

Unfortunately, I have to use old CI templates relying on this weird behavior that I can't easily change, so I'd like `gitlab-ci-local` to match what Gitlab does.

It ended up fairly easy to implement, and I added a few tests to ensure the behavior is the same as in Gitlab.

Example `.gitlab-ci.yml`:
```yaml
---
test:
  stage: test
  script:
    - echo test
  rules:
    - if: '"foo" =~ "foo"'
      when: always
    - when: never
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `=~` in if-expressions accept non-regex right-hand sides and treats them as substring checks, matching GitLab's documented but discouraged behavior. Previously this raised an error; now it evaluates `rhs.includes(lhs)`. Updates tests to cover the new matching logic.

<sup>Written for commit fbb397124a208e922f35ed3b0bbdfbe8a3ad4eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/gitlab-ci-local/pull/1940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

